### PR TITLE
fix bin conflict; new bins are client (gui), cli-client, and server

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,16 +72,22 @@ ln -s ../resources target    # Needed only for the Client
 ## Running the server
 
 ```
-cd netwayste
 cargo run --bin server 0.0.0.0:9000
 ```
 
-## Running the client
+## Running the GUI client
 
 ```
-cd conwayste
 cargo run --bin client
 ```
+Note: at the time of this writing, it does not have network support.
+
+## Running the CLI client
+
+```
+cargo run --bin cli-client
+```
+Note: at the time of this writing, it only has partial network support.
 
 ## FAQ
 

--- a/conwayste/Cargo.toml
+++ b/conwayste/Cargo.toml
@@ -17,9 +17,5 @@ serde_derive = "1.0"
 rand = "0.4"
 
 [[bin]]
-name = "server"
-path = "src/server.rs"
-
-[[bin]]
 name = "client"
 path = "src/client.rs"


### PR DESCRIPTION
This is to fix the bin conflict, so we can just go to the root repo and do one of these:
```
cargo run --bin client    # ggez gui
cargo run --bin server
cargo run --bin cli-client  # what was the netwayste client
```