### PR TITLE
Initial Menu UI with 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,8 @@ version = "0.0.2"
 dependencies = [
  "conway 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ggez 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sdl2 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sdl2-sys 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "version 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,20 @@ name = "ConWaysteTheEnemy"
 version = "0.0.2"
 dependencies = [
  "conway 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ggez 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "sdl2 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sdl2-sys 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "version 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -57,6 +67,15 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -112,6 +131,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "linked-hash-map"
 version = "0.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "log"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memchr"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "miniz-sys"
@@ -196,6 +228,23 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "regex"
+version = "0.1.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "rustc-serialize"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,6 +310,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-id"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "time"
 version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,6 +344,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "utf8-ranges"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "version"
@@ -307,6 +378,7 @@ dependencies = [
 ]
 
 [metadata]
+"checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
 "checksum arrayvec 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d89f1b0e242270b5b797778af0c8d182a1a2ccac5d8d6fadf414223cc0fab096"
 "checksum bitflags 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "72cd7314bd4ee024071241147222c706e80385a1605ac7d4cd2fcc339da2ae46"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
@@ -314,6 +386,7 @@ dependencies = [
 "checksum bzip2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c30a578393daf45ee6101aa043afa8d47a7e70f05032b15b88b28a7111c6a53"
 "checksum bzip2-sys 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "81c91586be5d862524de53126d49c11fef83dc1a8e8034235f37372e3b2da311"
 "checksum conway 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a81d41bb6411865450c592b4aa29d66e145c50436a90a586bad4de6c66d68327"
+"checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
 "checksum flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "3eeb481e957304178d2e782f2da1257f1434dfecbae883bafb61ada2a9fea3bb"
 "checksum gcc 0.3.41 (registry+https://github.com/rust-lang/crates.io-index)" = "3689e1982a563af74960ae3a4758aa632bb8fd984cfc3cc3b60ee6109477ab6e"
 "checksum ggez 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a6ee0da08bcd5334608e66363425096dbc8de92183d29f228493f80592696b0c"
@@ -321,6 +394,8 @@ dependencies = [
 "checksum lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6abe0ee2e758cd6bc8a2cd56726359007748fbf4128da998b65d0b70f881e19b"
 "checksum libc 0.2.19 (registry+https://github.com/rust-lang/crates.io-index)" = "9e030dc72013ed68994d1b2cbf36a94dd0e58418ba949c4b0db7eeb70a7a6352"
 "checksum linked-hash-map 0.0.10 (registry+https://github.com/rust-lang/crates.io-index)" = "f26e961e0c884309cd527b1402a5409d35db612b36915d755e1a4f5c1547a31c"
+"checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
+"checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum miniz-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d1f4d337a01c32e1f2122510fed46393d53ca35a7f429cb0450abaedfa3ed54"
 "checksum msdos_time 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c04b68cc63a8480fb2550343695f7be72effdec953a9d4508161c3e69041c7d8"
 "checksum nodrop 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "0dbbadd3f4c98dea0bd3d9b4be4c0cdaf1ab57035cb2e41fce3983db5add7cc5"
@@ -332,6 +407,8 @@ dependencies = [
 "checksum podio 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e5422a1ee1bc57cc47ae717b0137314258138f38fd5f3cea083f43a9725383a0"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
 "checksum redox_syscall 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "8dd35cc9a8bdec562c757e3d43c1526b5c6d2653e23e2315065bc25556550753"
+"checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
+"checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum rustc-serialize 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "237546c689f20bb44980270c73c3b9edd0891c1be49cc1274406134a66d3957b"
 "checksum rusttype 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c64ffc93b0cc5a6f5e5e84da2a4082b0271e0a1dd76e821bdac570bda7797e"
 "checksum sdl2 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2e15a33054d1b982ca8eec453666757046af6f95e7dd09e2747d67ab0aeca1bd"
@@ -339,8 +416,11 @@ dependencies = [
 "checksum sdl2_image 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ccc3c5fffeeed080695bcdaf0788a08c9b5d8489a02c7de2a2f2f16d0f40cda2"
 "checksum sdl2_mixer 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)" = "026ba5a448ad5eaac5da5e32ab3fa2c30b4ca961e51158cd6e5e52d37d91fe1a"
 "checksum stb_truetype 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a0955c15cfb412f0c4fdfb3d07d2b1915869e472b35646cc3a3a104a8f79517b"
+"checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
+"checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "211b63c112206356ef1ff9b19355f43740fc3f85960c598a93d3a3d3ba7beade"
 "checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
+"checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum version 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c941215489baf638156fcc85c59a45444709a7ac2093b9b22b45e3cfe80fe26"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "ConWaysteTheEnemy"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "conway 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ConWaysteTheEnemy"
-version = "0.0.2"
+version = "0.0.3"
 authors = [ "mang", "Aaron Miller <aaron.miller04@gmail.com>" ]
 license = "GPL-3.0+"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,9 +7,11 @@ license = "GPL-3.0+"
 [dependencies]
 conway = "0.1.2"  # { git = "https://github.com/AaronM04/libconway" }
 ggez = "0.2.1"
-version = "2.0.1"
+env_logger = "0.3"
+log = "0.3"
 sdl2-sys = "0.25.0"
 sdl2 = "0.25.0"
+version = "2.0.1"
 
 [[bin]]
 name = "server"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ license = "GPL-3.0+"
 conway = "0.1.2"  # { git = "https://github.com/AaronM04/libconway" }
 ggez = "0.2.1"
 version = "2.0.1"
+sdl2-sys = "0.25.0"
+sdl2 = "0.25.0"
 
 [[bin]]
 name = "server"

--- a/src/client.rs
+++ b/src/client.rs
@@ -46,6 +46,7 @@ use conway::{Universe, CellState, Region};
 use std::collections::BTreeMap;
 use sdl2::video::FullscreenType;
 mod menu;
+mod video;
 
 
 const FPS: u32 = 25;
@@ -433,35 +434,9 @@ impl GameState for MainState {
                                     }
                                     menu::MenuItemIdentifier::Resolution => {
                                         let renderer = &mut _ctx.renderer;
-                                        let video_menu = self.menu_sys.menus.get_mut(&menu::MenuState::Video).unwrap();
-                                        let mut screen_res_item = video_menu.get_mut(1).unwrap();
-                                        let cur_resolution = screen_res_item.get_value().clone();
 
                                         // Transition to next
-                                        let (x, y) = match cur_resolution {
-                                            menu::MenuItemValue::ValEnum(x) => 
-                                            {
-                                                match x {
-                                                    menu::ScreenResolution::PX800X600 => {
-                                                        screen_res_item.set_value(menu::MenuItemValue::ValEnum(menu::ScreenResolution::PX1024X768));
-                                                        (1024, 768)
-                                                    }
-                                                    menu::ScreenResolution::PX1024X768 => {
-                                                        screen_res_item.set_value(menu::MenuItemValue::ValEnum(menu::ScreenResolution::PX1200X960));
-                                                        (1200, 960)
-                                                    }
-                                                    menu::ScreenResolution::PX1200X960 => {
-                                                        screen_res_item.set_value(menu::MenuItemValue::ValEnum(menu::ScreenResolution::PX1920X1080));
-                                                        (1920, 1080)
-                                                    }
-                                                    menu::ScreenResolution::PX1920X1080 => {
-                                                        screen_res_item.set_value(menu::MenuItemValue::ValEnum(menu::ScreenResolution::PX800X600));
-                                                        (800, 600)
-                                                    }
-                                                }
-                                            }
-                                            _ => {(0,0)}
-                                        };
+                                        let (x, y) = self.menu_sys.transition_video_resolution();
 
                                         if (x,y) != (0,0) {
                                         // Resolution resizing
@@ -594,6 +569,9 @@ impl GameState for MainState {
                 match self.menu_sys.menu_state {
                     menu::MenuState::Video => {
                         let ref menus = self.menu_sys.menus.get(&menu::MenuState::Video).unwrap();
+                        ////////////////////////////////
+                        //// Fullscreen
+                        ///////////////////////////////
                         {
                             let ref menu_item_fs_coords = menus.get(0).unwrap().get_coords();
                             let coords = (menu_item_fs_coords.x() + 200, menu_item_fs_coords.y());
@@ -604,34 +582,16 @@ impl GameState for MainState {
                             let dst = Rect::new(coords.0, coords.1, is_fullscreen_text.width(), is_fullscreen_text.height());
                             graphics::draw(ctx, &mut is_fullscreen_text, None, Some(dst))?;
                         }
+
+                        ////////////////////////////////
+                        //// Resolution
+                        ///////////////////////////////
                         {
                             let ref menu_item_res_coords = menus.get(1).unwrap().get_coords();
                             let coords = (menu_item_res_coords.x() + 200, menu_item_res_coords.y());
 
                             let cur_resolution = menus.get(1).unwrap().get_value().clone();
-                            let mut cur_res_str = match cur_resolution {
-                                menu::MenuItemValue::ValEnum(x) => 
-                                {
-                                    match x {
-                                        menu::ScreenResolution::PX800X600 => {
-                                            Some("800 x 600")
-                                        }
-                                        menu::ScreenResolution::PX1024X768 => {
-                                            Some("1024 x 768")
-                                        }
-                                        menu::ScreenResolution::PX1200X960 => {
-                                            Some("1200 x 960")
-                                        }
-                                        menu::ScreenResolution::PX1920X1080 => {
-                                            Some("1920 x 1080")
-                                        }
-                                    }
-                                }
-                                _ => {
-                                    None
-                                }
-                            };
-                            let cur_res_str = cur_res_str.unwrap();
+                            let cur_res_str = menu::MenuItem::get_video_menu_current_resolution(cur_resolution).unwrap();
 
                             let mut cur_res_text = graphics::Text::new(ctx, &cur_res_str, &self.small_font).unwrap();
                             let dst = Rect::new(coords.0, coords.1, cur_res_text.width(), cur_res_text.height());

--- a/src/client.rs
+++ b/src/client.rs
@@ -321,7 +321,11 @@ impl GameState for MainState {
                 if self.arrow_input != (0,0) {
                     // move selection accordingly
                     let (_,y) = self.arrow_input;
-                    
+                   let ref mut metaData = self.menu_sys.get_meta_data();
+                   let ref mut menu_meta = metaData.get(&menu::MenuState::MainMenu).unwrap();
+
+                    menu_meta.adjust_index(y);
+ 
                 }
                 else {
                     // Return
@@ -434,15 +438,50 @@ impl GameState for MainState {
                 match self.menu_sys.menu_state {
                     menu::MenuState::MainMenu => {
                         let ref menu_state = self.menu_sys.menu_state;
-
                         let ref menus = self.menu_sys.menus.get(menu_state).unwrap();
-                        let start_game_string = menus.get(0).unwrap().get_text();
-                        let start_game_str = start_game_string.as_str();
-                        let mut start_game_text = graphics::Text::new(ctx,
-                                                               &start_game_str,
-                                                               &self.small_font).unwrap();
-                        let dst = Rect::new(0, 0, start_game_text.width(), start_game_text.height());
-                        graphics::draw(ctx, &mut start_game_text, None, Some(dst))?;
+
+                        /// Print Menu Items
+                        //////////////////////////////////////////////////////
+                        for menu_item in menus.iter() {
+                            let menu_option_string = menu_item.get_text();
+                            let menu_option_str = menu_option_string.as_str();
+                            let mut menu_option_text = graphics::Text::new(ctx,
+                                                                   &menu_option_str,
+                                                                   &self.small_font).unwrap();
+
+                            let menu_coords = menu_item.get_coords();
+
+                            let dst = Rect::new(menu_coords.x(), menu_coords.y(), menu_option_text.width(), menu_option_text.height());
+                            graphics::draw(ctx, &mut menu_option_text, None, Some(dst))?;
+                        }
+
+                        /// Print Current Selection
+                        ////////////////////////////////////////////////////
+                        {
+                            let ref menu_meta = self.menu_sys.menu_metadata.get(&self.menu_sys.menu_state.clone()).unwrap();
+                            let index = *(menu_meta.get_index());
+                            
+                            let cur_option_str = " <-";
+                            let mut cur_option_text = graphics::Text::new(ctx, &cur_option_str, &self.small_font).unwrap();
+                            let mut coords = (0,0);
+
+                            if index == 1
+                            {
+                                coords  = (250, 250);
+                            }
+                            else if index == 2
+                            {
+                                coords = (300, 300);
+                            }
+                            else if index == 3
+                            {
+                                coords = (400, 400);
+                            }
+
+                            let dst = Rect::new(coords.0, coords.1, cur_option_text.width(), cur_option_text.height());
+                            graphics::draw(ctx, &mut cur_option_text, None, Some(dst))?;
+
+                        }
                     }
                     menu::MenuState::Options => {
                     

--- a/src/client.rs
+++ b/src/client.rs
@@ -456,6 +456,7 @@ impl GameState for MainState {
                                             {
                                                 let window = renderer.window_mut().unwrap();
                                                 let _ = window.set_size(x,y);
+                                                self.video_settings.set_resolution(x as u16, y as u16);
                                             }
                                         }
                                     }
@@ -544,8 +545,8 @@ impl GameState for MainState {
                         /// Draw all menu Items
                         ////////////////////////////////////////////////
                         {
-                            let mut container = self.menu_sys.menus.get(cur_menu_state).unwrap();
-                            let mut pos_x = container.get_anchor().x();
+                            let container = self.menu_sys.menus.get(cur_menu_state).unwrap();
+                            let pos_x = container.get_anchor().x();
                             let mut pos_y = container.get_anchor().y();
 
                             /// Print Menu Items
@@ -572,7 +573,7 @@ impl GameState for MainState {
                             let mut cur_option_text = graphics::Text::new(ctx, &cur_option_str, &self.small_font).unwrap();
 
                             let ref container = self.menu_sys.menus.get(&cur_menu_state).unwrap();
-                            let mut coords = container.get_anchor();
+                            let coords = container.get_anchor();
 
                             let dst = Rect::new(coords.x() - 50, coords.y() + 50*index, cur_option_text.width(), cur_option_text.height());
                             graphics::draw(ctx, &mut cur_option_text, None, Some(dst))?;
@@ -881,7 +882,7 @@ fn adjust_panning(main_state: &mut MainState) {
 
     // check if the bottom/right coordinates are within the current window
     {
-        let resolution = main_state.video_settings.getResolution();
+        let resolution = main_state.video_settings.get_resolution();
         let win_x = resolution.0 as i32;
         let win_y = resolution.1 as i32;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -718,11 +718,9 @@ fn adjust_zoom_level(main_state: &mut MainState, direction : ZoomDirection) {
         }
 
         // TODO Mang Proper logging
-        if log_enabled!(LogLevel::Debug) {
-            debug!("Window Size: ({}, {})", main_state.grid_view.rect.width(), main_state.grid_view.rect.height());
-            debug!("Origin Before: ({},{})", main_state.grid_view.grid_origin.x(), main_state.grid_view.grid_origin.y());
-            debug!("Cell Size Before: {},", main_state.grid_view.cell_size);
-        }
+        debug!("Window Size: ({}, {})", main_state.grid_view.rect.width(), main_state.grid_view.rect.height());
+        debug!("Origin Before: ({},{})", main_state.grid_view.grid_origin.x(), main_state.grid_view.grid_origin.y());
+        debug!("Cell Size Before: {},", main_state.grid_view.cell_size);
 
         let old_cell_size = main_state.grid_view.cell_size;
         let next_cell_size = main_state.grid_view.cell_size as i32 + zoom_dir;
@@ -733,19 +731,15 @@ fn adjust_zoom_level(main_state: &mut MainState, direction : ZoomDirection) {
             let delta_x = zoom_dir * (old_cell_count_for_x as i32 * next_cell_size as i32 - old_cell_count_for_x as i32 * old_cell_size as i32);
             let delta_y = zoom_dir * (old_cell_count_for_y as i32 * next_cell_size as i32 - old_cell_count_for_y as i32 * old_cell_size as i32);
 
-            if log_enabled!(LogLevel::Debug) {
-                debug!("current cell count: {}, {}", old_cell_count_for_x, old_cell_count_for_x);
-                debug!("delta in win coords: {}, {}", delta_x, delta_y);
-            }
+            debug!("current cell count: {}, {}", old_cell_count_for_x, old_cell_count_for_x);
+            debug!("delta in win coords: {}, {}", delta_x, delta_y);
 
             main_state.grid_view.cell_size = next_cell_size as u32;
 
             main_state.grid_view.grid_origin = main_state.grid_view.grid_origin.offset(-zoom_dir * (delta_x as i32), -zoom_dir * (delta_y as i32));
 
-            if log_enabled!(LogLevel::Debug) {
-                debug!("Origin After: ({},{})\n", main_state.grid_view.grid_origin.x(), main_state.grid_view.grid_origin.y());
-                debug!("Cell Size After: {},", main_state.grid_view.cell_size);
-            }
+            debug!("Origin After: ({},{})\n", main_state.grid_view.grid_origin.x(), main_state.grid_view.grid_origin.y());
+            debug!("Cell Size After: {},", main_state.grid_view.cell_size);
         }
     }
 }
@@ -768,9 +762,7 @@ fn adjust_panning(main_state: &mut MainState) {
 
     let border_in_px = 100;
 
-    if log_enabled!(LogLevel::Debug) {
-        debug!("Cell Size: {:?}", (cell_size, border_in_px));
-    }
+    debug!("Cell Size: {:?}", (cell_size, border_in_px));
 
     // lol this works for now. One thing we'll need to check,
     // either during zooming in or panning,
@@ -786,10 +778,8 @@ fn adjust_panning(main_state: &mut MainState) {
         let win_x = resolution.0 as i32;
         let win_y = resolution.1 as i32;
 
-        if log_enabled!(LogLevel::Debug) {
-            debug!("Window: {:?}", (win_x, win_y));
-            debug!("Boundaries: {:?}", (right_boundary_in_px, bottom_boundary_in_px));
-        }
+        debug!("Window: {:?}", (win_x, win_y));
+        debug!("Boundaries: {:?}", (right_boundary_in_px, bottom_boundary_in_px));
 
         if i32::abs(right_boundary_in_px) > win_x {
             right_boundary_in_px += -1*(i32::abs(right_boundary_in_px) - win_x);
@@ -812,10 +802,8 @@ fn adjust_panning(main_state: &mut MainState) {
         main_state.grid_view.grid_origin = main_state.grid_view.grid_origin.offset(dx_in_pixels, dy_in_pixels);
     }
 
-    if log_enabled!(LogLevel::Debug) {
-        debug!("New Origin: {:?}", (new_origin_x, new_origin_y));
-        debug!("Boundary: {:?}", (right_boundary_in_px, bottom_boundary_in_px));
-    }
+    debug!("New Origin: {:?}", (new_origin_x, new_origin_y));
+    debug!("Boundary: {:?}", (right_boundary_in_px, bottom_boundary_in_px));
 
     // Snap edges in case we are out of bounds
     if new_origin_x >= border_in_px {

--- a/src/client.rs
+++ b/src/client.rs
@@ -102,7 +102,7 @@ impl ColorSettings {
 fn init_patterns(s: &mut MainState) -> Result<(), ()> {
     /*
     // R pentomino
-    s.uni.toggle(16, 15, 0)?;
+s.uni.toggle(16, 15, 0)?;
     s.uni.toggle(17, 15, 0)?;
     s.uni.toggle(15, 16, 0)?;
     s.uni.toggle(16, 16, 0)?;
@@ -254,7 +254,7 @@ impl GameState for MainState {
         color_settings.cell_colors.insert(CellState::Alive(Some(0)), Color::RGB(255,   0,   0));  // 0 is red
         color_settings.cell_colors.insert(CellState::Alive(Some(1)), Color::RGB(  0,   0, 255));  // 1 is blue
         color_settings.cell_colors.insert(CellState::Wall,           Color::RGB(158, 141, 105));
-        color_settings.cell_colors.insert(CellState::Fog,            Color::RGB(128, 128, 128));
+        color_settings.cell_colors.insert(CellState::Fog,            Color::RGB(200, 200, 200));
 
         // we're going to have to tear this all out when this becomes a real game
         let player0_writable = Region::new(100, 70, 34, 16);   // used for the glider gun and predefined patterns

--- a/src/client.rs
+++ b/src/client.rs
@@ -390,7 +390,7 @@ impl GameState for MainState {
                                     menu::MenuItemIdentifier::ReturnToPreviousMenu => {
                                         self.menu_sys.menu_state = menu::MenuState::MainMenu;
                                     }
-                                    _ => {}
+                                   _ => {}
                                 }
                             }
                             menu::MenuState::MenuOff => {
@@ -430,6 +430,47 @@ impl GameState for MainState {
                                             _ => {}
                                         }
                                         let _ = window.set_fullscreen(new_fs_type);
+                                    }
+                                    menu::MenuItemIdentifier::Resolution => {
+                                        let renderer = &mut _ctx.renderer;
+                                        let video_menu = self.menu_sys.menus.get_mut(&menu::MenuState::Video).unwrap();
+                                        let mut screen_res_item = video_menu.get_mut(1).unwrap();
+                                        let cur_resolution = screen_res_item.get_value().clone();
+
+                                        // Transition to next
+                                        let (x, y) = match cur_resolution {
+                                            menu::MenuItemValue::ValEnum(x) => 
+                                            {
+                                                match x {
+                                                    menu::ScreenResolution::PX800X600 => {
+                                                        screen_res_item.set_value(menu::MenuItemValue::ValEnum(menu::ScreenResolution::PX1024X768));
+                                                        (1024, 768)
+                                                    }
+                                                    menu::ScreenResolution::PX1024X768 => {
+                                                        screen_res_item.set_value(menu::MenuItemValue::ValEnum(menu::ScreenResolution::PX1200X960));
+                                                        (1200, 960)
+                                                    }
+                                                    menu::ScreenResolution::PX1200X960 => {
+                                                        screen_res_item.set_value(menu::MenuItemValue::ValEnum(menu::ScreenResolution::PX1920X1080));
+                                                        (1920, 1080)
+                                                    }
+                                                    menu::ScreenResolution::PX1920X1080 => {
+                                                        screen_res_item.set_value(menu::MenuItemValue::ValEnum(menu::ScreenResolution::PX800X600));
+                                                        (800, 600)
+                                                    }
+                                                }
+                                            }
+                                            _ => {(0,0)}
+                                        };
+
+                                        if (x,y) != (0,0) {
+                                        // Resolution resizing
+                                            let _ = renderer.set_logical_size(x,y);
+                                            {
+                                                let window = renderer.window_mut().unwrap();
+                                                let _ = window.set_size(x,y);
+                                            }
+                                        }
                                     }
                                     _ => {}
                                 }
@@ -554,14 +595,47 @@ impl GameState for MainState {
                     menu::MenuState::Video => {
                         let ref menus = self.menu_sys.menus.get(&menu::MenuState::Video).unwrap();
                         {
+                            let ref menu_item_fs_coords = menus.get(0).unwrap().get_coords();
+                            let coords = (menu_item_fs_coords.x() + 200, menu_item_fs_coords.y());
+
                             let is_fullscreen_str = if self.is_fullscreen { "Yes" } else { "No" };
                             let mut is_fullscreen_text = graphics::Text::new(ctx, &is_fullscreen_str, &self.small_font).unwrap();
-                            let ref menu_item_fs_coords = menus.get(0).unwrap().get_coords();
-
-                            let coords = (menu_item_fs_coords.x() + 200, menu_item_fs_coords.y());
 
                             let dst = Rect::new(coords.0, coords.1, is_fullscreen_text.width(), is_fullscreen_text.height());
                             graphics::draw(ctx, &mut is_fullscreen_text, None, Some(dst))?;
+                        }
+                        {
+                            let ref menu_item_res_coords = menus.get(1).unwrap().get_coords();
+                            let coords = (menu_item_res_coords.x() + 200, menu_item_res_coords.y());
+
+                            let cur_resolution = menus.get(1).unwrap().get_value().clone();
+                            let mut cur_res_str = match cur_resolution {
+                                menu::MenuItemValue::ValEnum(x) => 
+                                {
+                                    match x {
+                                        menu::ScreenResolution::PX800X600 => {
+                                            Some("800 x 600")
+                                        }
+                                        menu::ScreenResolution::PX1024X768 => {
+                                            Some("1024 x 768")
+                                        }
+                                        menu::ScreenResolution::PX1200X960 => {
+                                            Some("1200 x 960")
+                                        }
+                                        menu::ScreenResolution::PX1920X1080 => {
+                                            Some("1920 x 1080")
+                                        }
+                                    }
+                                }
+                                _ => {
+                                    None
+                                }
+                            };
+                            let cur_res_str = cur_res_str.unwrap();
+
+                            let mut cur_res_text = graphics::Text::new(ctx, &cur_res_str, &self.small_font).unwrap();
+                            let dst = Rect::new(coords.0, coords.1, cur_res_text.width(), cur_res_text.height());
+                             graphics::draw(ctx, &mut cur_res_text, None, Some(dst))?;
                         }
                     }
                      _  => {}

--- a/src/client.rs
+++ b/src/client.rs
@@ -49,7 +49,6 @@ use std::time::Duration;
 use std::fs::File;
 use conway::{Universe, CellState, Region};
 use std::collections::BTreeMap;
-use log::LogLevel;
 
 mod menu;
 mod video;

--- a/src/client.rs
+++ b/src/client.rs
@@ -316,14 +316,21 @@ impl GameState for MainState {
                 // Exit Game
                 //
                 //
-                
 
-                if self.arrow_input != (0,0) {
+                let is_direction_key_pressed = {
+                    let x = self.menu_sys.get_controls().is_menu_key_pressed();
+                    println!("Pressed? {}", x);
+                    x
+                };
+
+                if self.arrow_input != (0,0) && !is_direction_key_pressed {
                     // move selection accordingly
                     let (_,y) = self.arrow_input;
-                   let ref mut mainmenu_md = self.menu_sys.get_meta_data(&menu::MenuState::MainMenu);
-                   mainmenu_md.adjust_index(y);
- 
+                    {
+                        let ref mut mainmenu_md = self.menu_sys.get_meta_data(&menu::MenuState::MainMenu);
+                        mainmenu_md.adjust_index(y);
+                    }
+                    self.menu_sys.get_controls().set_menu_key_pressed(true);
                 }
                 else {
                     // Return
@@ -459,7 +466,6 @@ impl GameState for MainState {
                         /// Print Current Selection
                         ////////////////////////////////////////////////////
                         let index = {
-                           
                             let ref menu_meta = self.menu_sys.get_meta_data(&cur_menu_state);
                             *(menu_meta.get_index())
                         };
@@ -582,24 +588,28 @@ impl GameState for MainState {
                 self.stage = Stage::Menu;
             }
             Stage::Menu => {
-                match keycode {
-                    Keycode::Up => {
-                        self.arrow_input = (0, -1);
-                    }
-                    Keycode::Down => {
-                        self.arrow_input = (0, 1);
-                    }
-                    Keycode::Left => {
-                        self.arrow_input = (-1, 0);
-                    }
-                    Keycode::Right => {
-                        self.arrow_input = (1, 0);
-                    }
-                    Keycode::Return => {
-                       self.return_key_pressed = true;
-                    }
-                    _ => {
+                
+                if !self.menu_sys.get_controls().is_menu_key_pressed() {
+                    match keycode {
+                        Keycode::Up => {
+                            self.arrow_input = (0, -1);
+                        }
+                        Keycode::Down => {
+                            self.arrow_input = (0, 1);
+                            println!("Key is held down...");
+                        }
+                        Keycode::Left => {
+                            self.arrow_input = (-1, 0);
+                        }
+                        Keycode::Right => {
+                            self.arrow_input = (1, 0);
+                        }
+                        Keycode::Return => {
+                            self.return_key_pressed = true;
+                        }
+                        _ => {
 
+                        }
                     }
                 }
             }
@@ -670,6 +680,8 @@ impl GameState for MainState {
         match keycode {
             Keycode::Up | Keycode::Down | Keycode::Left | Keycode::Right => {
                 self.arrow_input = (0, 0);
+                self.menu_sys.get_controls().set_menu_key_pressed(false);
+                println!("Key released: {}", keycode);
             }
             _ => {}
         }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -28,10 +28,32 @@ pub struct MenuMetaData {
     menu_size:   u32,
 }
 
+#[derive(Debug)]
+pub struct MenuControls {
+    dir_key_pressed:       bool,
+}
+
 pub struct MenuSystem {
     pub    menus:           HashMap<MenuState, Vec<MenuItem> >,
     pub    menu_metadata:   HashMap<MenuState, MenuMetaData>,
     pub    menu_state:      MenuState,
+           controls:        MenuControls,
+}
+
+impl MenuControls {
+    pub fn new() -> MenuControls {
+        MenuControls {
+            dir_key_pressed: false,
+        }
+    }
+
+    pub fn set_menu_key_pressed(&mut self, state: bool) {
+        self.dir_key_pressed = state;
+    }
+
+    pub fn is_menu_key_pressed(&self) -> bool {
+        self.dir_key_pressed
+    }
 }
 
 impl MenuItem {
@@ -83,6 +105,7 @@ impl MenuSystem {
             menus: HashMap::new(),
             menu_metadata:  HashMap::new(),
             menu_state: MenuState::MainMenu,
+            controls: MenuControls::new(),
         };
 
         menu_sys.menus.insert(MenuState::MenuOff,  Vec::new());
@@ -173,6 +196,10 @@ impl MenuSystem {
 
     pub fn get_meta_data(&mut self, state: &MenuState) -> &mut MenuMetaData {
         self.menu_metadata.get_mut(&state).unwrap()
+    }
+
+    pub fn get_controls(&mut self) -> &mut MenuControls {
+        &mut self.controls
     }
 }
 

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -24,6 +24,18 @@ pub enum MenuItemIdentifier {
     GameplaySettings,
     ExitGame,
     ReturnToPreviousMenu,
+
+    Fullscreen,
+}
+
+#[derive(Debug, Clone)]
+pub enum MenuItemValue {
+    ValString(String),
+    ValI32(i32),
+    ValU32(u32),
+    ValF32(f32),
+    valBool(bool),
+    ValNone(),
 }
 
 #[derive(Debug, Clone)]
@@ -31,7 +43,7 @@ pub struct MenuItem {
     id:         MenuItemIdentifier,
     text:       String,
     editable:   bool,
-    value:      u32,
+    value:      MenuItemValue,
     coords:     Point
 }
 
@@ -70,7 +82,7 @@ impl MenuControls {
 }
 
 impl MenuItem {
-    pub fn new(identifier: MenuItemIdentifier, name: String, can_edit: bool, value: u32, point: Point) -> MenuItem {
+    pub fn new(identifier: MenuItemIdentifier, name: String, can_edit: bool, value: MenuItemValue, point: Point) -> MenuItem {
         MenuItem {
             id: identifier,
             text: name,
@@ -133,15 +145,17 @@ impl MenuSystem {
         menu_sys.menus.insert(MenuState::Audio,    Vec::new());
         menu_sys.menus.insert(MenuState::Gameplay, Vec::new());
 
-        let menu_off    = MenuItem::new(MenuItemIdentifier::None, String::from("NULL"),       false, 0, Point::new(0, 0));
-        let start_game  = MenuItem::new(MenuItemIdentifier::StartGame, String::from("Start Game"), false, 0, Point::new(100, 100));
-        let options     = MenuItem::new(MenuItemIdentifier::Options, String::from("Options"),    false, 0, Point::new(100, 300));
-        let video       = MenuItem::new(MenuItemIdentifier::VideoSettings, String::from("Video"),      false, 0, Point::new(100, 100));
-        let audio       = MenuItem::new(MenuItemIdentifier::AudioSettings, String::from("Audio"),      false, 0, Point::new(100, 300));
-        let gameplay    = MenuItem::new(MenuItemIdentifier::GameplaySettings, String::from("Gameplay"),   false, 0, Point::new(100, 500));
-        let goback      = MenuItem::new(MenuItemIdentifier::ReturnToPreviousMenu, String::from("Back"), false, 0, Point::new(100, 700));
-        let quit        = MenuItem::new(MenuItemIdentifier::ExitGame, String::from("Quit"),       false, 0, Point::new(100, 500));
-        let nothing     = MenuItem::new(MenuItemIdentifier::None, String::from("TBD"),        true, 100, Point::new(0, 0));
+        let menu_off    = MenuItem::new(MenuItemIdentifier::None, String::from("NULL"),       false, MenuItemValue::ValU32(0), Point::new(0, 0));
+        let start_game  = MenuItem::new(MenuItemIdentifier::StartGame, String::from("Start Game"), false, MenuItemValue::ValU32(0), Point::new(100, 100));
+        let options     = MenuItem::new(MenuItemIdentifier::Options, String::from("Options"),    false, MenuItemValue::ValU32(0), Point::new(100, 300));
+        let video       = MenuItem::new(MenuItemIdentifier::VideoSettings, String::from("Video"),      false, MenuItemValue::ValU32(0), Point::new(100, 100));
+        let audio       = MenuItem::new(MenuItemIdentifier::AudioSettings, String::from("Audio"),      false, MenuItemValue::ValU32(0), Point::new(100, 300));
+        let gameplay    = MenuItem::new(MenuItemIdentifier::GameplaySettings, String::from("Gameplay"),   false, MenuItemValue::ValU32(0), Point::new(100, 500));
+        let goback      = MenuItem::new(MenuItemIdentifier::ReturnToPreviousMenu, String::from("Back"), false, MenuItemValue::ValU32(0), Point::new(100, 700));
+        let quit        = MenuItem::new(MenuItemIdentifier::ExitGame, String::from("Quit"),       false, MenuItemValue::ValU32(0), Point::new(100, 500));
+        let nothing     = MenuItem::new(MenuItemIdentifier::None, String::from("TBD"),        false, MenuItemValue::ValNone(), Point::new(0, 0));
+
+        let fullscreen  = MenuItem::new(MenuItemIdentifier::Fullscreen, String::from("Fullscreen:"), true, MenuItemValue::valBool(false), Point::new(100, 100));
 
         menu_sys.menus
             .get_mut(&MenuState::MenuOff)
@@ -150,6 +164,9 @@ impl MenuSystem {
         menu_sys.menu_metadata.insert(MenuState::MenuOff,  MenuMetaData::new(0, 0));
 
         {
+            /////////////////////////
+            // Main Menu
+            /////////////////////////
             let ref mut metadata = menu_sys.menu_metadata;
             let ref mut main_menu = menu_sys.menus
                 .get_mut(&MenuState::MainMenu)
@@ -164,6 +181,9 @@ impl MenuSystem {
         }
 
         {
+            /////////////////////////
+            // Options
+            /////////////////////////
             let ref mut metadata = menu_sys.menu_metadata;
             let ref mut options_menu = menu_sys.menus
                 .get_mut(&MenuState::Options)
@@ -179,10 +199,14 @@ impl MenuSystem {
         }
 
         {
+            /////////////////////////
+            // Video
+            /////////////////////////
             let ref mut metadata = menu_sys.menu_metadata;
             let ref mut video_menu = menu_sys.menus
                 .get_mut(&MenuState::Video)
                 .unwrap();
+            video_menu.push(fullscreen);
             video_menu.push(goback.clone());
 
             let count = video_menu.len() as u32;
@@ -190,6 +214,9 @@ impl MenuSystem {
         }
 
         {
+            /////////////////////////
+            // Audio
+            /////////////////////////
             let ref mut metadata = menu_sys.menu_metadata;
             let ref mut audio_menu = menu_sys.menus
                 .get_mut(&MenuState::Audio)
@@ -201,6 +228,9 @@ impl MenuSystem {
         }
 
         {
+            /////////////////////////
+            // Gameplay
+            /////////////////////////
             let ref mut metadata = menu_sys.menu_metadata;
             let ref mut gameplay_menu = menu_sys.menus
                 .get_mut(&MenuState::Gameplay)

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -4,9 +4,6 @@ extern crate ggez;
 use ggez::graphics::{Point};
 use std::collections::{HashMap};
 
-type MenuIndex=u32;
-type MenuItemCount=u32;
-
 #[derive(PartialEq, Eq, Hash, Debug, Clone)]
 pub enum MenuState {
      MenuOff,
@@ -15,7 +12,6 @@ pub enum MenuState {
      Video,
      Audio,
      Gameplay,
-     Quit
 }
 
 #[derive(Debug, Clone)]
@@ -28,8 +24,8 @@ pub struct MenuItem {
 
 #[derive(Debug, Clone)]
 pub struct MenuMetaData {
-    menuIndex:  u32,
-    menuSize:   u32,
+    menu_index:  u32,
+    menu_size:   u32,
 }
 
 pub struct MenuSystem {
@@ -60,20 +56,24 @@ impl MenuItem {
 impl MenuMetaData {
     pub fn new(index: u32, size: u32) -> MenuMetaData {
         MenuMetaData {
-            menuIndex: index,
-            menuSize: size,
+            menu_index: index,
+            menu_size: size,
         }
     }
 
     pub fn get_index(&self) -> &u32 {
-        &self.menuIndex
+        &self.menu_index
     }
 
     pub fn adjust_index(&mut self, amt: i32) {
-        let size : i32 = self.menuSize as i32;
-        let new_index = (self.menuIndex as i32 + amt) % size;
+        let size = self.menu_size;
+        let mut new_index = (self.menu_index as i32 + amt) as u32 % size;
 
-        self.menuIndex = new_index as u32;
+        if amt < 0 && self.menu_index == 0 {
+            new_index = size-1;
+        }
+
+        self.menu_index = new_index as u32;
     }
 }
 
@@ -171,11 +171,13 @@ impl MenuSystem {
         menu_sys
     }
 
-    pub fn get_meta_data(& self) -> &mut HashMap<MenuState, MenuMetaData> {
-        &mut self.menu_metadata
+    pub fn get_meta_data(&mut self, state: &MenuState) -> &mut MenuMetaData {
+        self.menu_metadata.get_mut(&state).unwrap()
     }
 }
 
+#[allow(dead_code)]
+// when compiled with rustc we'll print out the menus
 fn main() {
     let my_menusys = MenuSystem::new();
 

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -172,7 +172,7 @@ impl MenuItem {
         let mut screen_res_item = video_menu.get_mut(1).unwrap();
         let cur_resolution = screen_res_item.get_value().clone();
 
-        match cur_resolution {
+        let resolution = match cur_resolution {
             MenuItemValue::ValEnum(x) => 
             {
                 match x {
@@ -195,7 +195,8 @@ impl MenuItem {
                 }
             }
             _ => {(0,0)}
-        }
+        };
+        resolution
     }
 
 }
@@ -240,15 +241,14 @@ impl MenuSystem {
         menu_sys.menus.insert(MenuState::Audio,    MenuContainer::new(200, 100));
         menu_sys.menus.insert(MenuState::Gameplay, MenuContainer::new(200, 100));
 
-        let menu_off    = MenuItem::new(MenuItemIdentifier::None, String::from("NULL"),       false, MenuItemValue::ValU32(0));
-        let start_game  = MenuItem::new(MenuItemIdentifier::StartGame, String::from("Start Game"), false, MenuItemValue::ValU32(0));
-        let options     = MenuItem::new(MenuItemIdentifier::Options, String::from("Options"),    false, MenuItemValue::ValU32(0));
-        let video       = MenuItem::new(MenuItemIdentifier::VideoSettings, String::from("Video"),      false, MenuItemValue::ValU32(0));
-        let audio       = MenuItem::new(MenuItemIdentifier::AudioSettings, String::from("Audio"),      false, MenuItemValue::ValU32(0));
-        let gameplay    = MenuItem::new(MenuItemIdentifier::GameplaySettings, String::from("Gameplay"),   false, MenuItemValue::ValU32(0));
-        let goback      = MenuItem::new(MenuItemIdentifier::ReturnToPreviousMenu, String::from("Back"), false, MenuItemValue::ValU32(0));
-        let quit        = MenuItem::new(MenuItemIdentifier::ExitGame, String::from("Quit"),       false, MenuItemValue::ValU32(0));
-        let nothing     = MenuItem::new(MenuItemIdentifier::None, String::from("TBD"),        false, MenuItemValue::ValNone());
+        let menu_off    = MenuItem::new(MenuItemIdentifier::None, String::from("NULL"),       false, MenuItemValue::ValNone());
+        let start_game  = MenuItem::new(MenuItemIdentifier::StartGame, String::from("Start Game"), false, MenuItemValue::ValNone());
+        let options     = MenuItem::new(MenuItemIdentifier::Options, String::from("Options"),    false, MenuItemValue::ValNone());
+        let video       = MenuItem::new(MenuItemIdentifier::VideoSettings, String::from("Video"),      false, MenuItemValue::ValNone());
+        let audio       = MenuItem::new(MenuItemIdentifier::AudioSettings, String::from("Audio"),      false, MenuItemValue::ValNone());
+        let gameplay    = MenuItem::new(MenuItemIdentifier::GameplaySettings, String::from("Gameplay"),   false, MenuItemValue::ValNone());
+        let goback      = MenuItem::new(MenuItemIdentifier::ReturnToPreviousMenu, String::from("Back"), false, MenuItemValue::ValNone());
+        let quit        = MenuItem::new(MenuItemIdentifier::ExitGame, String::from("Quit"),       false, MenuItemValue::ValNone());
 
         let fullscreen  = MenuItem::new(MenuItemIdentifier::Fullscreen, String::from("Fullscreen:"), true, MenuItemValue::ValBool(false));
         let resolution  = MenuItem::new(MenuItemIdentifier::Resolution, String::from("Resolution:"), true, MenuItemValue::ValEnum(video::ScreenResolution::PX1200X960));

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -1,0 +1,130 @@
+
+use std::collections::{HashMap};
+
+#[derive(PartialEq, Eq, Hash, Debug)]
+pub enum MenuState {
+     MenuOff,
+     MainMenu,
+     Options,
+     Video,
+     Audio,
+     Gameplay,
+     Quit
+}
+
+#[derive(Debug, Clone)]
+pub struct MenuItem {
+    text:       String,
+    editable:   bool,
+    value:      u32,
+}
+
+#[derive(Debug)]
+pub struct MenuMetaData {
+    menuIndex:   u32,
+}
+
+pub struct MenuSystem {
+    pub    menus:           HashMap<MenuState, Vec<MenuItem> >,
+    pub    menu_metadata:   HashMap<MenuState, MenuMetaData>,
+    pub    menu_state:      MenuState,
+}
+
+impl MenuItem {
+    pub fn new(name: String, can_edit: bool, value: u32) -> MenuItem {
+        MenuItem {
+            text: name,
+            editable: can_edit,
+            value: value
+        }
+    }
+
+    pub fn get_text(&self) -> &String {
+        &self.text
+    }
+}
+
+impl MenuSystem {
+    pub fn new() -> MenuSystem {
+        let mut menu_sys = MenuSystem {
+            menus: HashMap::new(),
+            menu_metadata:  HashMap::new(),
+            menu_state: MenuState::MainMenu,
+        };
+
+        
+        menu_sys.menus.insert(MenuState::MenuOff,  Vec::new());
+        menu_sys.menus.insert(MenuState::MainMenu, Vec::new());
+        menu_sys.menus.insert(MenuState::Options,  Vec::new());
+        menu_sys.menus.insert(MenuState::Video,    Vec::new());
+        menu_sys.menus.insert(MenuState::Audio,    Vec::new());
+        menu_sys.menus.insert(MenuState::Gameplay, Vec::new());
+
+        let menu_off    = MenuItem::new(String::from("NULL"), false, 0);
+        let start_game  = MenuItem::new(String::from("Start Game"), false, 0);
+        let options     = MenuItem::new(String::from("Options"), false, 0);
+        let video       = MenuItem::new(String::from("Video"), false, 0);
+        let audio       = MenuItem::new(String::from("Audio"), false, 0);
+        let gameplay    = MenuItem::new(String::from("Gameplay"), false, 0);
+        let quit        = MenuItem::new(String::from("Quit"), false, 0);
+
+        let nothing     = MenuItem::new(String::from("TBD"), true, 100);
+
+        menu_sys.menus
+            .get_mut(&MenuState::MenuOff)
+            .unwrap()
+            .push(menu_off);
+
+        {
+            let ref mut main_menu = menu_sys.menus
+                .get_mut(&MenuState::MainMenu)
+                .unwrap();
+            main_menu.push(start_game);
+            main_menu.push(options);
+            main_menu.push(quit);
+        }
+
+        {
+            let ref mut options_menu = menu_sys.menus
+                .get_mut(&MenuState::Options)
+                .unwrap();
+            options_menu.push(video);
+            options_menu.push(audio);
+            options_menu.push(gameplay);
+        }
+
+        {
+            let ref mut options_menu = menu_sys.menus
+                .get_mut(&MenuState::Video)
+                .unwrap();
+            options_menu.push(nothing.clone());
+        }
+
+        {
+            let ref mut options_menu = menu_sys.menus
+                .get_mut(&MenuState::Audio)
+                .unwrap();
+            options_menu.push(nothing.clone());
+        }
+
+        {
+            let ref mut options_menu = menu_sys.menus
+                .get_mut(&MenuState::Gameplay)
+                .unwrap();
+            options_menu.push(nothing.clone());
+        }
+
+        menu_sys
+    }
+}
+
+fn main() {
+    let my_menusys = MenuSystem::new();
+
+    // This will print it in arbitrary order
+    // Won't matter once we actually are in a State
+    for x in my_menusys.menus {
+        println!("{:?}, {:?}\n", x.0, x.1);
+    }
+
+}

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -160,6 +160,7 @@ impl MenuItem {
         self.value = new_val;
     }
 
+    /*
     pub fn get_video_menu_current_resolution(cur_resolution: MenuItemValue) -> Option<String> {
         match cur_resolution {
             MenuItemValue::ValEnum(x) => { Some(String::from(video::get_resolution_str(x))) }
@@ -198,6 +199,7 @@ impl MenuItem {
         };
         resolution
     }
+    */
 
 }
 
@@ -332,11 +334,6 @@ impl MenuSystem {
         &mut self.controls
     }
 
-    pub fn advance_menu_resolution_option(&mut self) -> (u32, u32) {
-        let video_menu = self.menus.get_mut(&MenuState::Video).unwrap();
-        let mut menu_list = video_menu.get_menu_item_list_mut();
-        MenuItem::set_next_menu_resolution(menu_list)
-    }
 }
 
 #[allow(dead_code)]

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -1,7 +1,7 @@
 
 extern crate ggez;
 
-use ggez::graphics::{Point};
+use ggez::graphics::{Point, Color};
 use std::collections::{HashMap};
 use video;
 
@@ -47,7 +47,6 @@ pub struct MenuItem {
     text:       String,
     editable:   bool,
     value:      MenuItemValue,
-    coords:     Point
 }
 
 #[derive(Debug, Clone)]
@@ -61,9 +60,60 @@ pub struct MenuControls {
     dir_key_pressed:       bool,
 }
 
+
+
+#[derive(Debug, Clone)]
+pub struct MenuContainer {
+    anchor:     Point,
+    menu_items: Vec<MenuItem>,
+    metadata:   MenuMetaData,
+    bg_color:   Color,
+    fg_color:   Color,
+}
+
+impl MenuContainer {
+    pub fn new(x: i32, y: i32) -> MenuContainer {
+        MenuContainer {
+            anchor: Point::new(x, y),
+            menu_items: Vec::<MenuItem>::new(),
+            metadata: MenuMetaData::new(0, 0),
+            bg_color: Color::RGB(100, 100, 100),
+            fg_color: Color::RGB(0, 255, 255),
+        }
+    }
+
+    pub fn update_menu_items(&mut self, menu_item_list: Vec<MenuItem>) {
+        self.menu_items = menu_item_list;
+    }
+
+    pub fn update_menu_index(&mut self, index: u32) {
+        self.metadata.menu_index = index;
+    }
+
+    pub fn update_menu_size(&mut self, size: u32) {
+        self.metadata.menu_size = size;
+    }
+
+    pub fn get_menu_item_list(&self) -> &Vec<MenuItem> {
+        &self.menu_items
+    }
+
+    pub fn get_menu_item_list_mut(&mut self) -> &mut Vec<MenuItem> {
+        &mut self.menu_items
+    }
+
+    pub fn get_anchor(&self) -> Point {
+        self.anchor
+    }
+
+    pub fn get_metadata(&mut self) -> &mut MenuMetaData {
+        &mut self.metadata
+    }
+
+}
+
 pub struct MenuSystem {
-    pub    menus:           HashMap<MenuState, Vec<MenuItem> >,
-    pub    menu_metadata:   HashMap<MenuState, MenuMetaData>,
+    pub    menus:           HashMap<MenuState, MenuContainer >,
     pub    menu_state:      MenuState,
            controls:        MenuControls,
 }
@@ -85,22 +135,17 @@ impl MenuControls {
 }
 
 impl MenuItem {
-    pub fn new(identifier: MenuItemIdentifier, name: String, can_edit: bool, value: MenuItemValue, point: Point) -> MenuItem {
+    pub fn new(identifier: MenuItemIdentifier, name: String, can_edit: bool, value: MenuItemValue) -> MenuItem {
         MenuItem {
             id: identifier,
             text: name,
             editable: can_edit,
             value: value,
-            coords: point,
         }
     }
 
     pub fn get_text(&self) -> &String {
         &self.text
-    }
-
-    pub fn get_coords(&self) -> &Point {
-        &self.coords
     }
 
     pub fn get_id(&self) -> MenuItemIdentifier {
@@ -183,134 +228,115 @@ impl MenuSystem {
     pub fn new() -> MenuSystem {
         let mut menu_sys = MenuSystem {
             menus: HashMap::new(),
-            menu_metadata:  HashMap::new(),
             menu_state: MenuState::MainMenu,
             controls: MenuControls::new(),
         };
 
-        menu_sys.menus.insert(MenuState::MenuOff,  Vec::new());
-        menu_sys.menus.insert(MenuState::MainMenu, Vec::new());
-        menu_sys.menus.insert(MenuState::Options,  Vec::new());
-        menu_sys.menus.insert(MenuState::Video,    Vec::new());
-        menu_sys.menus.insert(MenuState::Audio,    Vec::new());
-        menu_sys.menus.insert(MenuState::Gameplay, Vec::new());
+        // TODO needs to reference the window coordinates
+        menu_sys.menus.insert(MenuState::MenuOff,  MenuContainer::new(0, 0));
+        menu_sys.menus.insert(MenuState::MainMenu, MenuContainer::new(400, 300));
+        menu_sys.menus.insert(MenuState::Options,  MenuContainer::new(400, 300));
+        menu_sys.menus.insert(MenuState::Video,    MenuContainer::new(200, 100));
+        menu_sys.menus.insert(MenuState::Audio,    MenuContainer::new(200, 100));
+        menu_sys.menus.insert(MenuState::Gameplay, MenuContainer::new(200, 100));
 
-        let menu_off    = MenuItem::new(MenuItemIdentifier::None, String::from("NULL"),       false, MenuItemValue::ValU32(0), Point::new(0, 0));
-        let start_game  = MenuItem::new(MenuItemIdentifier::StartGame, String::from("Start Game"), false, MenuItemValue::ValU32(0), Point::new(100, 100));
-        let options     = MenuItem::new(MenuItemIdentifier::Options, String::from("Options"),    false, MenuItemValue::ValU32(0), Point::new(100, 300));
-        let video       = MenuItem::new(MenuItemIdentifier::VideoSettings, String::from("Video"),      false, MenuItemValue::ValU32(0), Point::new(100, 100));
-        let audio       = MenuItem::new(MenuItemIdentifier::AudioSettings, String::from("Audio"),      false, MenuItemValue::ValU32(0), Point::new(100, 300));
-        let gameplay    = MenuItem::new(MenuItemIdentifier::GameplaySettings, String::from("Gameplay"),   false, MenuItemValue::ValU32(0), Point::new(100, 500));
-        let goback      = MenuItem::new(MenuItemIdentifier::ReturnToPreviousMenu, String::from("Back"), false, MenuItemValue::ValU32(0), Point::new(100, 700));
-        let quit        = MenuItem::new(MenuItemIdentifier::ExitGame, String::from("Quit"),       false, MenuItemValue::ValU32(0), Point::new(100, 500));
-        let nothing     = MenuItem::new(MenuItemIdentifier::None, String::from("TBD"),        false, MenuItemValue::ValNone(), Point::new(0, 0));
+        let menu_off    = MenuItem::new(MenuItemIdentifier::None, String::from("NULL"),       false, MenuItemValue::ValU32(0));
+        let start_game  = MenuItem::new(MenuItemIdentifier::StartGame, String::from("Start Game"), false, MenuItemValue::ValU32(0));
+        let options     = MenuItem::new(MenuItemIdentifier::Options, String::from("Options"),    false, MenuItemValue::ValU32(0));
+        let video       = MenuItem::new(MenuItemIdentifier::VideoSettings, String::from("Video"),      false, MenuItemValue::ValU32(0));
+        let audio       = MenuItem::new(MenuItemIdentifier::AudioSettings, String::from("Audio"),      false, MenuItemValue::ValU32(0));
+        let gameplay    = MenuItem::new(MenuItemIdentifier::GameplaySettings, String::from("Gameplay"),   false, MenuItemValue::ValU32(0));
+        let goback      = MenuItem::new(MenuItemIdentifier::ReturnToPreviousMenu, String::from("Back"), false, MenuItemValue::ValU32(0));
+        let quit        = MenuItem::new(MenuItemIdentifier::ExitGame, String::from("Quit"),       false, MenuItemValue::ValU32(0));
+        let nothing     = MenuItem::new(MenuItemIdentifier::None, String::from("TBD"),        false, MenuItemValue::ValNone());
 
-        let fullscreen  = MenuItem::new(MenuItemIdentifier::Fullscreen, String::from("Fullscreen:"), true, MenuItemValue::ValBool(false), Point::new(100, 100));
-        let resolution  = MenuItem::new(MenuItemIdentifier::Resolution, String::from("Resolution:"), true, MenuItemValue::ValEnum(video::ScreenResolution::PX1200X960), Point::new(100, 150));
+        let fullscreen  = MenuItem::new(MenuItemIdentifier::Fullscreen, String::from("Fullscreen:"), true, MenuItemValue::ValBool(false));
+        let resolution  = MenuItem::new(MenuItemIdentifier::Resolution, String::from("Resolution:"), true, MenuItemValue::ValEnum(video::ScreenResolution::PX1200X960));
 
-        menu_sys.menus
-            .get_mut(&MenuState::MenuOff)
-            .unwrap()
-            .push(menu_off);
-        menu_sys.menu_metadata.insert(MenuState::MenuOff,  MenuMetaData::new(0, 0));
+        {
+            let container = menu_sys.menus.get_mut(&MenuState::MenuOff).unwrap();
+
+            container.update_menu_items(vec![menu_off]);
+            container.update_menu_size(1);
+            container.update_menu_index(0);
+        }
 
         {
             /////////////////////////
             // Main Menu
             /////////////////////////
-            let ref mut metadata = menu_sys.menu_metadata;
-            let ref mut main_menu = menu_sys.menus
-                .get_mut(&MenuState::MainMenu)
-                .unwrap();
-            main_menu.push(start_game); // 0
-            main_menu.push(options);    // 1
-            main_menu.push(quit);       // 2
+            let container = menu_sys.menus.get_mut(&MenuState::MainMenu).unwrap();
 
-            let count = main_menu.len() as u32;
-
-            metadata.insert(MenuState::MainMenu, MenuMetaData::new(0, count));
+            container.update_menu_items(vec![start_game, options, quit]);
+            let count = container.get_menu_item_list().len() as u32;
+            container.update_menu_size(count);
+            container.update_menu_index(0);
         }
 
         {
             /////////////////////////
             // Options
             /////////////////////////
-            let ref mut metadata = menu_sys.menu_metadata;
-            let ref mut options_menu = menu_sys.menus
-                .get_mut(&MenuState::Options)
-                .unwrap();
-            options_menu.push(video);
-            options_menu.push(audio);
-            options_menu.push(gameplay);
-            options_menu.push(goback.clone());
+            let container = menu_sys.menus.get_mut(&MenuState::Options).unwrap();
 
-            let count = options_menu.len() as u32;
-
-            metadata.insert(MenuState::Options,  MenuMetaData::new(0, count));
+            container.update_menu_items(vec![video, audio, gameplay, goback.clone()]);
+            let count = container.get_menu_item_list().len() as u32;
+            container.update_menu_size(count);
+            container.update_menu_index(0);
         }
 
         {
             /////////////////////////
             // Video
             /////////////////////////
-            let ref mut metadata = menu_sys.menu_metadata;
-            let ref mut video_menu = menu_sys.menus
-                .get_mut(&MenuState::Video)
-                .unwrap();
-            video_menu.push(fullscreen);
-            video_menu.push(resolution);
-            video_menu.push(goback.clone());
+            let container = menu_sys.menus.get_mut(&MenuState::Video).unwrap();
 
-            let count = video_menu.len() as u32;
-            metadata.insert(MenuState::Video,  MenuMetaData::new(0, count));
+            container.update_menu_items(vec![fullscreen, resolution, goback.clone()]);
+            let count = container.get_menu_item_list().len() as u32;
+            container.update_menu_size(count);
+            container.update_menu_index(0);
         }
 
         {
             /////////////////////////
             // Audio
             /////////////////////////
-            let ref mut metadata = menu_sys.menu_metadata;
-            let ref mut audio_menu = menu_sys.menus
-                .get_mut(&MenuState::Audio)
-                .unwrap();
-            audio_menu.push(goback.clone());
+            let container = menu_sys.menus.get_mut(&MenuState::Audio).unwrap();
 
-            let count = audio_menu.len() as u32;
-            metadata.insert(MenuState::Audio,  MenuMetaData::new(0, count));
+            container.update_menu_items(vec![goback.clone()]);
+            let count = container.get_menu_item_list().len() as u32;
+            container.update_menu_size(count);
+            container.update_menu_index(0);
         }
 
         {
             /////////////////////////
             // Gameplay
             /////////////////////////
-            let ref mut metadata = menu_sys.menu_metadata;
-            let ref mut gameplay_menu = menu_sys.menus
-                .get_mut(&MenuState::Gameplay)
-                .unwrap();
-            gameplay_menu.push(goback.clone());
+            let container = menu_sys.menus.get_mut(&MenuState::Gameplay).unwrap();
 
-            let count = gameplay_menu.len() as u32;
-            metadata.insert(MenuState::Gameplay,  MenuMetaData::new(0, count));
+            container.update_menu_items(vec![goback.clone()]);
+            let count = container.get_menu_item_list().len() as u32;
+            container.update_menu_size(count);
+            container.update_menu_index(0);
         }
 
         menu_sys
     }
 
-    pub fn get_meta_data(&mut self, state: &MenuState) -> &mut MenuMetaData {
-        self.menu_metadata.get_mut(&state).unwrap()
+    pub fn get_menu_container(&mut self, state: &MenuState) -> &mut MenuContainer {
+        self.menus.get_mut(&state).unwrap()
     }
 
     pub fn get_controls(&mut self) -> &mut MenuControls {
         &mut self.controls
     }
 
-    pub fn get_menu_item_list(&mut self, menu_state: &MenuState) -> &mut Vec<MenuItem> {
-        self.menus.get_mut(menu_state).unwrap()
-    }
-
+    // TODO Move into correct module
     pub fn transition_video_resolution(&mut self) -> (u32, u32) {
         let video_menu = self.menus.get_mut(&MenuState::Video).unwrap();
-        MenuItem::set_next_resolution(video_menu)
+        let mut menu_list = video_menu.get_menu_item_list_mut();
+        MenuItem::set_next_resolution(menu_list)
     }
 }
 

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -26,6 +26,16 @@ pub enum MenuItemIdentifier {
     ReturnToPreviousMenu,
 
     Fullscreen,
+    Resolution,
+}
+
+#[derive(Debug, Clone)]
+// TODO this should be moved into a video/gfx module
+pub enum ScreenResolution {
+    PX800X600,
+    PX1024X768,
+    PX1200X960,
+    PX1920X1080,
 }
 
 #[derive(Debug, Clone)]
@@ -34,7 +44,8 @@ pub enum MenuItemValue {
     ValI32(i32),
     ValU32(u32),
     ValF32(f32),
-    valBool(bool),
+    ValBool(bool),
+    ValEnum(ScreenResolution),
     ValNone(),
 }
 
@@ -103,6 +114,14 @@ impl MenuItem {
     pub fn get_id(&self) -> MenuItemIdentifier {
         self.id.clone()
     }
+    
+    pub fn get_value(&self) -> &MenuItemValue {
+        &self.value
+    }
+
+    pub fn set_value(&mut self, new_val: MenuItemValue) {
+        self.value = new_val;
+    }
 }
 
 impl MenuMetaData {
@@ -155,7 +174,8 @@ impl MenuSystem {
         let quit        = MenuItem::new(MenuItemIdentifier::ExitGame, String::from("Quit"),       false, MenuItemValue::ValU32(0), Point::new(100, 500));
         let nothing     = MenuItem::new(MenuItemIdentifier::None, String::from("TBD"),        false, MenuItemValue::ValNone(), Point::new(0, 0));
 
-        let fullscreen  = MenuItem::new(MenuItemIdentifier::Fullscreen, String::from("Fullscreen:"), true, MenuItemValue::valBool(false), Point::new(100, 100));
+        let fullscreen  = MenuItem::new(MenuItemIdentifier::Fullscreen, String::from("Fullscreen:"), true, MenuItemValue::ValBool(false), Point::new(100, 100));
+        let resolution  = MenuItem::new(MenuItemIdentifier::Resolution, String::from("Resolution:"), true, MenuItemValue::ValEnum(ScreenResolution::PX1200X960), Point::new(100, 150));
 
         menu_sys.menus
             .get_mut(&MenuState::MenuOff)
@@ -207,6 +227,7 @@ impl MenuSystem {
                 .get_mut(&MenuState::Video)
                 .unwrap();
             video_menu.push(fullscreen);
+            video_menu.push(resolution);
             video_menu.push(goback.clone());
 
             let count = video_menu.len() as u32;

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -167,7 +167,7 @@ impl MenuItem {
         }
     }
 
-    pub fn set_next_resolution(video_menu: &mut Vec<MenuItem>) -> (u32, u32) {
+    pub fn set_next_menu_resolution(video_menu: &mut Vec<MenuItem>) -> (u32, u32) {
 
         let mut screen_res_item = video_menu.get_mut(1).unwrap();
         let cur_resolution = screen_res_item.get_value().clone();
@@ -332,11 +332,10 @@ impl MenuSystem {
         &mut self.controls
     }
 
-    // TODO Move into correct module
-    pub fn transition_video_resolution(&mut self) -> (u32, u32) {
+    pub fn advance_menu_resolution_option(&mut self) -> (u32, u32) {
         let video_menu = self.menus.get_mut(&MenuState::Video).unwrap();
         let mut menu_list = video_menu.get_menu_item_list_mut();
-        MenuItem::set_next_resolution(menu_list)
+        MenuItem::set_next_menu_resolution(menu_list)
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,23 @@
+extern crate ggez;
+
+use ggez::graphics::{Rect, draw, Font, Text, Point};
+// use ggez::graphics::{Rect, Color};
+use ggez::Context;
+
+pub struct Graphics;
+
+impl Graphics {
+
+    pub fn draw_text(_ctx: &mut Context, font: &Font, text: &str, coords: &Point, adjustment: Option<&Point>) {
+        let mut graphics_text = Text::new(_ctx, text, font).unwrap();
+        let dst;
+
+        if let Some(offset) = adjustment {
+            dst = Rect::new(coords.x() + offset.x(), coords.y() + offset.y(), graphics_text.width(), graphics_text.height());
+        }
+        else {
+            dst = Rect::new(coords.x(), coords.y(), graphics_text.width(), graphics_text.height());
+        }
+        let _ = draw(_ctx, &mut graphics_text, None, Some(dst));
+    }
+}

--- a/src/video.rs
+++ b/src/video.rs
@@ -1,7 +1,13 @@
 extern crate ggez;
+extern crate env_logger;
 
 use ggez::Context;
-use sdl2::video::FullscreenType;
+use sdl2::video::{FullscreenType, DisplayMode};
+use log::LogLevel;
+
+// Need to replace this with 
+// call SDL_GetDisplayMode() in a loop, SDL_GetNumDisplayModes() times)
+// Enter into a list, point to current
 
 #[derive(Debug, Clone)]
 pub enum ScreenResolution {
@@ -12,24 +18,94 @@ pub enum ScreenResolution {
 }
 
 #[derive(Debug, Clone)]
+struct DisplayModeManager {
+    index: usize,
+    modes: Vec<DisplayMode>,
+}
+
+impl DisplayModeManager {
+    pub fn new() -> DisplayModeManager {
+        DisplayModeManager {
+            index: 0,
+            modes: Vec::new(),
+        }
+    }
+
+    pub fn at_capacity(&self) -> bool {
+        if log_enabled!(LogLevel::Debug) {
+            debug!("L: {}, C: {}", self.modes.len(), self.modes.capacity());
+        }
+        self.modes.len() != 0 && self.modes.len() == self.modes.capacity()
+    }
+
+    pub fn add_mode(&mut self, new_mode: DisplayMode) {
+            self.modes.push(new_mode);
+    }
+
+    pub fn print_supported_modes(&self) {
+        if log_enabled!(LogLevel::Info) {
+            info!("Supported Resolutions Discovered:");
+
+            for mode in self.modes.iter() {
+                println!("Width: {}, Height: {}, Format: {}", mode.w, mode.h, mode.format);
+            }
+        }
+    }
+
+    pub fn set_next_supported_resolution(&mut self) -> (i32, i32) {
+        self.index = (self.index + 1) % self.modes.len();
+        let display_mode = self.modes.get(self.index).unwrap();
+        (display_mode.w, display_mode.h)
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct VideoSettings {
-    pub resolution : (u16, u16),
+    pub resolution : (i32, i32),
+    res_manager : DisplayModeManager,
+
 }
 
 impl VideoSettings {
     pub fn new() -> VideoSettings {
         VideoSettings {
             resolution: (0,0),
+            res_manager: DisplayModeManager::new(),
         }
     }
 
-    pub fn get_resolution(&self) -> &(u16, u16) {
-        &self.resolution
+    pub fn gather_display_modes(&mut self, _ctx: &Context) {
+        let sdl_context =  &_ctx.sdl_context;
+        let sdl_video = sdl_context.video().unwrap();
+
+        let num_of_display_modes = sdl_video.num_display_modes(0).unwrap();
+
+        for x in  0..num_of_display_modes {
+            let display_mode = sdl_video.display_mode(0, x).unwrap();
+            self.res_manager.add_mode(display_mode);
+        }
+        
     }
 
-    pub fn set_resolution(&mut self, x: u16, y: u16) {
-        self.resolution = (x,y)
+    pub fn print_resolutions(&self) {
+        self.res_manager.print_supported_modes();
     }
+
+    pub fn get_active_resolution(&self) -> (i32, i32) {
+        self.resolution
+    }
+
+    pub fn set_active_resolution(&mut self, w: i32, h: i32) {
+        self.resolution = (w,h);
+    }
+
+    pub fn advance_to_next_resolution(&mut self, _ctx: &mut Context) {
+        let (width, height) = self.res_manager.set_next_supported_resolution();
+        self.set_active_resolution(width, height);
+
+        refresh_game_resolution(_ctx, width, height);
+    }
+
 }
 
 pub fn get_resolution_str(x: ScreenResolution) -> &'static str {
@@ -65,3 +141,42 @@ pub fn toggle_full_screen(_ctx: &mut Context) -> bool {
     
     new_fs_type == FullscreenType::True
 }
+
+pub fn get_display_mode(_ctx: &mut Context) -> bool {
+    let renderer = &mut _ctx.renderer;
+    let window = renderer.window_mut().unwrap();
+
+    match window.display_mode() {
+        Ok(x) => {
+            println!("Format: {}, W: {}, H: {}", x.format, x.w, x.h);
+        }
+        Err(x) => { println!("There was nothing to be found for the VSS: {}", x) }
+    }
+    true
+}
+
+pub fn get_current_display_mode(_ctx: &mut Context) -> bool {
+    let sdl_context = &mut _ctx.sdl_context;
+    let video_subsystem = sdl_context.video().unwrap();
+   // let video_subsystem = window.subsystem();
+
+    match video_subsystem.current_display_mode(0) {
+        Ok(x) => {
+            println!("Format: {}, W: {}, H: {}", x.format, x.w, x.h);
+        }
+        Err(x) => { println!("There was nothing to be found for the VSS: {}", x) }
+    }
+    true
+}
+
+fn refresh_game_resolution(_ctx: &mut Context, w: i32, h: i32) {
+    if w != 0 && h != 0 {
+        let ref mut renderer = _ctx.renderer;
+        let _ = renderer.set_logical_size(w as u32, h as u32);
+        {
+            let window = renderer.window_mut().unwrap();
+            let _ = window.set_size(w as u32, h as u32);
+        }
+    }
+}
+

--- a/src/video.rs
+++ b/src/video.rs
@@ -22,11 +22,11 @@ impl VideoSettings {
         }
     }
 
-    pub fn getResolution(&self) -> &(u16, u16) {
+    pub fn get_resolution(&self) -> &(u16, u16) {
         &self.resolution
     }
 
-    pub fn setResolution(&mut self, x: u16, y: u16) {
+    pub fn set_resolution(&mut self, x: u16, y: u16) {
         self.resolution = (x,y)
     }
 }

--- a/src/video.rs
+++ b/src/video.rs
@@ -3,7 +3,6 @@ extern crate env_logger;
 
 use ggez::Context;
 use sdl2::video::{FullscreenType, DisplayMode};
-use log::LogLevel;
 
 #[derive(Debug, Clone)]
 struct DisplayModeManager {

--- a/src/video.rs
+++ b/src/video.rs
@@ -10,6 +10,27 @@ pub enum ScreenResolution {
     PX1920X1080,
 }
 
+#[derive(Debug, Clone)]
+pub struct VideoSettings {
+    pub resolution : (u16, u16),
+}
+
+impl VideoSettings {
+    pub fn new() -> VideoSettings {
+        VideoSettings {
+            resolution: (0,0),
+        }
+    }
+
+    pub fn getResolution(&self) -> &(u16, u16) {
+        &self.resolution
+    }
+
+    pub fn setResolution(&mut self, x: u16, y: u16) {
+        self.resolution = (x,y)
+    }
+}
+
 pub fn get_resolution_str(x: ScreenResolution) -> &'static str {
     match x {
         ScreenResolution::PX800X600 => {

--- a/src/video.rs
+++ b/src/video.rs
@@ -108,6 +108,7 @@ pub fn toggle_full_screen(_ctx: &mut Context) -> bool {
     new_fs_type == FullscreenType::True
 }
 
+/*
 pub fn get_display_mode(_ctx: &mut Context) -> bool {
     let renderer = &mut _ctx.renderer;
     let window = renderer.window_mut().unwrap();
@@ -134,6 +135,7 @@ pub fn get_current_display_mode(_ctx: &mut Context) -> bool {
     }
     true
 }
+*/
 
 fn refresh_game_resolution(_ctx: &mut Context, w: i32, h: i32) {
     if w != 0 && h != 0 {

--- a/src/video.rs
+++ b/src/video.rs
@@ -1,8 +1,9 @@
 extern crate ggez;
 
+use ggez::Context;
+use sdl2::video::FullscreenType;
 
 #[derive(Debug, Clone)]
-// TODO this should be moved into a video/gfx module
 pub enum ScreenResolution {
     PX800X600,
     PX1024X768,
@@ -46,4 +47,21 @@ pub fn get_resolution_str(x: ScreenResolution) -> &'static str {
             "1920 x 1080"
         }
     }
+}
+
+pub fn toggle_full_screen(_ctx: &mut Context) -> bool {
+    let renderer = &mut _ctx.renderer;
+    let window = renderer.window_mut().unwrap();
+    let wlflags = window.window_flags();
+    let fullscreen_type = FullscreenType::from_window_flags(wlflags);
+    let mut new_fs_type = FullscreenType::Off;
+
+    match fullscreen_type {
+        FullscreenType::Off => {new_fs_type = FullscreenType::True;}
+        FullscreenType::True => {new_fs_type = FullscreenType::Off;}
+        _ => {}
+    }
+    let _ = window.set_fullscreen(new_fs_type);
+    
+    new_fs_type == FullscreenType::True
 }

--- a/src/video.rs
+++ b/src/video.rs
@@ -5,18 +5,6 @@ use ggez::Context;
 use sdl2::video::{FullscreenType, DisplayMode};
 use log::LogLevel;
 
-// Need to replace this with 
-// call SDL_GetDisplayMode() in a loop, SDL_GetNumDisplayModes() times)
-// Enter into a list, point to current
-
-#[derive(Debug, Clone)]
-pub enum ScreenResolution {
-    PX800X600,
-    PX1024X768,
-    PX1200X960,
-    PX1920X1080,
-}
-
 #[derive(Debug, Clone)]
 struct DisplayModeManager {
     index: usize,
@@ -29,13 +17,6 @@ impl DisplayModeManager {
             index: 0,
             modes: Vec::new(),
         }
-    }
-
-    pub fn at_capacity(&self) -> bool {
-        if log_enabled!(LogLevel::Debug) {
-            debug!("L: {}, C: {}", self.modes.len(), self.modes.capacity());
-        }
-        self.modes.len() != 0 && self.modes.len() == self.modes.capacity()
     }
 
     pub fn add_mode(&mut self, new_mode: DisplayMode) {
@@ -62,6 +43,7 @@ impl DisplayModeManager {
 #[derive(Debug, Clone)]
 pub struct VideoSettings {
     pub resolution : (i32, i32),
+    pub is_fullscreen:       bool,
     res_manager : DisplayModeManager,
 
 }
@@ -70,6 +52,7 @@ impl VideoSettings {
     pub fn new() -> VideoSettings {
         VideoSettings {
             resolution: (0,0),
+            is_fullscreen: false,
             res_manager: DisplayModeManager::new(),
         }
     }
@@ -106,23 +89,6 @@ impl VideoSettings {
         refresh_game_resolution(_ctx, width, height);
     }
 
-}
-
-pub fn get_resolution_str(x: ScreenResolution) -> &'static str {
-    match x {
-        ScreenResolution::PX800X600 => {
-            "800 x 600"
-        }
-        ScreenResolution::PX1024X768 => {
-            "1024 x 768"
-        }
-        ScreenResolution::PX1200X960 => {
-            "1200 x 960"
-        }
-        ScreenResolution::PX1920X1080 => {
-            "1920 x 1080"
-        }
-    }
 }
 
 pub fn toggle_full_screen(_ctx: &mut Context) -> bool {

--- a/src/video.rs
+++ b/src/video.rs
@@ -24,12 +24,10 @@ impl DisplayModeManager {
     }
 
     pub fn print_supported_modes(&self) {
-        if log_enabled!(LogLevel::Info) {
-            info!("Supported Resolutions Discovered:");
+        info!("Supported Resolutions Discovered:");
 
-            for mode in self.modes.iter() {
-                println!("Width: {}, Height: {}, Format: {}", mode.w, mode.h, mode.format);
-            }
+        for mode in self.modes.iter() {
+            info!("Width: {}, Height: {}, Format: {:?}", mode.w, mode.h, mode.format);
         }
     }
 

--- a/src/video.rs
+++ b/src/video.rs
@@ -1,0 +1,28 @@
+extern crate ggez;
+
+
+#[derive(Debug, Clone)]
+// TODO this should be moved into a video/gfx module
+pub enum ScreenResolution {
+    PX800X600,
+    PX1024X768,
+    PX1200X960,
+    PX1920X1080,
+}
+
+pub fn get_resolution_str(x: ScreenResolution) -> &'static str {
+    match x {
+        ScreenResolution::PX800X600 => {
+            "800 x 600"
+        }
+        ScreenResolution::PX1024X768 => {
+            "1024 x 768"
+        }
+        ScreenResolution::PX1200X960 => {
+            "1200 x 960"
+        }
+        ScreenResolution::PX1920X1080 => {
+            "1920 x 1080"
+        }
+    }
+}


### PR DESCRIPTION
Groundwork for the navigational menus were the primary focus of this request. Towards the end I started creeping into video/graphics. More focused effort towards modularization too.

General
- Logging support is added. Limit each message to a debug level for cleanliness.
- Explicitly using `rust-sdl2` v.0.25.0 to avoid compat conflicts with other versions
- Corrected panning (though this needs to be reworked again lol)
- I tried to write the menu code so that it was easily extendible in the future for draw() and update()  [went through a few revs of this hehe]

**New** Menu.rs
- Each menu view holds a container of items to be listed
- Current menus are Start Screen, Options, and Video/Audio/Gameplay settings

**New** Video.rs
- Fullscreen support
- Detect supported resolutions

**New** Utils.rs
- ::Graphics:: Common fn to draw text on screen for a given context