### PR TITLE
Subtree-merging in libconway and netwayste -- no more submodules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-target
-.sw?
+**/*.rs.bk
 .*.sw?
+.sw?
+/target/
 rusty-tags.*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "netwayste"]
-	path = netwayste
-	url = https://github.com/conwayste/netwayste
-[submodule "libconway"]
-	path = libconway
-	url = https://github.com/conwayste/libconway

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ Multiplayer Conway's Game of Life!
 ![life in action](https://giant.gfycat.com/BlaringTidyDutchsmoushond.gif)
 
 ## Installation
-Clone this repository with the submodules:
+Clone this repository:
 
 ```
-$ git clone --recursive https://github.com/conwayste/conwayste
+$ git clone https://github.com/conwayste/conwayste
 ```
 
-`conwayste` depends on `SDL2`, `SDL2_Mixer` and `SDL2_Image`. We do plan on bundling these libraries with the binary at some point in the future, but for now you will need to manually install them. The versions (at least) needed are:
+The GUI client (`cargo run --bin client`) depends on `SDL2`, `SDL2_Mixer` and `SDL2_Image`. We do plan on bundling these libraries with the binary at some point in the future, but for now you will need to manually install them. The versions (at least) needed are:
 
 * `SDL2 v2.0.5`
 * `SDL2_Mixer v2.0.1`

--- a/libconway/.gitignore
+++ b/libconway/.gitignore
@@ -1,3 +1,0 @@
-target
-.*.sw?
-rusty-tags.*

--- a/libconway/.gitignore
+++ b/libconway/.gitignore
@@ -1,0 +1,3 @@
+target
+.*.sw?
+rusty-tags.*

--- a/libconway/Cargo.toml
+++ b/libconway/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "conway"
+version = "0.3.0"
+authors = ["Aaron Miller <aaron.miller04@gmail.com>", "mang"]
+license = "GPL-3.0+"
+description = "library for multi-player game of life Conwayste"
+edition = "2018"
+
+[dependencies]
+env_logger = "0.3"
+log        = "0.3"
+rand       = "0.3"
+custom_error = "1.4"

--- a/libconway/LICENSE.txt
+++ b/libconway/LICENSE.txt
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/libconway/README.md
+++ b/libconway/README.md
@@ -1,0 +1,15 @@
+libconway
+=========
+
+This crate is part of [Conwayste](https://github.com/conwayste/conwayste), a multi-player version of [Conway's game of life](https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life). In particular, this crate implements the life engine.
+
+See the documentation for the latest published version at [docs.rs](https://docs.rs/conway/latest/conway/).
+
+## Usage
+
+Put this in your Cargo.toml and hack away, friend:
+
+```
+[dependencies]
+conway = "*"
+```

--- a/libconway/examples/random.rs
+++ b/libconway/examples/random.rs
@@ -1,0 +1,41 @@
+extern crate conway;
+extern crate rand;
+
+use rand::Rng;
+use std::{thread, time};
+use conway::universe::*;
+
+fn main() {
+    let player0 = PlayerBuilder::new(Region::new(100, 70, 34, 16));   // used for the glider gun and predefined patterns
+    let player1 = PlayerBuilder::new(Region::new(0, 0, 80, 80));
+    let players = vec![player0, player1];
+
+    let bigbang = BigBang::new()
+        .width(1280)
+        .height(800)
+        .server_mode(true)
+        .history(16)
+        .fog_radius(6)
+        .add_players(players)
+        .birth();
+
+    let mut uni = bigbang.unwrap();
+    let step_time = time::Duration::from_millis(30);
+
+    let mut rng = rand::thread_rng();
+    loop {
+        println!("\x1b[H\x1b[2J{}", uni);
+        println!("Gen: {}", uni.latest_gen());
+        let mut rand_word: u64 = rng.gen::<u8>() as u64;
+        for col in 60..64 {
+            for row in 15..17 {
+                if rand_word & 1 == 1 {
+                    let _ = uni.toggle(col, row, 0);
+                }
+                rand_word >>= 1;
+            }
+        }
+        uni.next();
+        thread::sleep(step_time);
+    }
+}

--- a/libconway/src/error.rs
+++ b/libconway/src/error.rs
@@ -1,0 +1,45 @@
+/*  Copyright 2019 the Conwayste Developers.
+ *
+ *  This file is part of libconway.
+ *
+ *  libconway is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  libconway is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libconway.  If not, see <http://www.gnu.org/licenses/>. */
+
+custom_error! {pub ConwayError
+    InvalidData {reason: String} = "ConwayError->InvalidData->{reason}",
+    AccessDenied{reason: String} = "ConwayError->AccessDenied->{reason}"
+}
+
+pub type ConwayResult<T> = ::std::result::Result<T, ConwayError>;
+
+impl PartialEq for ConwayError {
+    fn eq(&self, other: &ConwayError) -> bool {
+        use ConwayError::*;
+        match *self {
+            InvalidData{reason: ref self_reason} => {
+                if let InvalidData{reason: ref other_reason} = *other {
+                    self_reason == other_reason
+                } else {
+                    false
+                }
+            }
+            AccessDenied{reason: ref self_reason} => {
+                if let AccessDenied{reason: ref other_reason} = *other {
+                    self_reason == other_reason
+                } else {
+                    false
+                }
+            }
+        }
+    }
+}

--- a/libconway/src/grids.rs
+++ b/libconway/src/grids.rs
@@ -1,0 +1,410 @@
+/*  Copyright 2017-2019 the Conwayste Developers.
+ *
+ *  This file is part of libconway.
+ *
+ *  libconway is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  libconway is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libconway.  If not, see <http://www.gnu.org/licenses/>. */
+
+use std::ops::{Index, IndexMut};
+use std::cmp;
+use crate::universe::Region;
+use crate::rle::Pattern;
+
+
+#[derive(Eq, PartialEq, Debug, Clone, Copy)]
+pub enum BitOperation {
+    Clear,
+    Set,
+    Toggle
+}
+
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct BitGrid(pub Vec<Vec<u64>>);
+
+impl BitGrid {
+    /// Creates a new zero-initialized BitGrid of given dimensions.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `with_in_words` or `height` are zero.
+    pub fn new(width_in_words: usize, height: usize) -> Self {
+        assert!(width_in_words != 0);
+        assert!(height != 0);
+
+        let mut rows: Vec<Vec<u64>> = Vec::with_capacity(height);
+        for _ in 0 .. height {
+            let row: Vec<u64> = vec![0; width_in_words];
+            rows.push(row);
+        }
+        BitGrid(rows)
+    }
+
+    pub fn width_in_words(&self) -> usize {
+        if self.height() > 0 {
+            self.0[0].len()
+        } else {
+            0
+        }
+    }
+
+    #[inline]
+    pub fn modify_bits_in_word(&mut self, row: usize, word_col: usize, mask: u64, op: BitOperation) {
+        match op {
+            BitOperation::Set    => self[row][word_col] |=  mask,
+            BitOperation::Clear  => self[row][word_col] &= !mask,
+            BitOperation::Toggle => self[row][word_col] ^=  mask,
+        }
+    }
+
+    /// Sets, clears, or toggles a rectangle of bits.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `region` is out of range.
+    pub fn modify_region(&mut self, region: Region, op: BitOperation) {
+        for y in region.top() .. region.bottom() + 1 {
+            assert!(y >= 0);
+            for word_col in 0 .. self[y as usize].len() {
+                let x_left  = word_col * 64;
+                let x_right = x_left + 63;
+
+                if region.right() >= x_left as isize && region.left() <= x_right as isize {
+                    let mut mask = u64::max_value();
+
+                    for shift in (0..64).rev() {
+                        let x = x_right - shift;
+                        if (x as isize) < region.left() || (x as isize) > region.right() {
+                            mask &= !(1 << shift);
+                        }
+                    }
+
+                    // apply change to bitgrid based on mask and bit
+                    self.modify_bits_in_word(y as usize, word_col, mask, op);
+                }
+            }
+        }
+    }
+
+    /// Returns `Some(`smallest region containing every 1 bit`)`, or `None` if there are no 1 bits.
+    pub fn bounding_box(&self) -> Option<Region> {
+        let (width, height) = (self.width(), self.height());
+        let mut first_row = None;
+        let mut last_row = None;
+        let mut first_col = None;
+        let mut last_col = None;
+        for row in 0..height {
+            let mut col = 0;
+            while col < width {
+                let (rle_len, ch) = self.get_run(col, row, None);
+                if ch == 'o' {
+                    if let Some(_first_col) = first_col {
+                        if _first_col > col {
+                            first_col = Some(col);
+                        }
+                    } else {
+                        first_col = Some(col);
+                    }
+                    if first_row.is_none() {
+                        first_row = Some(row);
+                    }
+                    let run_last_col = col + rle_len - 1;
+                    if let Some(_last_col) = last_col {
+                        if _last_col < run_last_col {
+                            last_col = Some(run_last_col);
+                        }
+                    } else {
+                        last_col = Some(run_last_col);
+                    }
+                    last_row = Some(row);
+                }
+                col += rle_len;
+            }
+        }
+        if first_row.is_some() {
+            let width = last_col.unwrap() - first_col.unwrap() + 1;
+            let height = last_row.unwrap() - first_row.unwrap() + 1;
+            Some(Region::new(first_col.unwrap() as isize, first_row.unwrap() as isize, width, height))
+        } else {
+            None
+        }
+    }
+
+    /// Copies `src` BitGrid into `dst` BitGrid, but fit into `dst_region` with clipping. If there
+    /// is a 10x10 pattern in source starting at 0,0 and the dst_region is only 8x8 with top left
+    /// corner at 3,3 then the resulting pattern will be clipped in a 2 pixel region on the bottom
+    /// and right and extend from 3,3 to 10,10. If `dst_region` extends beyond `dst`, the pattern
+    /// will be further clipped by the dimensions of `dst`.
+    ///
+    /// The bits are copied using an `|=` operation, so 1 bits in the destination will not ever be
+    /// cleared.
+    pub fn copy(src: &BitGrid, dst: &mut BitGrid, dst_region: Region) {
+        let dst_left   = cmp::max(0, dst_region.left()) as usize;
+        let dst_right  = cmp::min(dst.width() as isize - 1, dst_region.right()) as usize;
+        let dst_top    = cmp::max(0, dst_region.top()) as usize;
+        let dst_bottom = cmp::min(dst.height() as isize - 1, dst_region.bottom()) as usize;
+        if dst_left > dst_right || dst_top > dst_bottom {
+            // nothing to do because both dimensions aren't positive
+            return;
+        }
+
+        for src_row in 0..src.height() {
+            let dst_row = src_row + dst_top;
+            if dst_row > dst_bottom {
+                break;
+            }
+            let mut src_col = 0;   // word-aligned
+            while src_col < src.width() {
+                let dst_col = src_col + dst_left;    // not word-aligned
+                if dst_col > dst_right {
+                    break;
+                }
+                let dst_word_idx = dst_col / 64;
+                let shift = dst_col - dst_word_idx*64;  // right shift amount
+                let mut word = src[src_row][src_col/64];
+                // clear bits that would be beyond dst_right
+                if dst_right - dst_col + 1 < 64 {
+                    let mask = !((1u64 << (64 - (dst_right - dst_col + 1))) - 1);
+                    word &= mask;
+                }
+                dst[dst_row][dst_word_idx] |= word >> shift;
+                if shift > 0 && dst_word_idx+1 < dst.width_in_words() {
+                    dst[dst_row][dst_word_idx+1] |= word << (64 - shift);
+                }
+                src_col += 64;
+            }
+        }
+    }
+
+    /// Get a Region of the same size as the BitGrid.
+    pub fn region(&self) -> Region {
+        Region::new(0, 0, self.width(), self.height())
+    }
+
+    /// Clear this BitGrid.
+    pub fn clear(&mut self) {
+        for row in &mut self.0 {
+            for col_idx in 0..row.len() {
+                row[col_idx] = 0;
+            }
+        }
+    }
+}
+
+
+impl Index<usize> for BitGrid {
+    type Output = Vec<u64>;
+
+    fn index(&self, i: usize) -> &Vec<u64> {
+        &self.0[i]
+    }
+}
+
+impl IndexMut<usize> for BitGrid {
+    fn index_mut(&mut self, i: usize) -> &mut Vec<u64> {
+        &mut self.0[i]
+    }
+}
+
+
+pub trait CharGrid {
+    /// Write a char `ch` to (`col`, `row`).
+    /// 
+    /// # Panics
+    /// 
+    /// Panics if:
+    /// * `col` or `row` are out of range
+    /// * `char` is invalid for this type. Use `is_valid` to check first.
+    /// * `visibility` is invalid. That is, it equals `Some(player_id)`, but there is no such `player_id`.
+    fn write_at_position(&mut self, col: usize, row: usize, ch: char, visibility: Option<usize>);
+
+    /// Is `ch` a valid character?
+    fn is_valid(ch: char) -> bool;
+
+    /// Width in cells
+    fn width(&self) -> usize;
+
+    /// Height in cells
+    fn height(&self) -> usize;
+
+    /// Returns a Pattern that describes this `CharGrid` as viewed by specified player if
+    /// `visibility.is_some()`, or a fog-less view if `visibility.is_none()`.
+    fn to_pattern(&self, visibility: Option<usize>) -> Pattern {
+
+        fn push(result: &mut String, output_col: &mut usize, rle_len: usize, ch: char) {
+            let what_to_add = if rle_len == 1 {
+                let mut s = String::with_capacity(1);
+                s.push(ch);
+                s
+            } else { format!("{}{}", rle_len, ch) };
+            if *output_col + what_to_add.len() > 70 {
+                result.push_str("\r\n");
+                *output_col = 0;
+            }
+            result.push_str(what_to_add.as_str());
+            *output_col += what_to_add.len();
+        }
+
+        let mut result = "".to_owned();
+        let (mut col, mut row) = (0, 0);
+        let mut line_ends_buffered = 0;
+        let mut output_col = 0;
+        while row < self.height() {
+            while col < self.width() {
+                let (rle_len, ch) = self.get_run(col, row, visibility);
+
+                match ch {
+                    'b' => {
+                        // Blank
+                        // TODO: if supporting diffs with this same algorithm, then need to allow
+                        // other characters to serve this purpose.
+                        if col + rle_len < self.width() {
+                            if line_ends_buffered > 0 {
+                                push(&mut result, &mut output_col, line_ends_buffered, '$');
+                                line_ends_buffered = 0;
+                            }
+                            push(&mut result, &mut output_col, rle_len, ch);
+                        }
+                    }
+                    _ => {
+                        // Non-blank
+                        if line_ends_buffered > 0 {
+                            push(&mut result, &mut output_col, line_ends_buffered, '$');
+                            line_ends_buffered = 0;
+                        }
+                        push(&mut result, &mut output_col, rle_len, ch);
+                    }
+                }
+
+                col += rle_len;
+            }
+
+            row += 1;
+            col = 0;
+            line_ends_buffered += 1;
+        }
+        push(&mut result, &mut output_col, 1, '!');
+        Pattern(result)
+    }
+
+    /// Given a starting cell at `(col, row)`, get the character at that cell, and the number of
+    /// contiguous identical cells considering only this cell and the cells to the right of it.
+    /// This is intended for exporting to RLE.
+    ///
+    /// The `visibility` parameter, if not `None`, is used to generate a run as observed by a
+    /// particular player.
+    ///
+    /// # Returns
+    ///
+    /// `(run_length, ch)`
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `col`, `row`, or `visibility` (`Some(player_id)`) are out of bounds.
+    fn get_run(&self, col: usize, row: usize, visibility: Option<usize>) -> (usize, char);
+}
+
+
+const VALID_BIT_GRID_CHARS: [char; 2] = ['b', 'o'];
+
+impl CharGrid for BitGrid {
+    /// Width in cells
+    fn width(&self) -> usize {
+        self.width_in_words() * 64
+    }
+
+    /// Height in cells
+    fn height(&self) -> usize {
+        self.0.len()
+    }
+
+    /// _visibility is ignored, since BitGrids have no concept of a player.
+    fn write_at_position(&mut self, col: usize, row: usize, ch: char, _visibility: Option<usize>) {
+        let word_col = col/64;
+        let shift = 63 - (col & (64 - 1));
+        match ch {
+            'b' => {
+                self.modify_bits_in_word(row, word_col, 1 << shift, BitOperation::Clear)
+            }
+            'o' => {
+                self.modify_bits_in_word(row, word_col, 1 << shift, BitOperation::Set)
+            }
+            _ => panic!("invalid character: {:?}", ch)
+        }
+    }
+
+    fn is_valid(ch: char) -> bool {
+        VALID_BIT_GRID_CHARS.contains(&ch)
+    }
+
+    /// Given a starting cell at `(col, row)`, get the character at that cell, and the number of
+    /// contiguous identical cells considering only this cell and the cells to the right of it.
+    /// This is intended for exporting to RLE.
+    ///
+    /// The `_visibility` argument is unused and should be `None`.
+    ///
+    /// # Returns
+    ///
+    /// `(run_length, ch)`
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `col` or `row` are out of bounds.
+    fn get_run(&self, col: usize, row: usize, _visibility: Option<usize>) -> (usize, char) {
+        let word_col = col/64;
+        let shift = 63 - (col & (64 - 1));
+        let mut word = self.0[row][word_col];
+        let mut mask = 1 << shift;
+        let is_set = (word & (1 << shift)) > 0;
+        let mut end_col = col + 1;
+        let ch = if is_set { 'o' } else { 'b' };
+
+        // go to end of current word
+        mask >>= 1;
+        while mask > 0 {
+            if (word & mask > 0) != is_set {
+                return (end_col - col, ch);
+            }
+            end_col += 1;
+            mask >>= 1;
+        }
+        assert_eq!(end_col % 64, 0);
+
+        // skip words
+        let mut end_word_col = word_col + 1;
+        while end_word_col < self.0[row].len() {
+            word = self.0[row][end_word_col];
+            if is_set && word < u64::max_value() {
+                break;
+            }
+            if !is_set && word > 0 {
+                break;
+            }
+            end_col += 64;
+            end_word_col += 1;
+        }
+        // start from beginning of last word
+        if end_word_col == self.0[row].len() {
+            return (end_col - col, ch);
+        }
+        mask = 1 << 63;
+        while mask > 0 {
+            if (word & mask > 0) != is_set {
+                break;
+            }
+            end_col += 1;
+            mask >>= 1;
+        }
+        return (end_col - col, ch);
+    }
+}

--- a/libconway/src/lib.rs
+++ b/libconway/src/lib.rs
@@ -1,0 +1,30 @@
+/*  Copyright 2017-2018 the Conwayste Developers.
+ *
+ *  This file is part of libconway.
+ *
+ *  libconway is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  libconway is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libconway.  If not, see <http://www.gnu.org/licenses/>. */
+
+#[macro_use] extern crate log;
+extern crate env_logger;
+#[macro_use] extern crate custom_error;
+
+pub mod universe;
+pub mod grids;
+pub mod rle;
+pub mod error;
+
+pub use error::{ConwayError, ConwayResult};
+
+#[cfg(test)]
+pub mod tests;

--- a/libconway/src/main.rs
+++ b/libconway/src/main.rs
@@ -1,0 +1,72 @@
+/*  Copyright 2017 the Conwayste Developers.
+ *
+ *  This file is part of libconway.
+ *
+ *  libconway is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  libconway is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libconway.  If not, see <http://www.gnu.org/licenses/>. */
+
+
+extern crate conway;
+
+use std::{thread, time};
+use conway::universe::*;
+
+fn main() {
+    let mut uni = Universe::new(128, 32, true, 16, 2, vec![Region::new(40,6,16,8), Region::new(60,16,8,8)], 16).unwrap();
+    let step_time = time::Duration::from_millis(150);
+
+    // pi heptomino
+    uni.toggle(62, 17, 1).unwrap();
+    uni.toggle(63, 17, 1).unwrap();
+    uni.toggle(61, 18, 1).unwrap();
+    uni.toggle(62, 18, 1).unwrap();
+    uni.toggle(62, 19, 1).unwrap();
+
+    // Spaceship in reverse direction
+    uni.toggle(48, 6, 0).unwrap();
+    uni.toggle(47, 7, 0).unwrap();
+    uni.toggle(47, 8, 0).unwrap();
+    uni.toggle(52, 8, 0).unwrap();
+    uni.toggle(47, 9, 0).unwrap();
+    uni.toggle(48, 9, 0).unwrap();
+    uni.toggle(49, 9, 0).unwrap();
+    uni.toggle(50, 9, 0).unwrap();
+    uni.toggle(51, 9, 0).unwrap();
+
+    uni.set_unchecked(74, 13, CellState::Wall);
+    uni.set_unchecked(75, 13, CellState::Wall);
+    uni.set_unchecked(76, 13, CellState::Wall);
+    uni.set_unchecked(77, 13, CellState::Wall);
+    uni.set_unchecked(78, 13, CellState::Wall);
+    uni.set_unchecked(78, 14, CellState::Wall);
+    uni.set_unchecked(78, 15, CellState::Wall);
+    uni.set_unchecked(78, 16, CellState::Wall);
+    uni.set_unchecked(78, 17, CellState::Wall);
+    uni.set_unchecked(78, 18, CellState::Wall);
+    uni.set_unchecked(78, 19, CellState::Wall);
+    uni.set_unchecked(78, 20, CellState::Wall);
+    uni.set_unchecked(78, 21, CellState::Wall);
+    uni.set_unchecked(78, 22, CellState::Wall);
+    uni.set_unchecked(78, 23, CellState::Wall);
+    uni.set_unchecked(78, 24, CellState::Wall);
+    uni.set_unchecked(77, 24, CellState::Wall);
+    uni.set_unchecked(76, 24, CellState::Wall);
+    uni.set_unchecked(75, 24, CellState::Wall);
+
+    loop {
+        println!("\x1b[H\x1b[2J{}", uni);
+        println!("Gen: {}", uni.latest_gen());
+        uni.next();
+        thread::sleep(step_time);
+    }
+}

--- a/libconway/src/rle.rs
+++ b/libconway/src/rle.rs
@@ -1,0 +1,256 @@
+/*  Copyright 2017-2019 the Conwayste Developers.
+ *
+ *  This file is part of libconway.
+ *
+ *  libconway is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  libconway is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libconway.  If not, see <http://www.gnu.org/licenses/>. */
+
+const MAX_NUMBER: usize = 50000;
+pub const NO_OP_CHAR: char = '"';
+
+use std::collections::BTreeMap;
+use std::str::FromStr;
+use crate::error::{ConwayError, ConwayResult};
+use crate::grids::{BitGrid, CharGrid};
+
+
+/// This contains just the RLE pattern string. For example: "4bobo$7b3o!"
+#[derive(Debug, PartialEq, Clone)]
+pub struct Pattern(pub String);
+
+/// Represents the contents of a RLE file.
+#[derive(Debug, PartialEq, Clone)]
+pub struct PatternFile {
+    pub comment_lines: Vec<String>,
+    pub header_line: HeaderLine,
+    pub pattern: Pattern,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct HeaderLine {
+    pub x: usize, // width (cols)
+    pub y: usize, // height (rows)
+    pub rule: Option<String>,
+}
+
+//TODO: module doc examples
+
+
+impl PatternFile {
+    #[inline]
+    pub fn width(&self) -> usize {
+        self.header_line.x
+    }
+
+    #[inline]
+    pub fn height(&self) -> usize {
+        self.header_line.y
+    }
+
+    pub fn to_new_bit_grid(&self) -> ConwayResult<BitGrid> {
+        self.pattern.to_new_bit_grid(self.width(), self.height())
+    }
+
+    pub fn to_grid<G: CharGrid>(&self, grid: &mut G, visibility: Option<usize>) -> ConwayResult<()> {
+        self.pattern.to_grid(grid, visibility)
+    }
+}
+
+impl FromStr for PatternFile {
+    type Err = ConwayError;
+
+    /// Generate a PatternFile from the contents of an RLE file.
+    fn from_str(file_contents: &str) -> Result<Self, Self::Err> {
+        use ConwayError::*;
+        let mut comment_lines: Vec<String> = vec![];
+        let mut comments_ended = false;
+        let mut opt_header_line: Option<HeaderLine> = None;
+        let mut pattern_lines: Vec<&str> = vec![];
+        for line in file_contents.lines() {
+            if line.starts_with("#") {
+                if comments_ended {
+                    return Err(InvalidData{reason: "Found a comment line after a non-comment line".to_owned()});
+                }
+                comment_lines.push(line.to_owned());
+                continue;
+            } else {
+                comments_ended = true;
+            }
+            if opt_header_line.is_none() {
+                // this line should be a header line
+                opt_header_line = Some(HeaderLine::from_str(line)?);
+                continue;
+            }
+            match line.find('!') {
+                Some(idx) => {
+                    pattern_lines.push(&line[0..=idx]);
+                    break; // we don't care about anything after the '!'
+                }
+                None => pattern_lines.push(line),
+            };
+        }
+        if opt_header_line.is_none() {
+            return Err(InvalidData{reason: "missing header line".to_owned()});
+        }
+        if pattern_lines.is_empty() {
+            return Err(InvalidData{reason: "missing pattern lines".to_owned()});
+        }
+        let mut pattern = "".to_owned();
+        for line in pattern_lines {
+            pattern.push_str(line);
+        }
+        Ok(PatternFile {
+            comment_lines,
+            header_line: opt_header_line.unwrap(),
+            pattern: Pattern(pattern),
+        })
+    }
+}
+
+
+impl FromStr for HeaderLine {
+    type Err = ConwayError;
+
+    fn from_str(line: &str) -> Result<Self, Self::Err> {
+        use ConwayError::*;
+        let mut map = BTreeMap::new();
+        for term in line.split(",") {
+            let parts = term
+                .split("=")
+                .map(|part| part.trim())
+                .collect::<Vec<&str>>();
+            if parts.len() != 2 {
+                return Err(InvalidData{reason: format!("unexpected term in header line: {:?}", term)});
+            }
+            map.insert(parts[0], parts[1]);
+        }
+        if !map.contains_key("x") || !map.contains_key("y") {
+            return Err(InvalidData{reason: format!("header line missing `x` and/or `y`: {:?}", line)});
+        }
+        let x = usize::from_str(map.get("x").unwrap()).map_err(|e| {
+            InvalidData{reason: format!("Error while parsing x: {}", e)}
+        })?;
+        let y = usize::from_str(map.get("y").unwrap()).map_err(|e| {
+            InvalidData{reason: format!("Error while parsing y: {}", e)}
+        })?;
+        let rule =  map.get("rule").map(|s: &&str| (*s).to_owned());
+        Ok(HeaderLine { x, y, rule })
+    }
+}
+
+
+fn digits_to_number(digits: &Vec<char>) -> ConwayResult<usize> {
+    use ConwayError::*;
+    let mut result = 0;
+    for ch in digits {
+        let d = ch.to_digit(10).unwrap();
+        result = result * 10 + d as usize;
+        if result > MAX_NUMBER {
+            return Err(InvalidData{reason: format!("Could not parse digits {:?} because larger than {}",
+                                                   digits, MAX_NUMBER)});
+        }
+    }
+    Ok(result)
+}
+
+
+impl Pattern {
+    /// Creates a BitGrid out of this pattern. If there are no parse errors, the result contains
+    /// the smallest BitGrid that fits a pattern `width` cells wide and `height` cells high.
+    pub fn to_new_bit_grid(&self, width: usize, height: usize) -> ConwayResult<BitGrid> {
+        let word_width = (width - 1)/64 + 1;
+        let mut grid = BitGrid::new(word_width, height);
+        self.to_grid(&mut grid, None)?;
+        Ok(grid)
+    }
+
+    /// Writes the pattern to a BitGrid or GenState (that is, anything implementing CharGrid).  The
+    /// characters in pattern must be valid for the grid, as determined by `::is_valid(ch)`, with
+    /// one exception: `NO_OP_CHAR` (`"`). Cells are skipped with runs containing `NO_OP_CHAR`.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if an attempt is made to write out of bounds.
+    ///
+    /// # Note
+    ///
+    /// If there is a parsing error, `grid` may be in a partially written state. If this is a
+    /// problem, then back up `grid` before calling this.
+    pub fn to_grid<G: CharGrid>(&self, grid: &mut G, visibility: Option<usize>) -> ConwayResult<()> {
+        use ConwayError::*;
+        let mut col: usize = 0;
+        let mut row: usize = 0;
+        let mut char_indices = self.0.char_indices();
+        let mut ch;
+        let mut i;
+        let mut complete = false;
+        let mut digits: Vec<char> = vec![];
+        loop {
+            match char_indices.next() {
+                Some((_i, _ch)) => {
+                    ch = _ch;
+                    i = _i;
+                }
+                None => break
+            };
+            if digits.len() > 0 && ch == '!' {
+                return Err(InvalidData{reason: format!("Cannot have {} after number at {}", ch, i)});
+            }
+            match ch {
+                _ if G::is_valid(ch) => {
+                    // cell
+                    let number = if digits.len() > 0 {
+                        //TODO: wrap errors from digits_to_number rather than just forwarding
+                        digits_to_number(&digits)?
+                    } else { 1 };
+                    digits.clear();
+                    if ch != NO_OP_CHAR {
+                        for _ in 0..number {
+                            grid.write_at_position(col, row, ch, visibility);
+                            col += 1;
+                        }
+                    } else {
+                        col += number;
+                    }
+                }
+                '!' => {
+                    // end of input
+                    complete = true;
+                    break;
+                }
+                '$' => {
+                    // new line
+                    let number = if digits.len() > 0 {
+                        digits_to_number(&digits)?
+                    } else { 1 };
+                    digits.clear();
+                    col = 0;
+                    row += number;
+                }
+                '\r' | '\n' => {
+                    // ignore newlines
+                }
+                x if x.is_digit(10) => {
+                    digits.push(ch);
+                }
+                _ => {
+                    return Err(InvalidData{reason: format!("Unrecognized character {} at {}", ch, i)});
+                }
+            }
+        }
+        if !complete {
+            return Err(InvalidData{reason: "Premature termination".to_owned()});
+        }
+        Ok(())
+    }
+}

--- a/libconway/src/tests.rs
+++ b/libconway/src/tests.rs
@@ -1,0 +1,1066 @@
+/*  Copyright 2017-2019 the Conwayste Developers.
+ *
+ *  This file is part of libconway.
+ *
+ *  libconway is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  libconway is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libconway.  If not, see <http://www.gnu.org/licenses/>. */
+
+mod universe_tests {
+    use crate::universe::*;
+    use crate::universe::test_helpers::*;
+    use crate::grids::CharGrid;
+    use crate::rle::Pattern;
+    use crate::error::ConwayError::*;
+
+
+    #[test]
+    fn new_universe_with_valid_dims() {
+        let uni = generate_test_universe_with_default_params(UniType::Server);
+        let universe_as_region = Region::new(0, 0, 256, 128);
+
+        assert_eq!(uni.width(), 256);
+        assert_eq!(uni.height(), 128);
+        assert_eq!(uni.region(), universe_as_region);
+    }
+
+    #[test]
+    fn new_universe_with_bad_dims() {
+
+        let player0 = PlayerBuilder::new(Region::new(100, 70, 34, 16));   // used for the glider gun and predefined patterns
+        let player1 = PlayerBuilder::new(Region::new(0, 0, 80, 80));
+        let players = vec![player0, player1];
+
+        let mut bigbang = BigBang::new()
+            .width(256)
+            .height(128)
+            .server_mode(true)
+            .history(16)
+            .fog_radius(9)
+            .add_players(players);
+
+        bigbang = bigbang.width(255);
+
+        let uni_result1 = bigbang.birth();
+        assert!(uni_result1.is_err());
+
+        bigbang = bigbang.width(256).height(0);
+        let uni_result2 = bigbang.birth();
+        assert!(uni_result2.is_err());
+
+        bigbang = bigbang.width(0).height(256);
+        let uni_result3 = bigbang.birth();
+        assert!(uni_result3.is_err());
+    }
+
+    #[test]
+    fn new_universe_first_gen_is_one() {
+        let uni = generate_test_universe_with_default_params(UniType::Server);
+        assert_eq!(uni.latest_gen(), 1);
+    }
+
+    #[test]
+    fn next_test_data1() {
+        let mut uni = generate_test_universe_with_default_params(UniType::Server);
+
+        // r-pentomino
+        let _ = uni.toggle(16, 15, 0);
+        let _ = uni.toggle(17, 15, 0);
+        let _ = uni.toggle(15, 16, 0);
+        let _ = uni.toggle(16, 16, 0);
+        let _ = uni.toggle(16, 17, 0);
+
+        let gens = 20;
+        for _ in 0..gens {
+            uni.next();
+        }
+        assert_eq!(uni.latest_gen(), gens + 1);
+    }
+
+    #[test]
+    fn set_unchecked_with_valid_rows_and_cols() {
+        let mut uni = generate_test_universe_with_default_params(UniType::Server);
+        let max_width = uni.width()-1;
+        let max_height = uni.height()-1;
+        let mut cell_state;
+        
+        for x in 0.. max_width {
+            for y in 0..max_height {
+                cell_state = uni.get_cell_state(x,y, None);
+                assert_eq!(cell_state, CellState::Dead);
+            }
+        }
+
+        uni.set_unchecked(0, 0, CellState::Alive(None));
+        cell_state = uni.get_cell_state(0,0, None);
+        assert_eq!(cell_state, CellState::Alive(None));
+
+        uni.set_unchecked(max_width, max_height, CellState::Alive(None));
+        assert_eq!(cell_state, CellState::Alive(None));
+
+        uni.set_unchecked(55, 55, CellState::Alive(None));
+        assert_eq!(cell_state, CellState::Alive(None));
+   }
+
+    #[test]
+    #[should_panic]
+    fn set_unchecked_with_invalid_rols_and_cols_panics() {
+        let mut uni = generate_test_universe_with_default_params(UniType::Server);
+        uni.set_unchecked(257, 129, CellState::Alive(None));
+    }
+
+    #[test]
+    fn universe_cell_states_are_dead_on_creation() {
+        let mut uni = generate_test_universe_with_default_params(UniType::Server);
+        let max_width = uni.width()-1;
+        let max_height = uni.height()-1;
+        
+        for x in 0..max_width {
+            for y in 0..max_height {
+                let cell_state = uni.get_cell_state(x,y, None);
+                assert_eq!(cell_state, CellState::Dead);
+            }
+        }
+    }
+
+    #[test]
+    fn set_checked_verify_players_remain_within_writable_regions() {
+        let mut uni = generate_test_universe_with_default_params(UniType::Server);
+        let max_width = uni.width()-1;
+        let max_height = uni.height()-1;
+        let player_id = 1; // writing into player 1's regions
+        let alive_player_cell = CellState::Alive(Some(player_id));
+        let mut cell_state;
+
+        // Writable region OK, Transitions to Alive
+        uni.set(0, 0, alive_player_cell, player_id);
+        cell_state = uni.get_cell_state(0,0, Some(player_id));
+        assert_eq!(cell_state, alive_player_cell);
+
+        // This should be dead as it is outside the writable region
+        uni.set(max_width, max_height, alive_player_cell, player_id);
+        cell_state = uni.get_cell_state(max_width, max_height, Some(player_id));
+        assert_eq!(cell_state, CellState::Dead);
+
+        // Writable region OK, transitions to Alive
+        uni.set(55, 55, alive_player_cell, player_id);
+        cell_state = uni.get_cell_state(55, 55, Some(player_id));
+        assert_eq!(cell_state, alive_player_cell);
+
+        // Outside of player_id's writable region which will remain unchanged
+        uni.set(81, 81, alive_player_cell, player_id);
+        cell_state = uni.get_cell_state(81, 81, Some(player_id));
+        assert_eq!(cell_state, CellState::Dead);
+    }
+
+    #[test]
+    fn toggle_checked_outside_a_player_writable_region_fails() {
+        let mut uni = generate_test_universe_with_default_params(UniType::Server);
+        let player_one = 0;
+        let player_two = 1;
+        let row = 0;
+        let col = 0;
+
+        assert_eq!(uni.toggle(row, col, player_one),
+                   Err(AccessDenied{reason: "outside writable area for player 0: col=0, row=0".to_owned()}));
+        assert_eq!(uni.toggle(row, col, player_two).unwrap(), CellState::Alive(Some(player_two)));
+    }
+
+    #[test]
+    fn generate_fog_circle_bitmap_fails_with_radius_zero() {
+        let player0 = PlayerBuilder::new(Region::new(100, 70, 34, 16));   // used for the glider gun and predefined patterns
+        let player1 = PlayerBuilder::new(Region::new(0, 0, 80, 80));
+        let players = vec![player0, player1];
+
+        let uni = BigBang::new()
+            .width(256)
+            .height(128)
+            .server_mode(true)
+            .history(16)
+            .fog_radius(0)
+            .add_players(players)
+            .birth();
+
+        assert!(uni.is_err());
+    }
+
+    #[test]
+    fn each_non_dead_detects_some_cells() {
+        let mut uni = generate_test_universe_with_default_params(UniType::Server);
+        let player1 = 1;
+
+        // glider
+        uni.toggle(16, 15, player1).unwrap();
+        uni.toggle(17, 16, player1).unwrap();
+        uni.toggle(15, 17, player1).unwrap();
+        uni.toggle(16, 17, player1).unwrap();
+        uni.toggle(17, 17, player1).unwrap();
+
+        // just a wall, for no reason at all
+        for col in 10..15 {
+            uni.set_unchecked(col, 12, CellState::Wall);
+        }
+
+        let gens = 21;
+        for _ in 0..gens {
+            uni.next();
+        }
+        let mut cells_with_pos: Vec<(usize, usize, CellState)> = vec![];
+        uni.each_non_dead(Region::new(0, 0, 80, 80), Some(player1), &mut |col, row, state| {
+            cells_with_pos.push((col, row, state));
+        });
+        assert_eq!(cells_with_pos.len(), 10);
+        assert_eq!(cells_with_pos, vec![(10, 12, CellState::Wall),
+                                        (11, 12, CellState::Wall),
+                                        (12, 12, CellState::Wall),
+                                        (13, 12, CellState::Wall),
+                                        (14, 12, CellState::Wall),
+                                        (20, 21, CellState::Alive(Some(1))),
+                                        (22, 21, CellState::Alive(Some(1))),
+                                        (21, 22, CellState::Alive(Some(1))),
+                                        (22, 22, CellState::Alive(Some(1))),
+                                        (21, 23, CellState::Alive(Some(1)))]);
+
+    }
+
+    #[test]
+    fn each_non_dead_detects_fog() {
+        let mut uni = generate_test_universe_with_default_params(UniType::Server);
+        let player0 = 0;
+        let player1 = 1;
+
+        // blinker as player 1
+        uni.toggle(16, 15, player1).unwrap();
+        uni.toggle(16, 16, player1).unwrap();
+        uni.toggle(16, 17, player1).unwrap();
+
+        // attempt to view as different player
+        uni.each_non_dead(Region::new(0, 0, 80, 80), Some(player0), &mut |col, row, state| {
+            assert_eq!(state, CellState::Fog, "expected fog at col {} row {} but found {:?}", col, row, state);
+        });
+    }
+
+    #[test]
+    fn universe_apply_basic2() {
+        // we do Server to Server so that the fog doesn't interfere with pattern comparison
+        let mut src_uni = generate_test_universe_with_default_params(UniType::Server);
+        let mut dst_uni = generate_test_universe_with_default_params(UniType::Server);
+        let player1 = 1;
+        // glider
+        src_uni.next(); // just ensure we're at generation 2
+        src_uni.toggle(16, 15, player1).unwrap();
+        src_uni.toggle(17, 16, player1).unwrap();
+        src_uni.toggle(15, 17, player1).unwrap();
+        src_uni.toggle(16, 17, player1).unwrap();
+        src_uni.toggle(17, 17, player1).unwrap();
+        let gens = 4;
+        let diff1 = src_uni.diff(1, 2, None).unwrap();
+        assert_eq!(dst_uni.apply(&diff1, None), Ok(Some(2)));
+        for _ in 0..gens {
+            src_uni.next();
+        }
+        let diff2 = src_uni.diff(2, 6, None).unwrap();
+        assert_eq!(dst_uni.apply(&diff2, None), Ok(Some(6)));
+        assert_eq!(src_uni.to_pattern(None), dst_uni.to_pattern(None));
+    }
+
+    #[test]
+    fn universe_apply_but_already_applied() {
+        let mut s_uni = generate_test_universe_with_default_params(UniType::Server);  // server
+        let mut c_uni = generate_test_universe_with_default_params(UniType::Client); // client is missing generation 1
+        let player1 = 1;
+        // glider
+        s_uni.toggle(16, 15, player1).unwrap();
+        s_uni.toggle(17, 16, player1).unwrap();
+        s_uni.toggle(15, 17, player1).unwrap();
+        s_uni.toggle(16, 17, player1).unwrap();
+        s_uni.toggle(17, 17, player1).unwrap();
+        let gens = 4;
+        for _ in 0..gens {
+            s_uni.next();
+        }
+        let diff = s_uni.diff(0, 5, None).unwrap();
+        c_uni.apply(&diff, None).unwrap();
+        assert_eq!(c_uni.apply(&diff, None).unwrap(), None); // applying a second time does nothing
+        // earlier gen
+        let diff2 = s_uni.diff(0, 4, None).unwrap();
+        assert_eq!(c_uni.apply(&diff2, None).unwrap(), None); // applying does noting if our gen is later than diff's gen
+    }
+
+    #[test]
+    fn universe_apply_but_base_gen_absent() {
+        let mut s_uni = generate_test_universe_with_default_params(UniType::Server);  // server
+        let mut c_uni = generate_test_universe_with_default_params(UniType::Client); // client is missing generation 1
+        let player1 = 1;
+        // glider
+        s_uni.toggle(16, 15, player1).unwrap();
+        s_uni.toggle(17, 16, player1).unwrap();
+        s_uni.toggle(15, 17, player1).unwrap();
+        s_uni.toggle(16, 17, player1).unwrap();
+        s_uni.toggle(17, 17, player1).unwrap();
+        let gens = 4;
+        for _ in 0..gens {
+            s_uni.next();
+        }
+        let diff = s_uni.diff(1, 5, None).unwrap();
+        assert_eq!(c_uni.apply(&diff, None).unwrap(), None); // we don't have base gen (1), so can't apply it
+    }
+
+    #[test]
+    fn universe_apply_too_large_range() {
+        let base = 3;
+        let diff = GenStateDiff{gen0: base, gen1: base + GEN_BUFSIZE + 1, pattern: Pattern("!".to_owned())};
+        let mut c_uni = generate_test_universe_with_default_params(UniType::Client);
+        assert_eq!(c_uni.apply(&diff, None), Err(InvalidData{reason: "diff is across too many generations to be applied: 17 >= 16".to_owned()}));
+    }
+
+    #[test]
+    fn universe_diff_crazy_numbers_is_none() {
+        let uni = generate_test_universe_with_default_params(UniType::Server);
+        assert!(uni.diff(123, 456, None).is_none());
+    }
+
+    #[test]
+    #[should_panic]
+    fn universe_diff_crazier_numbers_panics() {
+        let uni = generate_test_universe_with_default_params(UniType::Server);
+        assert!(uni.diff(456, 456, None).is_none());
+    }
+
+    #[test]
+    fn universe_diff_good_numbers_is_valid() {
+        let mut uni = generate_test_universe_with_default_params(UniType::Server);
+        let player1 = 1;
+        // glider
+        uni.toggle(16, 15, player1).unwrap();
+        uni.toggle(17, 16, player1).unwrap();
+        uni.toggle(15, 17, player1).unwrap();
+        uni.toggle(16, 17, player1).unwrap();
+        uni.toggle(17, 17, player1).unwrap();
+        let gens = 4;
+        for _ in 0..gens {
+            uni.next();
+        }
+        let diff = uni.diff(2, 3, None).unwrap();
+        assert_eq!(diff.gen0, 2);
+        assert_eq!(diff.gen1, 3);
+        let pat_str = diff.pattern.0.as_str();
+        let s = pat_str.split("256\"$")
+                       .filter(|&s| {
+                           s != "\r\n" && s != ""
+                       })
+                       .next()
+                       .unwrap();
+        assert_eq!(s, "15\"b240\"$15\"Bb239\"$17\"B238\"$");
+    }
+
+    #[test]
+    fn universe_diff_zero_base_gen() {
+        let mut uni = generate_test_universe_with_default_params(UniType::Server);
+        let player1 = 1;
+        // glider
+        uni.toggle(16, 15, player1).unwrap();
+        uni.toggle(17, 16, player1).unwrap();
+        uni.toggle(15, 17, player1).unwrap();
+        uni.toggle(16, 17, player1).unwrap();
+        uni.toggle(17, 17, player1).unwrap();
+        let gens = 4;
+        for _ in 0..gens {
+            uni.next();
+        }
+        let diff = uni.diff(0, 4, None).unwrap();
+        assert_eq!(diff.gen0, 0);
+        assert_eq!(diff.gen1, 4);
+    }
+
+    #[test]
+    fn universe_diff_some_player1_sees_cells() {
+        let mut uni = generate_test_universe_with_default_params(UniType::Server);
+        let player1 = 1;
+        // glider
+        uni.toggle(16, 15, player1).unwrap();
+        uni.toggle(17, 16, player1).unwrap();
+        uni.toggle(15, 17, player1).unwrap();
+        uni.toggle(16, 17, player1).unwrap();
+        uni.toggle(17, 17, player1).unwrap();
+        let gens = 4;
+        for _ in 0..gens {
+            uni.next();
+        }
+        let diff = uni.diff(0, 4, Some(player1)).unwrap();
+        assert!(diff.pattern.0.find('B').is_some());  // should find cells from player 1
+    }
+
+    #[test]
+    fn universe_diff_some_other_player_does_not_see_cells() {
+        let mut uni = generate_test_universe_with_default_params(UniType::Server);
+        let player1 = 1;
+        let other_player = 0;
+        // glider
+        uni.toggle(16, 15, player1).unwrap();
+        uni.toggle(17, 16, player1).unwrap();
+        uni.toggle(15, 17, player1).unwrap();
+        uni.toggle(16, 17, player1).unwrap();
+        uni.toggle(17, 17, player1).unwrap();
+        let gens = 4;
+        for _ in 0..gens {
+            uni.next();
+        }
+        let diff = uni.diff(0, 4, Some(other_player)).unwrap();
+        assert!(diff.pattern.0.find('B').is_none());  // should not find cells from player 1
+    }
+}
+
+
+mod genstate_tests {
+    use crate::universe::test_helpers::*;
+    use crate::grids::CharGrid;
+    use crate::rle::Pattern;
+
+    #[test]
+    fn gen_state_get_run_simple() {
+        let mut genstate = make_gen_state();
+
+        Pattern("o!".to_owned()).to_grid(&mut genstate, None).unwrap();
+        assert_eq!(genstate.get_run(0, 0, None), (1, 'o'));
+    }
+
+    #[test]
+    fn gen_state_get_run_wall() {
+        let mut genstate = make_gen_state();
+
+        Pattern("4W!".to_owned()).to_grid(&mut genstate, None).unwrap();
+        assert_eq!(genstate.get_run(0, 0, None), (4, 'W'));
+    }
+
+    #[test]
+    fn gen_state_get_run_wall_blank_in_front() {
+        let mut genstate = make_gen_state();
+
+        Pattern("12b4W!".to_owned()).to_grid(&mut genstate, None).unwrap();
+        assert_eq!(genstate.get_run(12, 0, None), (4, 'W'));
+    }
+
+    #[test]
+    fn gen_state_get_run_alternating_owned_unowned() {
+        let mut genstate = make_gen_state();
+
+        Pattern("15o3A2B9o!".to_owned()).to_grid(&mut genstate, None).unwrap();
+        assert_eq!(genstate.get_run(0,      0, None), (15, 'o'));
+        assert_eq!(genstate.get_run(15,     0, None), (3,  'A'));
+        assert_eq!(genstate.get_run(15+3,   0, None), (2,  'B'));
+        assert_eq!(genstate.get_run(15+3+2, 0, None), (9,  'o'));
+    }
+
+    #[test]
+    fn gen_state_get_run_player1_no_fog() {
+        let mut genstate = make_gen_state();
+
+        let write_pattern_as = Some(1);   // avoid clearing fog for players other than player 1
+        Pattern("o!".to_owned()).to_grid(&mut genstate, write_pattern_as).unwrap();
+        let visibility = Some(1); // as player 1
+        assert_eq!(genstate.get_run(0, 0, visibility), (1, 'o'));
+    }
+
+    #[test]
+    fn gen_state_diff_simple1() {
+        let gs0 = make_gen_state();
+        let mut gs1 = make_gen_state();
+        Pattern("o!".to_owned()).to_grid(&mut gs1, None).unwrap();
+
+        let gsdiff = gs0.diff(&gs1, None);
+        assert_eq!(gsdiff.pattern.0.len(), 659);
+        let mut gsdiff_pattern_iter = gsdiff.pattern.0.split('$');
+        assert_eq!(gsdiff_pattern_iter.next().unwrap(), "o255\"");
+        assert_eq!(gsdiff_pattern_iter.next().unwrap(), "256\"");
+        assert_eq!(gsdiff_pattern_iter.next().unwrap(), "256\"");
+        // if you keep doing this, you'll eventually get a string containing \r\n
+    }
+
+    #[test]
+    fn gen_state_diff_and_restore_simple1() {
+        let gs0 = make_gen_state();
+        let mut gs1 = make_gen_state();
+        let visibility = None;
+        Pattern("o!".to_owned()).to_grid(&mut gs1, visibility).unwrap();
+
+        let gsdiff = gs0.diff(&gs1, visibility);
+
+        let mut new_gs = make_gen_state();
+
+        gsdiff.pattern.to_grid(&mut new_gs, visibility).unwrap();
+        assert_eq!(new_gs, gs1);
+    }
+}
+
+
+mod region_tests {
+    use crate::universe::*;
+
+    #[test]
+    fn region_with_valid_dims() {
+        let region = Region::new(1, 10, 100, 200);
+
+        assert_eq!(region.left(), 1);
+        assert_eq!(region.top(), 10);
+        assert_eq!(region.height(), 200);
+        assert_eq!(region.width(), 100);
+        assert_eq!(region.right(), 100);
+        assert_eq!(region.bottom(), 209);
+    }
+    
+    #[test]
+    fn region_with_valid_dims_negative_top_and_left() {
+        let region = Region::new(-1, -10, 100, 200);
+
+        assert_eq!(region.left(), -1);
+        assert_eq!(region.top(), -10);
+        assert_eq!(region.height(), 200);
+        assert_eq!(region.width(), 100);
+        assert_eq!(region.right(), 98);
+        assert_eq!(region.bottom(), 189);
+    }
+
+    #[test]
+    #[should_panic]
+    fn region_with_bad_dims_panics() {
+        Region::new(0, 0, 0, 0);
+    }
+
+    #[test]
+    fn region_contains_a_valid_sub_region() {
+        let region1 = Region::new(1, 10, 100, 200);
+        let region2 = Region::new(-100, -200, 100, 200);
+
+        assert!(region1.contains(50, 50));
+        assert!(region2.contains(-50, -50));
+    }
+    
+    #[test]
+    fn region_does_not_contain_sub_region() {
+        let region1 = Region::new(1, 10, 100, 200);
+        let region2 = Region::new(-100, -200, 100, 200);
+
+        assert!(!region1.contains(-50, -50));
+        assert!(!region2.contains(50, 50));
+    }
+
+    #[test]
+    fn region_no_intersection() {
+        let region1 = Region::new(1, 10, 100, 200);
+        let region2 = Region::new(-100, -200, 100, 200);
+        assert_eq!(region1.intersection(region2), None);
+        assert_eq!(region2.intersection(region1), None);
+    }
+
+    #[test]
+    fn region_intersection_with_self() {
+        let region1 = Region::new(1, 10, 100, 200);
+        assert_eq!(region1.intersection(region1), Some(region1));
+    }
+
+    #[test]
+    fn region_intersection_overlap() {
+        let region1 = Region::new( 1,  10, 100, 200);
+        let region2 = Region::new(90, 120, 100, 200);
+        assert_eq!(region1.intersection(region2), Some(Region::new(90, 120, 11, 90)));
+    }
+
+    #[test]
+    fn region_no_intersection_overlap_one_dim() {
+        let region1 = Region::new(0, 0, 2, 2);
+        let region2 = Region::new(3, 0, 2, 2);
+        assert_eq!(region1.intersection(region2), None);
+    }
+}
+
+mod cellstate_tests {
+    use crate::universe::*;
+
+    #[test]
+    fn cell_states_as_char() {
+        let dead = CellState::Dead;
+        let alive = CellState::Alive(None);
+        let player1 = CellState::Alive(Some(1));
+        let player2 = CellState::Alive(Some(2));
+        let wall = CellState::Wall;
+        let fog = CellState::Fog;
+
+        assert_eq!(dead.to_char(), 'b');
+        assert_eq!(alive.to_char(), 'o');
+        assert_eq!(player1.to_char(), 'B');
+        assert_eq!(player2.to_char(), 'C');
+        assert_eq!(wall.to_char(), 'W');
+        assert_eq!(fog.to_char(), '?');
+    }
+}
+
+mod grid_tests {
+    use crate::universe::Region;
+    use crate::rle::Pattern;
+    use crate::grids::*;
+
+    #[test]
+    fn height_works() {
+        let grid = BitGrid::new(2, 5);
+        assert_eq!(grid.height(), 5);
+    }
+
+    #[test]
+    fn width_works() {
+        let grid = BitGrid::new(2, 5);
+        assert_eq!(grid.width(), 2*64);
+    }
+
+    #[test]
+    fn create_valid_empty_bitgrid() {
+        let height = 11;
+        let width_in_words = 10;
+        let grid = BitGrid::new(width_in_words, height);
+
+        assert_eq!(grid[0][0], 0);
+        assert_eq!(grid[height-1][width_in_words-1], 0);
+
+        for x in 0..height {
+            for y in 0..width_in_words {
+                assert_eq!(grid[x][y], 0);
+            }
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    fn create_bitgrid_with_invalid_dims() {
+        let height = 0;
+        let width_in_words = 0;
+        let _ = BitGrid::new(width_in_words, height);
+    }
+
+    #[test]
+    fn set_cell_bits_within_a_bitgrid() {
+        let height = 10;
+        let width_in_words = 10;
+        let mut grid = BitGrid::new(width_in_words, height);
+
+        for x in 0..height {
+            for y in 0..width_in_words {
+                assert_eq!(grid[x][y], 0);
+            }
+        }
+
+        grid.modify_bits_in_word(height/2, width_in_words/2, 1<<63, BitOperation::Set);
+        assert_eq!(grid[height/2][width_in_words/2] >> 63, 1);
+        
+        grid.modify_bits_in_word(height-1, width_in_words-1, 1<<63, BitOperation::Set);
+        assert_eq!(grid[height-1][width_in_words-1] >> 63, 1);
+    }
+
+    #[test]
+    fn clear_cell_bits_within_a_bitgrid() {
+        let height = 10;
+        let width_in_words = 10;
+        let mut grid = BitGrid::new(width_in_words, height);
+
+        for x in 0..height {
+            for y in 0..width_in_words {
+                grid[x][y] = u64::max_value();
+            }
+        }
+
+        grid.modify_bits_in_word(height/2, width_in_words/2, 1<<63, BitOperation::Clear);
+        assert_eq!(grid[height/2][width_in_words/2] >> 63, 0);
+        
+        grid.modify_bits_in_word(height-1, width_in_words-1, 1<<63, BitOperation::Clear);
+        assert_eq!(grid[height-1][width_in_words-1] >> 63, 0);
+    }
+
+    #[test]
+    fn toggle_cell_bits_within_a_bitgrid() {
+        let height = 10;
+        let width_in_words = 10;
+        let mut grid = BitGrid::new(width_in_words, height);
+
+        for x in 0..height {
+            for y in 0..width_in_words {
+                grid[x][y] = u64::max_value();
+            }
+        }
+
+        grid.modify_bits_in_word(height/2, width_in_words/2, 1<<63, BitOperation::Toggle);
+        assert_eq!(grid[height/2][width_in_words/2] >> 63, 0);
+        
+        grid.modify_bits_in_word(height/2, width_in_words/2, 1<<63, BitOperation::Toggle);
+        assert_eq!(grid[height/2][width_in_words/2] >> 63, 1);
+    }
+
+    #[test]
+    fn fill_region_within_a_bit_grid() {
+        let height = 10;
+        let width_in_words = 10;
+
+        let region1_w = 7;
+        let region1_h = 7;
+        let region2_w = 3;
+        let region2_h = 3;
+        let region3_h = 4;
+        let region3_w = 4;
+
+        let mut grid = BitGrid::new(width_in_words, height);
+        let region1 = Region::new(0, 0, region1_w, region1_h);
+        let region2 = Region::new(0, 0, region2_w, region2_h);
+        let region3 = Region::new(region2_w as isize, region2_h as isize, region3_w, region3_h);
+
+        grid.modify_region(region1, BitOperation::Set);
+
+        for y in 0..region1_w {
+            assert_eq!(grid[y][0], 0xFE00000000000000);
+        }
+
+        grid.modify_region(region2, BitOperation::Clear);
+        for y in 0..region2_w {
+            assert_eq!(grid[y][0], 0x1E00000000000000);
+        }
+
+        grid.modify_region(region3, BitOperation::Toggle);
+        for x in region2_w..region3_w {
+            for y in region2_h..region3_h {
+                assert_eq!(grid[x][y], 0);
+            }
+        }
+    }
+
+    #[test]
+    fn bounding_box_of_empty_bit_grid_is_none() {
+        let grid = BitGrid::new(1, 1);
+        assert_eq!(grid.bounding_box(), None);
+    }
+
+    #[test]
+    fn bounding_box_of_empty_bit_grid_is_none2() {
+        let grid = BitGrid::new(2, 5);
+        assert_eq!(grid.bounding_box(), None);
+    }
+
+    #[test]
+    fn bounding_box_for_single_off() {
+        let grid = Pattern("b!".to_owned()).to_new_bit_grid(1, 1).unwrap();
+        assert_eq!(grid.bounding_box(), None);
+    }
+
+    #[test]
+    fn bounding_box_for_single_on() {
+        let grid = Pattern("o!".to_owned()).to_new_bit_grid(1, 1).unwrap();
+        assert_eq!(grid.bounding_box(), Some(Region::new(0, 0, 1, 1)));
+    }
+
+    #[test]
+    fn bounding_box_for_single_line_complicated() {
+        let grid = Pattern("15b87o!".to_owned()).to_new_bit_grid(15+87, 1).unwrap();
+        assert_eq!(grid.bounding_box(), Some(Region::new(15, 0, 87, 1)));
+    }
+
+    #[test]
+    fn bounding_box_for_single_line_complicated2() {
+        let grid = Pattern("82b87o!".to_owned()).to_new_bit_grid(82+87, 1).unwrap();
+        assert_eq!(grid.bounding_box(), Some(Region::new(82, 0, 87, 1)));
+    }
+
+    #[test]
+    fn bounding_box_for_multi_line_complicated() {
+        let grid = Pattern("4$15b87o!".to_owned()).to_new_bit_grid(15+87, 5).unwrap();
+        assert_eq!(grid.bounding_box(), Some(Region::new(15, 4, 87, 1)));
+    }
+
+    #[test]
+    fn bounding_box_for_multi_line_complicated2() {
+        let grid = Pattern("4$15b87o$10b100o$25b3o!".to_owned()).to_new_bit_grid(110, 7).unwrap();
+        assert_eq!(grid.bounding_box(), Some(Region::new(10, 4, 100, 3)));
+    }
+
+
+    #[test]
+    fn copy_simple() {
+        let grid = Pattern("64o$64o!".to_owned()).to_new_bit_grid(64, 2).unwrap();
+        let mut grid2 = BitGrid::new(1, 2); // 64x2
+        let dst_region = Region::new(0, 0, 32, 3);
+        BitGrid::copy(&grid, &mut grid2, dst_region);
+        assert_eq!(grid2.to_pattern(None).0, "32o$32o!".to_owned());
+    }
+
+    #[test]
+    fn copy_out_of_bounds() {
+        let grid = Pattern("64o$64o!".to_owned()).to_new_bit_grid(64, 2).unwrap();
+        let mut grid2 = BitGrid::new(1, 2); // 64x2
+        let dst_region = Region::new(17, 3, 32, 5);
+        BitGrid::copy(&grid, &mut grid2, dst_region);
+        assert_eq!(grid2.to_pattern(None).0, "!".to_owned());
+    }
+
+    #[test]
+    fn copy_simple2() {
+        let grid = Pattern("64o$64o!".to_owned()).to_new_bit_grid(64, 2).unwrap();
+        let mut grid2 = BitGrid::new(1, 2); // 64x2
+        let dst_region = Region::new(16, 1, 32, 3);
+        BitGrid::copy(&grid, &mut grid2, dst_region);
+        assert_eq!(grid2.to_pattern(None).0, "$16b32o!".to_owned());
+    }
+
+    #[test]
+    fn copy_for_multi_line_complicated() {
+        let grid = Pattern("4$b87o$3b100o$3o!".to_owned()).to_new_bit_grid(110, 7).unwrap();
+        let mut grid2 = BitGrid::new(2, 10); // 128x10
+        let dst_region = Region::new(2, 3, 64, 5);
+        BitGrid::copy(&grid, &mut grid2, dst_region);
+        assert_eq!(grid2.to_pattern(None).0, "7$3b63o!".to_owned());
+    }
+
+    #[test]
+    fn copy_for_multi_line_complicated2() {
+        let grid = Pattern("4$b87o$3b100o$3o!".to_owned()).to_new_bit_grid(110, 7).unwrap();
+        let mut grid2 = BitGrid::new(2, 10); // 128x10
+        let dst_region = Region::new(2, 3, 65, 5);
+        BitGrid::copy(&grid, &mut grid2, dst_region);
+        assert_eq!(grid2.to_pattern(None).0, "7$3b64o!".to_owned());
+    }
+
+    #[test]
+    fn copy_for_multi_line_complicated3() {
+        let grid = Pattern("4$b87o$3b100o$3o!".to_owned()).to_new_bit_grid(110, 7).unwrap();
+        let mut grid2 = BitGrid::new(1, 10); // 64x10
+        let dst_region = Region::new(2, 3, 5, 5);
+        BitGrid::copy(&grid, &mut grid2, dst_region);
+        assert_eq!(grid2.to_pattern(None).0, "7$3b4o!".to_owned());
+    }
+
+
+    #[test]
+    #[should_panic]
+    fn modify_region_with_a_negative_region_panics() {
+        let height = 10;
+        let width_in_words = 10;
+
+        let mut grid = BitGrid::new(width_in_words, height);
+        let region_neg = Region::new(-1, -1, 1, 1);
+        grid.modify_region(region_neg, BitOperation::Set);
+    }
+
+    #[test]
+    fn get_run_for_single_on() {
+        let grid = Pattern("o!".to_owned()).to_new_bit_grid(1, 1).unwrap();
+        assert_eq!(grid.get_run(0, 0, None), (1, 'o'));
+    }
+
+    #[test]
+    fn get_run_for_single_off_then_on() {
+        let grid = Pattern("bo!".to_owned()).to_new_bit_grid(2, 1).unwrap();
+        assert_eq!(grid.get_run(0, 0, None), (1, 'b'));
+    }
+
+    #[test]
+    fn get_run_for_single_off() {
+        let grid = Pattern("b!".to_owned()).to_new_bit_grid(1, 1).unwrap();
+        assert_eq!(grid.get_run(0, 0, None), (64, 'b'));
+    }
+
+    #[test]
+    fn get_run_nonzero_col_for_single_off() {
+        let grid = Pattern("b!".to_owned()).to_new_bit_grid(1, 1).unwrap();
+        assert_eq!(grid.get_run(23, 0, None), (64 - 23, 'b'));
+    }
+
+    #[test]
+    fn get_run_nonzero_col_complicated() {
+        let grid = Pattern("15b87o!".to_owned()).to_new_bit_grid(15+87, 1).unwrap();
+        assert_eq!(grid.get_run(15, 0, None), (87, 'o'));
+    }
+
+    #[test]
+    fn get_run_nonzero_col_multiline_complicated() {
+        let grid = Pattern("3$15b87o!".to_owned()).to_new_bit_grid(15+87, 4).unwrap();
+        assert_eq!(grid.get_run(15, 3, None), (87, 'o'));
+    }
+
+
+
+    #[test]
+    fn to_pattern_simple() {
+        let original_pattern = Pattern("bo!".to_owned());
+        let grid = original_pattern.to_new_bit_grid(2, 1).unwrap();
+        let pattern = grid.to_pattern(None);
+        assert_eq!(pattern, original_pattern);
+    }
+
+    #[test]
+    fn to_pattern_nonzero_col_3empty_then_complicated() {
+        let original_pattern = Pattern("3$15b87o!".to_owned());
+        let grid = original_pattern.to_new_bit_grid(15+87, 4).unwrap();
+        let pattern = grid.to_pattern(None);
+        assert_eq!(pattern, original_pattern);
+    }
+
+    #[test]
+    fn to_pattern_nonzero_col_veryverycomplicated() {
+        let original_pattern = Pattern("b2o23b2o21b$b2o23bo22b$24bobo22b$15b2o7b2o23b$2o13bobo31b$2o13bob2o30b$16b2o31b$16bo32b$44b2o3b$16bo27b2o3b$16b2o31b$2o13bob2o13bo3bo12b$2o13bobo13bo5bo7b2o2b$15b2o14bo13b2o2b$31b2o3bo12b$b2o30b3o13b$b2o46b$33b3o13b$31b2o3bo12b$31bo13b2o2b$31bo5bo7b2o2b$32bo3bo12b2$44b2o3b$44b2o3b5$37b2o10b$37bobo7b2o$39bo7b2o$37b3o9b$22bobo24b$21b3o25b$21b3o25b$21bo15b3o9b$25bobo11bo9b$21b2o4bo9bobo9b$16b2o4bo3b2o9b2o10b$15bobo6bo24b$15bo33b$14b2o!".to_owned());
+        let grid = original_pattern.to_new_bit_grid(49, 43).unwrap();
+        let pattern = grid.to_pattern(None);
+        assert_eq!(pattern.0.as_str(), "b2o23b2o$b2o23bo$24bobo$15b2o7b2o$2o13bobo$2o13bob2o$16b2o$16bo$44b2o$\r\n16bo27b2o$16b2o$2o13bob2o13bo3bo$2o13bobo13bo5bo7b2o$15b2o14bo13b2o$\r\n31b2o3bo$b2o30b3o$b2o$33b3o$31b2o3bo$31bo13b2o$31bo5bo7b2o$32bo3bo2$\r\n44b2o$44b2o5$37b2o$37bobo7b2o$39bo7b2o$37b3o$22bobo$21b3o$21b3o$21bo\r\n15b3o$25bobo11bo$21b2o4bo9bobo$16b2o4bo3b2o9b2o$15bobo6bo$15bo$14b2o!");
+        for line in pattern.0.as_str().lines() {
+            assert!(line.len() <= 70);
+        }
+    }
+
+    #[test]
+    fn get_run_empty() {
+        let grid = BitGrid::new(1,1);
+        let pattern = grid.to_pattern(None);
+        assert_eq!(pattern.0.as_str(), "!");
+    }
+
+    #[test]
+    fn clear_all_ones_really_is_clear() {
+        let pat = Pattern("64o$64o$64o$64o$64o$64o$64o$64o$64o$64o$64o$64o!".to_owned());
+        let mut grid = pat.to_new_bit_grid(64, 12).unwrap();
+        grid.clear();
+        for row in &grid.0 {
+            for col_idx in 0..row.len() {
+                assert_eq!(row[col_idx], 0);
+            }
+        }
+    }
+}
+
+
+mod rle_tests {
+    use crate::rle::*;
+    use crate::grids::BitGrid;
+    use std::str::FromStr;
+
+    // Glider gun
+    #[test]
+    fn one_line_parsing_works1() {
+        let gun = Pattern("24bo$22bobo$12b2o6b2o12b2o$11bo3bo4b2o12b2o$2o8bo5bo3b2o$2o8bo3bob2o4bobo$10bo5bo7bo$11bo3bo$12b2o!".to_owned()).to_new_bit_grid(36, 9).unwrap();
+        assert_eq!(gun[0][0], 0b0000000000000000000000001000000000000000000000000000000000000000);
+        assert_eq!(gun[1][0], 0b0000000000000000000000101000000000000000000000000000000000000000);
+        assert_eq!(gun[2][0], 0b0000000000001100000011000000000000110000000000000000000000000000);
+        assert_eq!(gun[3][0], 0b0000000000010001000011000000000000110000000000000000000000000000);
+        assert_eq!(gun[4][0], 0b1100000000100000100011000000000000000000000000000000000000000000);
+        assert_eq!(gun[5][0], 0b1100000000100010110000101000000000000000000000000000000000000000);
+        assert_eq!(gun[6][0], 0b0000000000100000100000001000000000000000000000000000000000000000);
+        assert_eq!(gun[7][0], 0b0000000000010001000000000000000000000000000000000000000000000000);
+        assert_eq!(gun[8][0], 0b0000000000001100000000000000000000000000000000000000000000000000);
+    }
+
+
+    // Glider gun with line break
+    #[test]
+    fn multi_line_parsing_works1() {
+        let gun = Pattern("24bo$22bobo$12b2o6b2o\r\n12b2o$\r\n11bo3bo4b2o12b2o$2o8b\ro5bo3b2o$2o8bo3bob2o4b\nobo$10bo5bo7bo$11bo3bo$12b2o!".to_owned()).to_new_bit_grid(36, 9).unwrap();
+        assert_eq!(gun[0][0], 0b0000000000000000000000001000000000000000000000000000000000000000);
+        assert_eq!(gun[1][0], 0b0000000000000000000000101000000000000000000000000000000000000000);
+        assert_eq!(gun[2][0], 0b0000000000001100000011000000000000110000000000000000000000000000);
+        assert_eq!(gun[3][0], 0b0000000000010001000011000000000000110000000000000000000000000000);
+        assert_eq!(gun[4][0], 0b1100000000100000100011000000000000000000000000000000000000000000);
+        assert_eq!(gun[5][0], 0b1100000000100010110000101000000000000000000000000000000000000000);
+        assert_eq!(gun[6][0], 0b0000000000100000100000001000000000000000000000000000000000000000);
+        assert_eq!(gun[7][0], 0b0000000000010001000000000000000000000000000000000000000000000000);
+        assert_eq!(gun[8][0], 0b0000000000001100000000000000000000000000000000000000000000000000);
+    }
+
+    #[test]
+    fn parsing_with_new_row_rle_works() {
+        let pattern = Pattern("27bo$28bo$29bo$28bo$27bo$29b3o20$oo$bbo$bbo$3b4o!".to_owned()).to_new_bit_grid(32, 29).unwrap();
+        assert_eq!(pattern.0[0..=5],
+           [[0b0000000000000000000000000001000000000000000000000000000000000000],
+            [0b0000000000000000000000000000100000000000000000000000000000000000],
+            [0b0000000000000000000000000000010000000000000000000000000000000000],
+            [0b0000000000000000000000000000100000000000000000000000000000000000],
+            [0b0000000000000000000000000001000000000000000000000000000000000000],
+            [0b0000000000000000000000000000011100000000000000000000000000000000]]);
+        for row in 6..=24 {
+            assert_eq!(pattern.0[row][0], 0);
+        }
+        assert_eq!(pattern.0[25..=28],
+            [[0b1100000000000000000000000000000000000000000000000000000000000000],
+             [0b0010000000000000000000000000000000000000000000000000000000000000],
+             [0b0010000000000000000000000000000000000000000000000000000000000000],
+             [0b0001111000000000000000000000000000000000000000000000000000000000]]);
+    }
+
+
+    #[test]
+    fn parse_whole_file_works() {
+        let pat: PatternFile = PatternFile::from_str("#N Gosper glider gun\n#C This was the first gun discovered.\n#C As its name suggests, it was discovered by Bill Gosper.\nx = 36, y = 9, rule = B3/S23\n24bo$22bobo$12b2o6b2o12b2o$11bo3bo4b2o12b2o$2o8bo5bo3b2o$2o8bo3bob2o4b\nobo$10bo5bo7bo$11bo3bo$12b2o!\n").unwrap();
+        assert_eq!(pat.comment_lines.len(), 3);
+        assert_eq!(pat.header_line, HeaderLine{x: 36, y: 9, rule: Some("B3/S23".to_owned())});
+        assert_eq!(pat.pattern.0, "24bo$22bobo$12b2o6b2o12b2o$11bo3bo4b2o12b2o$2o8bo5bo3b2o$2o8bo3bob2o4bobo$10bo5bo7bo$11bo3bo$12b2o!");
+    }
+
+    #[test]
+    fn parse_whole_file_works_with_crap_at_the_end() {
+        let pat: PatternFile = PatternFile::from_str("#N Gosper glider gun\n#C This was the first gun discovered.\n#C As its name suggests, it was discovered by Bill Gosper.\nx = 36, y = 9, rule = B3/S23\n24bo$22bobo$12b2o6b2o12b2o$11bo3bo4b2o12b2o$2o8bo5bo3b2o$2o8bo3bob2o4b\nobo$10bo5bo7bo$11bo3bo$12b2o!blah\n\nyaddayadda\n").unwrap();
+        assert_eq!(pat.comment_lines.len(), 3);
+        assert_eq!(pat.header_line, HeaderLine{x: 36, y: 9, rule: Some("B3/S23".to_owned())});
+        assert_eq!(pat.pattern.0, "24bo$22bobo$12b2o6b2o12b2o$11bo3bo4b2o12b2o$2o8bo5bo3b2o$2o8bo3bob2o4bobo$10bo5bo7bo$11bo3bo$12b2o!");
+    }
+
+    #[test]
+    fn parse_whole_file_works_vacuum_cleaner() {
+        let pat: PatternFile = PatternFile::from_str("#N Vacuum (gun)\r\n#O Dieter Leithner\r\n#C A true period 46 double-barreled gun found on February 21, 1997.\r\n#C www.conwaylife.com/wiki/index.php?title=Vacuum_(gun)\r\nx = 49, y = 43, rule = b3/s23\r\nb2o23b2o21b$b2o23bo22b$24bobo22b$15b2o7b2o23b$2o13bobo31b$2o13bob2o30b\r\n$16b2o31b$16bo32b$44b2o3b$16bo27b2o3b$16b2o31b$2o13bob2o13bo3bo12b$2o\r\n13bobo13bo5bo7b2o2b$15b2o14bo13b2o2b$31b2o3bo12b$b2o30b3o13b$b2o46b$\r\n33b3o13b$31b2o3bo12b$31bo13b2o2b$31bo5bo7b2o2b$32bo3bo12b2$44b2o3b$44b\r\n2o3b5$37b2o10b$37bobo7b2o$39bo7b2o$37b3o9b$22bobo24b$21b3o25b$21b3o25b\r\n$21bo15b3o9b$25bobo11bo9b$21b2o4bo9bobo9b$16b2o4bo3b2o9b2o10b$15bobo6b\r\no24b$15bo33b$14b2o!").unwrap();
+        assert_eq!(pat.comment_lines.len(), 4);
+        assert_eq!(pat.header_line, HeaderLine{x: 49, y: 43, rule: Some("B3/S23".to_owned().to_lowercase())});
+        assert_eq!(pat.pattern.0, "b2o23b2o21b$b2o23bo22b$24bobo22b$15b2o7b2o23b$2o13bobo31b$2o13bob2o30b$16b2o31b$16bo32b$44b2o3b$16bo27b2o3b$16b2o31b$2o13bob2o13bo3bo12b$2o13bobo13bo5bo7b2o2b$15b2o14bo13b2o2b$31b2o3bo12b$b2o30b3o13b$b2o46b$33b3o13b$31b2o3bo12b$31bo13b2o2b$31bo5bo7b2o2b$32bo3bo12b2$44b2o3b$44b2o3b5$37b2o10b$37bobo7b2o$39bo7b2o$37b3o9b$22bobo24b$21b3o25b$21b3o25b$21bo15b3o9b$25bobo11bo9b$21b2o4bo9bobo9b$16b2o4bo3b2o9b2o10b$15bobo6bo24b$15bo33b$14b2o!");
+        assert_eq!(pat.to_new_bit_grid().unwrap(), BitGrid(vec![
+            vec![0b0110000000000000000000000011000000000000000000000000000000000000],
+            vec![0b0110000000000000000000000010000000000000000000000000000000000000],
+            vec![0b0000000000000000000000001010000000000000000000000000000000000000],
+            vec![0b0000000000000001100000001100000000000000000000000000000000000000],
+            vec![0b1100000000000001010000000000000000000000000000000000000000000000],
+            vec![0b1100000000000001011000000000000000000000000000000000000000000000],
+            vec![0b0000000000000000110000000000000000000000000000000000000000000000],
+            vec![0b0000000000000000100000000000000000000000000000000000000000000000],
+            vec![0b0000000000000000000000000000000000000000000011000000000000000000],
+            vec![0b0000000000000000100000000000000000000000000011000000000000000000],
+            vec![0b0000000000000000110000000000000000000000000000000000000000000000],
+            vec![0b1100000000000001011000000000000010001000000000000000000000000000],
+            vec![0b1100000000000001010000000000000100000100000001100000000000000000],
+            vec![0b0000000000000001100000000000000100000000000001100000000000000000],
+            vec![0b0000000000000000000000000000000110001000000000000000000000000000],
+            vec![0b0110000000000000000000000000000001110000000000000000000000000000],
+            vec![0b0110000000000000000000000000000000000000000000000000000000000000],
+            vec![0b0000000000000000000000000000000001110000000000000000000000000000],
+            vec![0b0000000000000000000000000000000110001000000000000000000000000000],
+            vec![0b0000000000000000000000000000000100000000000001100000000000000000],
+            vec![0b0000000000000000000000000000000100000100000001100000000000000000],
+            vec![0b0000000000000000000000000000000010001000000000000000000000000000],
+            vec![0b0000000000000000000000000000000000000000000000000000000000000000],
+            vec![0b0000000000000000000000000000000000000000000011000000000000000000],
+            vec![0b0000000000000000000000000000000000000000000011000000000000000000],
+            vec![0b0000000000000000000000000000000000000000000000000000000000000000],
+            vec![0b0000000000000000000000000000000000000000000000000000000000000000],
+            vec![0b0000000000000000000000000000000000000000000000000000000000000000],
+            vec![0b0000000000000000000000000000000000000000000000000000000000000000],
+            vec![0b0000000000000000000000000000000000000110000000000000000000000000],
+            vec![0b0000000000000000000000000000000000000101000000011000000000000000],
+            vec![0b0000000000000000000000000000000000000001000000011000000000000000],
+            vec![0b0000000000000000000000000000000000000111000000000000000000000000],
+            vec![0b0000000000000000000000101000000000000000000000000000000000000000],
+            vec![0b0000000000000000000001110000000000000000000000000000000000000000],
+            vec![0b0000000000000000000001110000000000000000000000000000000000000000],
+            vec![0b0000000000000000000001000000000000000111000000000000000000000000],
+            vec![0b0000000000000000000000000101000000000001000000000000000000000000],
+            vec![0b0000000000000000000001100001000000000101000000000000000000000000],
+            vec![0b0000000000000000110000100011000000000110000000000000000000000000],
+            vec![0b0000000000000001010000001000000000000000000000000000000000000000],
+            vec![0b0000000000000001000000000000000000000000000000000000000000000000],
+            vec![0b0000000000000011000000000000000000000000000000000000000000000000]]));
+    }
+}

--- a/libconway/src/universe.rs
+++ b/libconway/src/universe.rs
@@ -1,0 +1,2507 @@
+/*  Copyright 2016-2019 the Conwayste Developers.
+ *
+ *  This file is part of libconway.
+ *
+ *  libconway is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  libconway is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with libconway.  If not, see <http://www.gnu.org/licenses/>. */
+
+use std::{char, cmp, fmt};
+
+use crate::error::{ConwayError, ConwayResult};
+use crate::grids::{BitGrid, BitOperation, CharGrid};
+use crate::rle::{Pattern, NO_OP_CHAR};
+
+/// Builder paradigm to create `Universe` structs with default values.
+pub struct BigBang {
+    width:           usize,
+    height:          usize,
+    is_server:       bool,
+    history:         usize,
+    num_players:     usize,
+    player_writable: Vec<Region>,
+    fog_radius:      usize
+}
+
+/// Player builder
+pub struct PlayerBuilder {
+    writable_region: Region,
+}
+
+impl PlayerBuilder {
+    /// Returns a new PlayerBuilder.
+    pub fn new(region: Region) -> PlayerBuilder {
+        PlayerBuilder {
+            writable_region: region,
+        }
+    }
+}
+
+/// This is a builder for `Universe` structs.
+/// 
+/// # Examples
+/// 
+/// ```
+/// let mut uni = conway::universe::BigBang::new()
+///                 .width(512)      // optionally override width
+///                 .height(256)     // optionally override height
+///                 .fog_radius(16)  // optionally override fog radius
+///                 .birth()
+///                 .unwrap();
+/// ```
+impl BigBang {
+    /// Creates and returns a new builder.
+    pub fn new() -> BigBang {
+        BigBang {
+            width: 256,
+            height: 128,
+            is_server: true,
+            history: 16,
+            num_players: 0,
+            player_writable: vec![],
+            fog_radius: 6,
+        }
+    }
+
+    /// Update the total number of columns for this Universe
+    pub fn width(mut self, new_width: usize) -> BigBang {
+        self.width = new_width;
+        self
+    }
+
+    /// Update the total number of rows for this Universe
+    pub fn height(mut self, new_height: usize) -> BigBang {
+        self.height = new_height;
+        self
+    }
+
+    /// Determines whether we are running a Server or a Client.
+    /// * `true` - Server
+    /// * `false` - Client
+    pub fn server_mode(mut self, is_server: bool) -> BigBang {
+        self.is_server = is_server;
+        self
+    }
+
+    /// This records the number of generations that will be buffered.
+    pub fn history(mut self, history_depth: usize) -> BigBang {
+        self.history = history_depth;
+        self
+    }
+
+    /// This will add a single player to the list of players. Each player is responsible for
+    /// providing their details through the PlayerBuilder.
+    /// 
+    /// # Panics
+    /// 
+    /// Panics if, after adding this player, the length of the internal `player_writable` vector
+    /// does not match the number of players.
+    pub fn add_player(mut self, new_player: PlayerBuilder) -> BigBang {
+        self.num_players += 1;
+        self.player_writable.push(new_player.writable_region);
+        assert_eq!(self.num_players, self.player_writable.len()); // These should always match up!
+        self
+    }
+
+    /// Adds a vector of players using `add_player` method.
+    /// 
+    /// # Panics
+    /// 
+    /// Panics if, after adding these players, the length of the internal `player_writable` vector
+    /// does not match the number of players.
+    pub fn add_players(mut self, new_player_list: Vec<PlayerBuilder>) -> BigBang {
+        for player in new_player_list {
+            self = self.add_player(player);
+        }
+        self
+    }
+
+    /// Updates the fog to a new visibility radius.
+    /// This is used to grant players visibility into the fog when
+    /// they are competing against other players and they create
+    /// cells outside of their own writiable regions.
+    pub fn fog_radius(mut self, new_radius: usize) -> BigBang {
+        self.fog_radius = new_radius;
+        self
+    }
+
+    /// "Gives life to the universe and the first moment of time."
+    /// Creates a Universe which can then CGoL process generations.
+    /// 
+    /// # Errors
+    /// 
+    /// - if `width` or `height` are not positive, or if `width` is not a multiple of 64.
+    /// - if `fog_radius` is not positive.
+    /// - if `history` is not positive.
+    pub fn birth(&self) -> ConwayResult<Universe> {
+        let universe = Universe::new(
+            self.width,
+            self.height,
+            self.is_server,        // if false, allow receiving generation 1 as GenStateDiff
+            self.history,
+            self.num_players,      // number of players in the game (player numbers are 0-based)
+            self.player_writable.clone(), // writable region (indexed by player_id)
+            self.fog_radius,       // fog radius provides visiblity outside of writable regions
+        );
+        universe
+    }
+}
+
+
+/// Represents a wrapping universe in Conway's game of life.
+pub struct Universe {
+    width:           usize,
+    height:          usize,
+    width_in_words:  usize,                     // width in u64 elements, _not_ width in cells!
+    generation:      usize,                     // current generation (1-based)
+    num_players:     usize,                     // number of players in the game (player numbers are 0-based)
+    state_index:     usize,                     // index of GenState for current generation within gen_states
+    gen_states:      Vec<GenState>,             // circular buffer of generational states
+    player_writable: Vec<Region>,               // writable region (indexed by player_id)
+    fog_radius:      usize,
+    fog_circle:      BitGrid,
+}
+
+
+// Describes the state of the universe for a particular generation
+// This includes any cells alive, known, and each player's own gen states
+// for this current session
+#[derive(Debug, Clone, PartialEq)]
+pub struct GenState {
+    gen_or_none:   Option<usize>,        // Some(generation number) (redundant info); if None, this is an unused buffer
+    cells:         BitGrid,              // 1 = cell is known to be Alive
+    wall_cells:    BitGrid,              // 1 = is a wall cell (should this just be fixed for the universe?)
+    known:         BitGrid,              // 1 = cell is known (always 1 if this is server)
+    player_states: Vec<PlayerGenState>,  // player-specific info (indexed by player_id)
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GenStateDiff {
+    pub gen0:    usize,         // must be >= 0; zero means diff is based off of the beginning of time
+    pub gen1:    usize,         // must be >= 1
+    pub pattern: Pattern,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct PlayerGenState {
+    cells:     BitGrid,   // cells belonging to this player (if 1 here, must be 1 in GenState cells)
+    fog:       BitGrid,   // cells that are currently invisible to the player
+}
+
+
+#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Debug)]
+pub enum CellState {
+    Dead,
+    Alive(Option<usize>),    // Some(player_number) or alive but not belonging to any player
+    Wall,
+    Fog,
+}
+
+impl CellState {
+    /// Convert this `CellState` to a `char`. When the state is `Alive(None)` or `Dead`, this will
+    /// match what would be found in a .rle file. `Wall`, `Alive(Some(player_id))`, and `Fog` are
+    /// unsupported in vanilla CGoL, and thus are not part of the [RLE
+    /// specification](http://www.conwaylife.com/wiki/Run_Length_Encoded).
+    /// 
+    /// # Panics
+    /// 
+    /// Panics if `player_id` is not less than 23, since we map IDs 0 through 22 to uppercase
+    /// letters A through V. W is not usable since it represents a wall cell.
+    pub fn to_char(self) -> char {
+        match self {
+            CellState::Alive(Some(player_id)) => {
+                if player_id >= 23 {
+                    panic!("Player IDs must be less than 23 to be converted to chars");
+                }
+                char::from_u32(player_id as u32 + 65).unwrap()
+            }
+            CellState::Alive(None) => 'o',
+            CellState::Dead        => 'b',
+            CellState::Wall        => 'W',
+            CellState::Fog         => '?',
+        }
+    }
+
+    // TODO: doc comment
+    pub fn from_char(ch: char) -> Option<Self> {
+        match ch {
+            'o' => Some(CellState::Alive(None)),
+            'b' => Some(CellState::Dead),
+            'W' => Some(CellState::Wall),
+            '?' => Some(CellState::Fog),
+            'A'..='V' => {
+                Some(CellState::Alive(Some(u32::from(ch) as usize - 65)))
+            }
+            _ => {
+                None
+            }
+        }
+    }
+}
+
+
+impl GenState {
+    /// Sets the state of a cell, with minimal checking.  It doesn't support setting
+    /// `CellState::Fog`.
+    /// 
+    /// # Panics
+    /// 
+    /// Panics if an attempt is made to set an unknown cell.
+    pub fn set_unchecked(&mut self, col: usize, row: usize, new_state: CellState) {
+        let word_col = col/64;
+        let shift = 63 - (col & (64 - 1)); // translate literal col (ex: 134) to bit index in word_col
+        let mask  = 1 << shift;     // cell to set
+
+        // panic if not known
+        let known_cell_word = self.known[row][word_col];
+        if known_cell_word & mask == 0 {
+            panic!("Tried to set unknown cell at ({}, {})", col, row);
+        }
+
+        // clear all player cell bits, so that this cell is unowned by any player (we'll set
+        // ownership further down)
+        {
+            for player_id in 0 .. self.player_states.len() {
+                let ref mut grid = self.player_states[player_id].cells;
+                grid.modify_bits_in_word(row, word_col, mask, BitOperation::Clear);
+            }
+        }
+
+        let cells = &mut self.cells;
+        let walls  = &mut self.wall_cells;
+        match new_state {
+            CellState::Dead => {
+                cells.modify_bits_in_word(row, word_col, mask, BitOperation::Clear);
+                walls.modify_bits_in_word(row, word_col, mask, BitOperation::Clear);
+            }
+            CellState::Alive(opt_player_id) => {
+                cells.modify_bits_in_word(row, word_col, mask, BitOperation::Set);
+                walls.modify_bits_in_word(row, word_col, mask, BitOperation::Clear);
+
+                if let Some(player_id) = opt_player_id {
+                    let ref mut player = self.player_states[player_id];
+                    player.cells.modify_bits_in_word(row, word_col, mask, BitOperation::Set);
+                    player.fog.modify_bits_in_word(row, word_col, mask, BitOperation::Clear);
+                }
+            }
+            CellState::Wall => {
+                cells.modify_bits_in_word(row, word_col, mask, BitOperation::Clear);
+                walls.modify_bits_in_word(row, word_col, mask, BitOperation::Set);
+            }
+            _ => unimplemented!()
+        }
+    }
+
+    /// Copies from `src` BitGrid to this GenState as the player specified by `opt_player_id`,
+    /// unless `opt_player_id` is `None`. This is an "or" operation, so any existing alive cells
+    /// are retained, though they may change ownership.  Walls, however, are preserved. Fog is
+    /// cleared on a cell-by-cell basis, rather than using fog radius.
+    ///
+    /// IMPORTANT: dst_region should not extend beyond GenState, nor beyond player's writable
+    /// region. Caller may ensure this using Region::intersection.
+    ///
+    /// The top-left cell (that is, the cell at `(0,0)`) in `src` gets written to `(dst_region.top(),
+    /// dst_region.left())` in `dst`.
+    pub fn copy_from_bit_grid(&mut self, src: &BitGrid, dst_region: Region, opt_player_id: Option<usize>) {
+
+        BitGrid::copy(src, &mut self.cells, dst_region);
+
+        if let Some(player_id) = opt_player_id {
+
+            BitGrid::copy(src, &mut self.player_states[player_id].cells, dst_region);
+
+            for row in dst_region.top()..=dst_region.bottom() {
+                let row = row as usize;
+
+                // This actually can operate on cells to the left and right of dst_region, but that
+                // shouldn't matter, since it's enforcing an invariant that should already be true.
+                for word_col in (dst_region.left()/64) ..= (dst_region.right()/64) {
+                    let word_col = word_col as usize;
+
+                    // for each wall bit that's 1, clear it in player's cells
+                    self.player_states[player_id].cells[row][word_col] &= !self.wall_cells[row][word_col];
+                    // for each player cell bit that's 1, clear it in player's fog
+                    self.player_states[player_id].fog[row][word_col] &= !self.player_states[player_id].cells[row][word_col];
+                }
+            }
+        }
+
+        // on the rows in dst_region, for each wall bit that's 1, clear it in dst.cells
+        for row in dst_region.top()..=dst_region.bottom() {
+            let row = row as usize;
+
+            for word_col in (dst_region.left()/64) ..= (dst_region.right()/64) {
+                let word_col = word_col as usize;
+
+                self.cells[row][word_col] &= !self.wall_cells[row][word_col];
+            }
+        }
+    }
+
+    /// Creates a "diff" RLE pattern (contained within GenStateDiff) showing the changes present in
+    /// `new`, using `self` as a base (that is, `self` is assumed to be "old"). If `visibility` is
+    /// not `None`, only the changes visible to specified player will be recorded.
+    ///
+    /// The `gen0` field of the result will be equal to `self.gen_or_none.unwrap()` and the `gen1`
+    /// field will be equal to `new.gen_or_none.unwrap()`.
+    ///
+    /// When `visibility` is `Some(player_id)`, then for all possible `gs0` and `gs1` where
+    /// `player_id` is valid and dimensions match, the following should be true:
+    ///
+    ///  ```no_run
+    ///  # use conway::universe::GenState;
+    ///  # fn do_eet(gs0: GenState, gs1: GenState, mut new_gs: GenState, visibility: Option<usize>) {
+    ///  let gsdiff = gs0.diff(&gs1, visibility);
+    ///  gsdiff.pattern.to_grid(&mut new_gs, visibility).unwrap();
+    ///  assert_eq!(new_gs, gs1);
+    ///  # }
+    ///  ```
+    ///
+    /// Panics:
+    ///
+    /// * This will panic if either `self.gen_or_none` or `new.gen_or_none` is `None`.
+    /// * This will panic if the lengths of the `player_states` vectors do not match.
+    /// * This will panic if the dimensions of the grids do not match.
+    pub fn diff(&self, new: &GenState, visibility: Option<usize>) -> GenStateDiff {
+        if self.height() != new.height() || self.width() != new.width() {
+            panic!("Dimensions do not match: {}x{} vs {}x{}", self.width(), self.height(), new.width(), new.height());
+        }
+
+        let self_gen = self.gen_or_none.unwrap();
+        let new_gen = new.gen_or_none.unwrap();
+
+        if self.player_states.len() != new.player_states.len() {
+            panic!("Player state vectors do not match");
+        }
+
+        let pair = GenStatePair {
+            gen_state0: &self,
+            gen_state1: &new,
+        };
+        let pattern = pair.to_pattern(visibility);
+
+        GenStateDiff {
+            gen0: self_gen,
+            gen1: new_gen,
+            pattern,
+        }
+    }
+
+    /// Zeroes out all bit grids. Note: this means fog is cleared for all players.
+    pub fn clear(&mut self) {
+        let region = Region::new(0, 0, self.width(), self.height());
+        self.cells.modify_region(region, BitOperation::Clear);
+        self.known.modify_region(region, BitOperation::Clear);
+        self.wall_cells.modify_region(region, BitOperation::Clear);
+
+        for player_id in 0..self.player_states.len() {
+            let p = &mut self.player_states[player_id];
+            p.cells.modify_region(region, BitOperation::Clear);
+            p.fog.modify_region(region, BitOperation::Clear);
+        }
+    }
+
+    pub fn copy(&self, dest: &mut GenState) {
+        let region = Region::new(0, 0, self.width(), self.height());
+        BitGrid::copy(&self.cells, &mut dest.cells, region);
+        BitGrid::copy(&self.known, &mut dest.known, region);
+        BitGrid::copy(&self.wall_cells, &mut dest.wall_cells, region);
+
+        for player_id in 0..dest.player_states.len() {
+            BitGrid::copy(&self.player_states[player_id].cells, &mut dest.player_states[player_id].cells, region);
+            BitGrid::copy(&self.player_states[player_id].fog, &mut dest.player_states[player_id].fog, region);
+        }
+    }
+}
+
+impl CharGrid for GenState {
+    /// Width in cells
+    fn width(&self) -> usize {
+        self.cells.width()
+    }
+
+    /// Height in cells
+    fn height(&self) -> usize {
+        self.cells.height()
+    }
+
+    #[inline]
+    fn write_at_position(&mut self, col: usize, row: usize, ch: char, visibility: Option<usize>) {
+        if !GenState::is_valid(ch) {
+            panic!(format!("char {:?} is invalid for this CharGrid", ch));
+        }
+        let word_col = col/64;
+        let shift = 63 - (col & (64 - 1));
+        // cells
+        match ch {
+            'b' | 'W' | '?' => {
+                self.cells[row][word_col] &= !(1 << shift)
+            }
+            'o' | 'A'..='V' => {
+                self.cells[row][word_col] |=   1 << shift
+            }
+            _ => unreachable!()
+        }
+        // wall cells
+        match ch {
+            'W' => {
+                self.wall_cells[row][word_col] |=   1 << shift
+            }
+            'b' | 'o' | 'A'..='V' | '?' => {
+                self.wall_cells[row][word_col] &= !(1 << shift)
+            }
+            _ => unreachable!()
+        }
+        // player_states
+        if ch == '?' {
+            if visibility.is_none() {
+                // I expect that only clients will read a pattern containing fog, and clients will
+                // never have visibility set to None.
+                panic!("cannot write fog when no player_id is specified");
+            }
+            let player_id = visibility.unwrap();
+            // only set fog bit for specified player
+            self.player_states[player_id].fog[row][word_col] |= 1 << shift;
+        } else {
+            self.known[row][word_col] |= 1 << shift;    // known
+            if let Some(player_id) = visibility {
+                // only clear fog bit for specified player
+                self.player_states[player_id].fog[row][word_col] &= !(1 << shift);
+            } else {
+                // clear fog bit for all players
+                for i in 0 .. self.player_states.len() {
+                    self.player_states[i].fog[row][word_col] &= !(1 << shift);
+                }
+            }
+            // clear all player's cells
+            for i in 0 .. self.player_states.len() {
+                self.player_states[i].cells[row][word_col] &= !(1 << shift);
+            }
+            // if 'A'..='V', set that player's cells
+            if ch >= 'A' && ch <= 'V' {
+                let p_id = ch as usize - 'A' as usize;
+                self.player_states[p_id].cells[row][word_col] |= 1 << shift; // can panic if p_id out of range
+            }
+        }
+    }
+
+    #[inline]
+    fn is_valid(ch: char) -> bool {
+        match ch {
+            'o' | 'b' | 'A'..='W' | '?' => true,
+            NO_OP_CHAR => true,
+            _ => false
+        }
+    }
+
+    /// Given a starting cell at `(col, row)`, get the character at that cell, and the number of
+    /// contiguous identical cells considering only this cell and the cells to the right of it.
+    /// This is intended for exporting to RLE.
+    ///
+    /// The `visibility` parameter, if not `None`, is used to generate a run as observed by a
+    /// particular player.
+    ///
+    /// # Returns
+    ///
+    /// `(run_length, ch)`
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `col`, `row`, or `visibility` (`Some(player_id)`) are out of bounds.
+    fn get_run(&self, col: usize, row: usize, visibility: Option<usize>) -> (usize, char) {
+        let mut min_run = self.width() - col;
+
+        let (known_run, known_ch) = self.known.get_run(col, row, None);
+        if known_run < min_run { min_run = known_run; }
+        if known_ch == 'b' {
+            return (min_run, CellState::Fog.to_char());
+        }
+
+        if let Some(player_id) = visibility {
+            let (fog_run, fog_ch) = self.player_states[player_id].fog.get_run(col, row, None);
+            if fog_run < min_run { min_run = fog_run; }
+            if fog_ch == 'o' {
+                return (min_run, CellState::Fog.to_char());
+            }
+        }
+
+        let (cell_run, cell_ch) = self.cells.get_run(col, row, None);
+        if cell_run < min_run { min_run = cell_run; }
+
+        let (wall_run, wall_ch) = self.wall_cells.get_run(col, row, None);
+        if wall_run < min_run { min_run = wall_run; }
+
+        if cell_ch == 'o' {
+            for player_id in 0 .. self.player_states.len() {
+                let (player_cell_run, player_cell_ch) = self.player_states[player_id].cells.get_run(col, row, None);
+                if player_cell_run < min_run { min_run = player_cell_run; }
+                if player_cell_ch == 'o' {
+                    let owned_ch = CellState::Alive(Some(player_id)).to_char();
+                    return (min_run, owned_ch);
+                }
+            }
+            return (min_run, CellState::Alive(None).to_char());
+        }
+        if wall_ch == 'o' {
+            return (min_run, CellState::Wall.to_char());
+        } else {
+            return (min_run, CellState::Dead.to_char());
+        }
+    }
+}
+
+
+/// This internal struct is only needed so we can implement CharGrid::to_pattern. It's a little silly...
+struct GenStatePair<'a,'b> {
+    gen_state0: &'a GenState,
+    gen_state1: &'b GenState,
+}
+
+
+impl<'a,'b> CharGrid for GenStatePair<'a,'b> {
+    /// Width in cells
+    fn width(&self) -> usize {
+        self.gen_state0.width()
+    }
+
+    /// Height in cells
+    fn height(&self) -> usize {
+        self.gen_state0.height()
+    }
+
+    fn write_at_position(&mut self, _col: usize, _row: usize, _ch: char, _visibility: Option<usize>) {
+        unimplemented!("This is a read-only struct!");
+    }
+
+    /// Is `ch` a valid character?
+    fn is_valid(ch: char) -> bool {
+        if ch == NO_OP_CHAR {
+            return true;
+        }
+        GenState::is_valid(ch)
+    }
+
+    /// Given a starting cell at `(col, row)`, get the character at that cell, and the number of
+    /// contiguous identical cells considering only this cell and the cells to the right of it.
+    /// This is intended for exporting to RLE.
+    ///
+    /// The `visibility` parameter, if not `None`, is used to generate a run as observed by a
+    /// particular player.
+    ///
+    /// # Returns
+    ///
+    /// `(run_length, ch)`
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if `col`, `row`, or `visibility` (`Some(player_id)`) are out of bounds.
+    fn get_run(&self, mut col: usize, row: usize, visibility: Option<usize>) -> (usize, char) {
+        let (run0, ch0) = self.gen_state0.get_run(col, row, visibility);
+        let (run1, ch1) = self.gen_state1.get_run(col, row, visibility);
+        let ch;
+        if ch0 == ch1 {
+            ch = NO_OP_CHAR;  // no change
+        } else {
+            ch = ch1;         // change here; return the new character
+        }
+        let mut run = cmp::min(run0, run1);
+        let mut total_run = run;
+        if ch == NO_OP_CHAR {
+            loop {
+                col += run;
+                if col >= self.width() {
+                    break;
+                }
+                let (run0, ch0) = self.gen_state0.get_run(col, row, visibility);
+                let (run1, ch1) = self.gen_state1.get_run(col, row, visibility);
+                if ch0 != ch1 {
+                    break;
+                }
+                run = cmp::min(run0, run1);
+                total_run += run;
+            }
+        }
+        (total_run, ch)
+    }
+}
+
+
+impl fmt::Display for Universe {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let cells = &self.gen_states[self.state_index].cells;
+        let wall  = &self.gen_states[self.state_index].wall_cells;
+        let known = &self.gen_states[self.state_index].known;
+        for row_idx in 0 .. self.height {
+            for col_idx in 0 .. self.width_in_words {
+                let cell_cen  = cells[row_idx][col_idx];
+                let wall_cen  = wall [row_idx][col_idx];
+                let known_cen = known[row_idx][col_idx];
+                let mut s = String::with_capacity(64);
+                for shift in (0..64).rev() {
+                    if (known_cen>>shift)&1 == 0 {
+                        s.push('?');
+                    } else if (cell_cen>>shift)&1 == 1 {
+                        let mut is_player = false;
+                        for player_id in 0 .. self.num_players {
+                            let player_word = self.gen_states[self.state_index].player_states[player_id].cells[row_idx][col_idx];
+                            if (player_word>>shift)&1 == 1 {
+                                s.push(char::from_u32(player_id as u32 + 65).unwrap());
+                                is_player = true;
+                                break;
+                            }
+                        }
+                        if !is_player { s.push('*'); }
+                    } else if (wall_cen>>shift)&1 == 1 {
+                        s.push('W');
+                    } else {
+                        s.push(' ');
+                    }
+                }
+                write!(f, "{}", s)?;
+            }
+            write!(f, "\n")?;
+        }
+        Ok(())
+    }
+}
+
+
+impl Universe {
+
+    /// Gets a `CellState` enum for cell at (`col`, `row`).
+    /// 
+    /// # Panics
+    /// 
+    /// Panics if `row` or `col` are out of range.
+    pub fn get_cell_state(&mut self, col: usize, row: usize, opt_player_id: Option<usize>) -> CellState {
+        let gen_state = &mut self.gen_states[self.state_index];
+        let word_col = col/64;
+        let shift = 63 - (col & (64 - 1)); // translate literal col (ex: 134) to bit index in word_col
+        let mask  = 1 << shift;     // cell to set
+
+        if let Some(player_id) = opt_player_id {
+            let cell = (gen_state.player_states[player_id].cells[row][word_col] & mask) >> shift;
+            if cell == 1 {CellState::Alive(opt_player_id)} else {CellState::Dead}
+        }
+        else {
+            let cell = (gen_state.cells[row][word_col] & mask) >> shift;
+            if cell == 1 {CellState::Alive(None)} else {CellState::Dead}
+        }
+    }
+
+
+    /// Sets the state of a cell in the latest generation, with minimal checking.  It doesn't
+    /// support setting `CellState::Fog`.
+    /// 
+    /// # Panics
+    /// 
+    /// Panics if an attempt is made to set an unknown cell.
+    pub fn set_unchecked(&mut self, col: usize, row: usize, new_state: CellState) {
+        self.gen_states[self.state_index].set_unchecked(col, row, new_state)
+    }
+
+
+    /// Checked set - check for:
+    /// * current cell state (can't change wall)
+    /// * player writable region
+    /// * fog
+    /// * if current cell is alive, player_id matches player_id argument
+    ///
+    /// If any of the above checks fail, do nothing.
+    ///
+    /// # Panics
+    ///
+    /// Panic if player_id inside CellState does not match player_id argument.
+    pub fn set(&mut self, col: usize, row: usize, new_state: CellState, player_id: usize) {
+
+        {
+            let gen_state = &mut self.gen_states[self.state_index];
+            let word_col = col/64;
+            let shift = 63 - (col & (64 - 1));
+            let mask  = 1 << shift;     // bit to set for cell represented by (row,col)
+
+            let cells = &mut gen_state.cells;
+            let wall  = &mut gen_state.wall_cells;
+            let cells_word = cells[row][word_col];
+            let walls_word = wall [row][word_col];
+
+            if walls_word & mask > 0 {
+                return;
+            }
+
+            if !self.player_writable[player_id].contains(col as isize, row as isize) { return;
+            }
+
+            if gen_state.player_states[player_id].fog[row][word_col] & mask > 0 {
+                return;
+            }
+
+            // If the current cell is alive but not owned by this player, do nothing
+            if cells_word & mask > 0 && gen_state.player_states[player_id].cells[row][word_col] & mask == 0 {
+                return;
+            }
+
+            if let CellState::Alive(Some(new_state_player_id)) = new_state {
+                if new_state_player_id != player_id {
+                    panic!("A player cannot set the cell state of another player");
+                }
+            }
+        }
+
+        self.set_unchecked(col, row, new_state)
+    }
+
+
+    /// Switches any non-dead state to CellState::Dead.
+    /// Switches CellState::Dead to CellState::Alive(opt_player_id) and clears fog for that player,
+    /// if any.
+    ///
+    /// This operation works in three steps:
+    ///  1. Toggle alive/dead cell in the current generation state cell grid
+    ///  2. Clear all players' cell
+    ///  3. If general cell transitioned Dead->Alive, then set requested player's cell
+    ///
+    /// The new value of the cell is returned.
+    pub fn toggle_unchecked(&mut self, col: usize, row: usize, opt_player_id: Option<usize>) -> CellState {
+        let word_col = col/64;
+        let shift = 63 - (col & (64 - 1));
+        let mask = 1 << shift;
+
+        let word =
+        {
+            let cells = &mut self.gen_states[self.state_index].cells;
+            cells.modify_bits_in_word(row, word_col, mask, BitOperation::Toggle);
+            cells[row][word_col]
+        };
+
+        // Cell transitioned Dead -> Alive 
+        let next_cell = (word & mask) > 0;
+
+        // clear all player cell bits
+        for player_id in 0 .. self.num_players {
+            let ref mut player_cells = self.gen_states[self.state_index].player_states[player_id].cells;
+            player_cells.modify_bits_in_word(row, word_col, mask, BitOperation::Clear);
+        }
+
+        if next_cell {
+            // set this player's cell bit, if needed, and clear fog
+            if let Some(player_id) = opt_player_id {
+                let ref mut player = self.gen_states[self.state_index].player_states[player_id];
+                player.cells.modify_bits_in_word(row, word_col, mask, BitOperation::Set);
+                player.fog.modify_bits_in_word(row, word_col, mask, BitOperation::Clear);
+            }
+
+            CellState::Alive(opt_player_id)
+        } else {
+            CellState::Dead
+        }
+    }
+
+
+    /// Checked toggle - switch between CellState::Alive and CellState::Dead.
+    /// 
+    /// # Errors
+    /// 
+    /// It is an error to toggle outside player's writable area, or to toggle a wall or an unknown cell.
+    pub fn toggle(&mut self, col: usize, row: usize, player_id: usize) -> ConwayResult<CellState> {
+        use ConwayError::*;
+        if !self.player_writable[player_id].contains(col as isize, row as isize) {
+            return Err(AccessDenied{reason: format!("outside writable area for player {}: col={}, row={}",
+                                                    player_id, col, row)});
+        }
+
+        let word_col = col/64;
+        let shift = 63 - (col & (64 - 1));
+        {
+            let wall  = &self.gen_states[self.state_index].wall_cells;
+            let known = &self.gen_states[self.state_index].known;
+            if (wall[row][word_col] >> shift) & 1 == 1 {
+                return Err(AccessDenied{reason: format!("cannot write to wall cell: col={}, row={}", col, row)});
+            }
+            if (known[row][word_col] >> shift) & 1 == 0 {
+                return Err(AccessDenied{reason: format!("not a known cell for player {}: col={}, row={}",
+                                                        player_id, col, row)});
+            }
+        }
+        Ok(self.toggle_unchecked(col, row, Some(player_id)))
+    }
+
+
+    /// Instantiate a new blank universe with the given width and height, in cells.
+    /// The universe is at generation 1.
+    /// 
+    /// **Note**: it is easier to use `BigBang` to build a `Universe`, as that has default values
+    /// that can be overridden as needed.
+    pub fn new(width:           usize,
+               height:          usize,
+               is_server:       bool,
+               history:         usize,
+               num_players:     usize,
+               player_writable: Vec<Region>,
+               fog_radius:      usize) -> ConwayResult<Universe> {
+        use ConwayError::*;
+        if height == 0 {
+            return Err(InvalidData{reason:"Height must be positive".to_owned()});
+        }
+
+        let width_in_words = width/64;
+        if width % 64 != 0 {
+            return Err(InvalidData{reason: "Width must be a multiple of 64".to_owned()});
+        } else if width == 0 {
+            return Err(InvalidData{reason: "Width must be positive".to_owned()});
+        }
+
+        if history == 0 {
+            return Err(InvalidData{reason: "History must be positive".to_owned()});
+        }
+
+        if fog_radius == 0 {
+            return Err(InvalidData{reason: "Fog radius must be positive".to_owned()});
+        }
+
+        // Initialize all generational states with the default appropriate bitgrids
+        let mut gen_states = Vec::new();
+        for i in 0 .. history {
+            let mut player_states = Vec::new();
+            for player_id in 0 .. num_players {
+
+                let mut pgs = PlayerGenState {
+                    cells:     BitGrid::new(width_in_words, height),
+                    fog:       BitGrid::new(width_in_words, height),
+                };
+
+                // unless writable region, the whole grid is player fog
+                pgs.fog.modify_region(Region::new(0, 0, width, height), BitOperation::Set);
+
+                // clear player fog on writable regions
+                pgs.fog.modify_region(player_writable[player_id], BitOperation::Clear);
+
+                player_states.push(pgs);
+            }
+
+            // Known cells describe what the current operative (player, server)
+            // visibility reaches. For example, a Server has total visibility as
+            // it needs to know all.
+            let mut known = BitGrid::new(width_in_words, height);
+            
+            if is_server && i == 0 {
+                // could use modify_region but it's much cheaper this way
+                for y in 0 .. height {
+                    for x in 0 .. width_in_words {
+                        known[y][x] = u64::max_value();   // if server, all cells are known
+                    }
+                }
+            }
+
+            gen_states.push(GenState {
+                gen_or_none:   if i == 0 && is_server { Some(1) } else { None },
+                cells:         BitGrid::new(width_in_words, height),
+                wall_cells:    BitGrid::new(width_in_words, height),
+                known:         known,
+                player_states: player_states,
+            });
+        }
+
+        let mut uni = Universe {
+            width:           width,
+            height:          height,
+            width_in_words:  width_in_words,
+            generation:      1,
+            num_players:     num_players,
+            state_index:     0,
+            gen_states:      gen_states,
+            player_writable: player_writable,
+            // TODO: it's not very rusty to have uninitialized stuff (use Option<FogInfo> instead)
+            fog_radius:      fog_radius,      // uninitialized
+            fog_circle:      BitGrid(vec![]), // uninitialized
+        };
+        uni.generate_fog_circle_bitmap();
+        Ok(uni)
+    }
+
+
+    /// Pre-computes a "fog circle" bitmap of given cell radius to be saved to the `Universe`
+    /// struct. This bitmap is used for clearing fog around a player's cells.
+    ///
+    /// The bitmap has 0 bits inside the circle radius, and 1 bits elsewhere. The bitmap has
+    /// width and height such that the circle's height exactly fits, and the left edge of the
+    /// circle touches the left edge of the bitmap. Therefore, before masking out the fog, it
+    /// must be shifted up and to the left by `fog_radius - 1` cells.
+    ///
+    /// Notable `fog_radius` values:
+    /// * 1: This does not clear any fog around the cell
+    /// * 2: This clears the cell and its neighbors
+    /// * 4: Smallest radius at which the cleared fog region is not a square
+    /// * 8: Smallest radius at which the cleared fog region is neither square nor octagon
+    fn generate_fog_circle_bitmap(&mut self) {
+        let fog_radius = self.fog_radius;
+        let height = 2*fog_radius - 1;
+        let word_width = (height - 1) / 64 + 1;
+        self.fog_circle = BitGrid::new(word_width, height);
+
+        // Parts outside the circle must be 1, so initialize with 1 first, then draw the
+        // filled-in circle, containing 0 bits.
+        for y in 0 .. height {
+            for x in 0 .. word_width {
+                self.fog_circle[y][x] = u64::max_value();
+            }
+        }
+
+        // calculate the center bit coordinates
+        let center_x = (fog_radius - 1) as isize;
+        let center_y = (fog_radius - 1) as isize;
+        // algebra!
+        for y in 0 .. height {
+            for bit_x in 0 .. word_width*64 {
+                let shift = 63 - (bit_x & 63);
+                let mask = 1<<shift;
+                // calculate x_delta and y_delta
+                let x_delta = isize::abs(center_x - bit_x as isize) as usize;
+                let y_delta = isize::abs(center_y - y as isize) as usize;
+                if x_delta*x_delta + y_delta*y_delta < fog_radius*fog_radius {
+                    self.fog_circle[y][bit_x/64] &= !mask;
+                }
+            }
+        }
+    }
+
+
+    /// Get the latest generation number (1-based).
+    pub fn latest_gen(&self) -> usize {
+        assert!(self.generation != 0);
+        self.generation
+    }
+
+    fn next_single_gen(nw: u64, n: u64, ne: u64, w: u64, center: u64, e: u64, sw: u64, s: u64, se: u64) -> u64 {
+        let a  = (nw     << 63) | (n      >>  1);
+        let b  =  n;
+        let c  = (n      <<  1) | (ne     >> 63);
+        let d  = (w      << 63) | (center >> 1);
+        let y6 = center;
+        let e  = (center <<  1) | (e      >> 63);
+        let f  = (sw     << 63) | (s      >>  1);
+        let g  =  s;
+        let h  = (s      <<  1) | (se     >> 63);
+
+        // full adder #1
+        let b_xor_c = b^c;
+        let y1 = (a & b_xor_c) | (b & c);
+        let y2 = a ^ b_xor_c;
+
+        // full adder #2
+        let e_xor_f = e^f;
+        let c2 = (d & e_xor_f) | (e & f);
+        let s2 = d ^ e_xor_f;
+
+        // half adder #1
+        let c3 = g & h;
+        let s3 = g ^ h;
+
+        // half adder #2
+        let c4 = s2 & s3;
+        let y5 = s2 ^ s3;
+
+        // full adder #3
+        let c2_xor_c3 = c2 ^ c3;
+        let y3 = (c4 & c2_xor_c3) | (c2 & c3);
+        let y4 = c4 ^ c2_xor_c3;
+
+        let int1 = !y3 & !y4;
+        !y1&y6&(y2&int1&y5 | y4&!y5) | y1&int1&(!y2&(y5 | y6) | y2&!y5) | !y1&y4&(y2^y5)
+    }
+
+    /*
+     * A B C
+     * D   E
+     * F G H
+     */
+    // a cell is 0 if itself or any of its neighbors are 0
+    fn contagious_zero(nw: u64, n: u64, ne: u64, w: u64, center: u64, e: u64, sw: u64, s: u64, se: u64) -> u64 {
+        let a  = (nw     << 63) | (n      >>  1);
+        let b  =  n;
+        let c  = (n      <<  1) | (ne     >> 63);
+        let d  = (w      << 63) | (center >> 1);
+        let e  = (center <<  1) | (e      >> 63);
+        let f  = (sw     << 63) | (s      >>  1);
+        let g  =  s;
+        let h  = (s      <<  1) | (se     >> 63);
+        a & b & c & d & center & e & f & g & h
+    }
+
+
+    // a cell is 1 if itself or any of its neighbors are 1
+    fn contagious_one(nw: u64, n: u64, ne: u64, w: u64, center: u64, e: u64, sw: u64, s: u64, se: u64) -> u64 {
+        let a  = (nw     << 63) | (n      >>  1);
+        let b  =  n;
+        let c  = (n      <<  1) | (ne     >> 63);
+        let d  = (w      << 63) | (center >> 1);
+        let e  = (center <<  1) | (e      >> 63);
+        let f  = (sw     << 63) | (s      >>  1);
+        let g  =  s;
+        let h  = (s      <<  1) | (se     >> 63);
+        a | b | c | d | center | e | f | g | h
+    }
+
+
+    /// Compute the next generation. Returns the new latest generation number.
+    pub fn next(&mut self) -> usize {
+        // get the buffers and buffers_next
+        assert!(self.gen_states[self.state_index].gen_or_none.unwrap() == self.generation);
+        let history = self.gen_states.len();
+        let next_state_index = (self.state_index + 1) % history;
+
+        let (gen_state, gen_state_next) = if self.state_index < next_state_index {
+            let (p0, p1) = self.gen_states.split_at_mut(next_state_index);
+            (&p0[next_state_index - 1], &mut p1[0])
+        } else {
+            // self.state_index == history-1 and next_state_index == 0
+            let (p0, p1) = self.gen_states.split_at_mut(next_state_index + 1);
+            (&p1[history - 2], &mut p0[0])
+        };
+
+        {
+            let cells      = &gen_state.cells;
+            let wall       = &gen_state.wall_cells;
+            let known      = &gen_state.known;
+            let cells_next = &mut gen_state_next.cells;
+            let wall_next  = &mut gen_state_next.wall_cells;
+            let known_next = &mut gen_state_next.known;
+
+            // Copy fog over to next generation
+            for row_idx in 0 .. self.height {
+                for player_id in 0 .. self.num_players {
+                    gen_state_next.player_states[player_id].fog[row_idx].copy_from_slice(&gen_state.player_states[player_id].fog[row_idx]);
+                }
+            }
+
+            for row_idx in 0 .. self.height {
+                let n_row_idx = (row_idx + self.height - 1) % self.height;
+                let s_row_idx = (row_idx + 1) % self.height;
+                let cells_row_n = &cells[n_row_idx];
+                let cells_row_c = &cells[ row_idx ];
+                let cells_row_s = &cells[s_row_idx];
+                let wall_row_c  = &wall[ row_idx ];
+                let known_row_n = &known[n_row_idx];
+                let known_row_c = &known[ row_idx ];
+                let known_row_s = &known[s_row_idx];
+
+                // These will be shifted over at the beginning of the loop
+                let mut cells_nw;
+                let mut cells_w;
+                let mut cells_sw;
+                let mut cells_n   = cells_row_n[self.width_in_words - 1];
+                let mut cells_cen = cells_row_c[self.width_in_words - 1];
+                let mut cells_s   = cells_row_s[self.width_in_words - 1];
+                let mut cells_ne  = cells_row_n[0];
+                let mut cells_e   = cells_row_c[0];
+                let mut cells_se  = cells_row_s[0];
+                let mut known_nw;
+                let mut known_w;
+                let mut known_sw;
+                let mut known_n   = known_row_n[self.width_in_words - 1];
+                let mut known_cen = known_row_c[self.width_in_words - 1];
+                let mut known_s   = known_row_s[self.width_in_words - 1];
+                let mut known_ne  = known_row_n[0];
+                let mut known_e   = known_row_c[0];
+                let mut known_se  = known_row_s[0];
+
+                for col_idx in 0 .. self.width_in_words {
+                    // shift over
+                    cells_nw  = cells_n;
+                    cells_n   = cells_ne;
+                    cells_w   = cells_cen;
+                    cells_cen = cells_e;
+                    cells_sw  = cells_s;
+                    cells_s   = cells_se;
+                    cells_ne  = cells_row_n[(col_idx + 1) % self.width_in_words];
+                    cells_e   = cells_row_c[(col_idx + 1) % self.width_in_words];
+                    cells_se  = cells_row_s[(col_idx + 1) % self.width_in_words];
+                    known_nw  = known_n;
+                    known_n   = known_ne;
+                    known_w   = known_cen;
+                    known_cen = known_e;
+                    known_sw  = known_s;
+                    known_s   = known_se;
+                    known_ne  = known_row_n[(col_idx + 1) % self.width_in_words];
+                    known_e   = known_row_c[(col_idx + 1) % self.width_in_words];
+                    known_se  = known_row_s[(col_idx + 1) % self.width_in_words];
+
+                    // apply BitGrid changes
+                    let mut cells_cen_next = Universe::next_single_gen(cells_nw, cells_n, cells_ne, cells_w, cells_cen, cells_e, cells_sw, cells_s, cells_se);
+
+                    // any known cells with at least one unknown neighbor will become unknown in
+                    // the next generation
+                    known_next[row_idx][col_idx] = Universe::contagious_zero(known_nw, known_n, known_ne, known_w, known_cen, known_e, known_sw, known_s, known_se);
+
+                    cells_cen_next &= known_next[row_idx][col_idx];
+                    cells_cen_next &= !wall_row_c[col_idx];
+
+                    // assign to the u64 element in the next generation
+                    cells_next[row_idx][col_idx] = cells_cen_next;
+
+                    let mut in_multiple: u64 = 0;
+                    let mut seen_before: u64 = 0;
+                    for player_id in 0 .. self.num_players {
+                        // Any unknown cell with 
+                        //
+                        // A cell which would have belonged to 2+ players in the next
+                        // generation will belong to no one. These are unowned cells.
+                        //
+                        // Unowned cells follow the same rules of life.
+                        //
+                        // Any unowned cells are influenced by their neighbors, and if players,
+                        // can be acquired by the player, just as long as no two players are
+                        // fighting over those cells
+                        let player_cell_next =
+                            Universe::contagious_one(
+                                gen_state.player_states[player_id].cells[n_row_idx][(col_idx + self.width_in_words - 1) % self.width_in_words],
+                                gen_state.player_states[player_id].cells[n_row_idx][col_idx],
+                                gen_state.player_states[player_id].cells[n_row_idx][(col_idx + 1) % self.width_in_words],
+                                gen_state.player_states[player_id].cells[ row_idx ][(col_idx + self.width_in_words - 1) % self.width_in_words],
+                                gen_state.player_states[player_id].cells[ row_idx ][col_idx],
+                                gen_state.player_states[player_id].cells[ row_idx ][(col_idx + 1) % self.width_in_words],
+                                gen_state.player_states[player_id].cells[s_row_idx][(col_idx + self.width_in_words - 1) % self.width_in_words],
+                                gen_state.player_states[player_id].cells[s_row_idx][col_idx],
+                                gen_state.player_states[player_id].cells[s_row_idx][(col_idx + 1) % self.width_in_words]
+                            ) & cells_cen_next;
+                        in_multiple |= player_cell_next & seen_before;
+                        seen_before |= player_cell_next;
+                        gen_state_next.player_states[player_id].cells[row_idx][col_idx] = player_cell_next;
+                    }
+                    for player_id in 0 .. self.num_players {
+                        let cell_cur = gen_state.player_states[player_id].cells[row_idx][col_idx];
+                        let mut cell_next = gen_state_next.player_states[player_id].cells[row_idx][col_idx];
+                        cell_next &= !in_multiple; // if a cell would have belonged to multiple players, it belongs to none
+                        gen_state_next.player_states[player_id].cells[row_idx][col_idx] = cell_next;
+
+                        // clear fog for all cells that turned on in this generation
+                        Universe::clear_fog(&mut gen_state_next.player_states[player_id].fog, &self.fog_circle, self.fog_radius, self.width, self.height, row_idx, col_idx, cell_next & !cell_cur);
+                    }
+                }
+
+                // copy wall to wall_next
+                wall_next[row_idx].copy_from_slice(wall_row_c);
+            }
+        }
+
+        // increment generation in appropriate places
+        self.generation += 1;
+        self.state_index = next_state_index;
+        gen_state_next.gen_or_none = Some(self.generation);
+        self.generation
+    }
+
+
+    /// Clears the fog for the specified bits in the 64-bit word at `center_row_idx` and
+    /// `center_col_idx` using the fog circle (see `generate_fog_circle_bitmap` documentation for
+    /// more on this).
+    //TODO: unit test with fog_radiuses above and below 64
+    fn clear_fog(player_fog:     &mut BitGrid,
+                 fog_circle:     &BitGrid,
+                 fog_radius:     usize,
+                 uni_width:      usize,
+                 uni_height:     usize,
+                 center_row_idx: usize,
+                 center_col_idx: usize,
+                 bits_to_clear:  u64) {
+
+        if bits_to_clear == 0 {
+            return; // nothing to do
+        }
+        debug!("---");
+
+        // Iterate over every u64 in a rectangular region of `player_fog`, ANDing together the
+        // shifted u64s of `fog_circle` according to `bits_to_clear`, so as to only perform a
+        // single `&=` in `player_fog`.
+        // EXPLANATION OF VAR NAMES: "_idx" indicates this is a word index; otherwise, it's a game
+        // coord.
+
+        // Get the highest and lowest bits in bits_to_clear
+        let mut col_of_highest_to_clear = center_col_idx * 64;
+        for shift in (0..64).rev() {
+            if bits_to_clear & (1 << shift) > 0 {
+                break;
+            }
+            col_of_highest_to_clear += 1;
+        }
+        let mut col_of_lowest_to_clear  = center_col_idx * 64 + 63;
+        for shift in 0..64 {
+            if bits_to_clear & (1 << shift) > 0 {
+                break;
+            }
+            col_of_lowest_to_clear -= 1;
+        }
+        debug!("bits_to_clear: row {} and cols range [{}, {}]", center_row_idx, col_of_highest_to_clear, col_of_lowest_to_clear);
+
+        // Get the bounds in terms of game coordinates (from col_left to col_right, inclusive,
+        // and from row_top to row_bottom, inclusive).
+        let row_top    = (uni_height + center_row_idx - (fog_radius - 1)) % uni_height;
+        let row_bottom = (center_row_idx + fog_radius - 1) % uni_height;
+        let col_left   = (uni_width + col_of_highest_to_clear - (fog_radius - 1)) % uni_width;
+        let col_right  = (col_of_lowest_to_clear + fog_radius - 1) % uni_width;
+        debug!("row_(top,bottom) range is [{}, {}]", row_top, row_bottom);
+        debug!("col_(left,right) range is [{}, {}]", col_left, col_right);
+
+        // Convert cols to col_idxes
+        let col_idx_left  = col_left/64;
+        let col_idx_right = col_right/64;
+
+        let mut row_idx = row_top;
+        let uni_word_width = uni_width/64;
+        loop {
+            //debug!("row_idx is {} (out of height {})", row_idx, uni_height);
+            let mut col_idx = col_idx_left;
+            loop {
+                debug!("row {}, col range [{}, {}]", row_idx, col_idx*64, col_idx*64+63);
+                //debug!("col_idx is {} (out of word_width {}); stopping after {}", col_idx, uni_word_width, col_idx_right);
+                let mut mask = u64::max_value();
+                for shift in (0..64).rev() {
+                    if mask == 0 {
+                        break;
+                    }
+                    if bits_to_clear & (1 << shift) > 0 {
+                        let fog_row_idx = (uni_height  +  row_idx - center_row_idx + (fog_radius - 1)) % uni_height;
+                        let current_highest_col = col_idx * 64;
+                        let current_lowest_col  = col_idx * 64 + 63;
+                        for fog_col_idx in 0 .. fog_circle.width_in_words() {
+                            let fog_highest_col = (uni_width + center_col_idx*64 + (63 - shift) - (fog_radius - 1)) % uni_width;
+                            let fog_lowest_col  = (uni_width + center_col_idx*64 + (63 - shift) - (fog_radius - 1) + 63) % uni_width;
+                            debug!("  fog col range [{}, {}]", fog_highest_col, fog_lowest_col);
+
+                            if current_highest_col == fog_highest_col && current_lowest_col == fog_lowest_col {
+                                mask &= fog_circle[fog_row_idx][fog_col_idx];
+                                debug!("  mask is now {:016x}, cleared by fog circle R{}, Ci{}, no shift", mask, fog_row_idx, fog_col_idx);
+                            } else if current_highest_col <= fog_lowest_col && fog_lowest_col < current_lowest_col {
+                                // we need to double negate so that shifting results in 1s, not 0s
+                                mask &= !(!fog_circle[fog_row_idx][fog_col_idx] << (current_lowest_col - fog_lowest_col));
+                                debug!("  fog word is {:016x}", fog_circle[fog_row_idx][fog_col_idx]);
+                                debug!("  mask is now {:016x}, cleared by fog circle R{}, Ci{}, fog circle << {}", mask, fog_row_idx, fog_col_idx, current_lowest_col - fog_lowest_col);
+                            } else if current_highest_col < fog_highest_col && fog_highest_col <= current_lowest_col {
+                                mask &= !(!fog_circle[fog_row_idx][fog_col_idx] >> (fog_highest_col - current_highest_col));
+                                debug!("  fog word is {:016x}", fog_circle[fog_row_idx][fog_col_idx]);
+                                debug!("  mask is now {:016x}, cleared by fog circle R{}, Ci{}, fog circle >> {}", mask, fog_row_idx, fog_col_idx, fog_highest_col - current_highest_col);
+                            }
+                        }
+                    }
+                }
+                player_fog[row_idx][col_idx] &= mask;
+
+                if col_idx == col_idx_right {
+                    break;
+                }
+                col_idx = (col_idx + 1) % uni_word_width;
+            }
+
+            if row_idx == row_bottom {
+                break;
+            }
+            row_idx = (row_idx + 1) % uni_height;
+        }
+    }
+
+
+    /// Iterate over every non-dead cell in the universe for the current generation. `region` is
+    /// the rectangular area used for restricting results. `visibility` is an optional player_id;
+    /// if specified, causes cells not visible to the player to be passed as `CellState::Fog` to the
+    /// callback.
+    /// 
+    /// Callback receives (`col`, `row`, `cell_state`).
+    /// 
+    /// # Panics
+    /// 
+    /// Does numerous consistency checks on the bitmaps, and panics if inconsistencies are found.
+    //XXX non_dead_cells_in_region
+    pub fn each_non_dead(&self, region: Region, visibility: Option<usize>, callback: &mut FnMut(usize, usize, CellState)) {
+        let cells = &self.gen_states[self.state_index].cells;
+        let wall  = &self.gen_states[self.state_index].wall_cells;
+        let known = &self.gen_states[self.state_index].known;
+        let opt_player_state = if let Some(player_id) = visibility {
+            Some(&self.gen_states[self.state_index].player_states[player_id])
+        } else { None };
+        let mut col;
+        for row in 0 .. self.height {
+            let cells_row = &cells[row];
+            let wall_row  = &wall [row];
+            let known_row = &known[row];
+            if (row as isize) >= region.top() && (row as isize) < (region.top() + region.height() as isize) {
+                col = 0;
+                for col_idx in 0 .. self.width_in_words {
+                    let cells_word = cells_row[col_idx];
+                    let wall_word  = wall_row [col_idx];
+                    let known_word = known_row[col_idx];
+                    let opt_player_words;
+                    if let Some(player_state) = opt_player_state {
+                        let player_cells_word = player_state.cells[row][col_idx];
+                        let player_fog_word   = player_state.fog[row][col_idx];
+                        opt_player_words = Some((player_cells_word, player_fog_word));
+                    } else {
+                        opt_player_words = None;
+                    }
+                    for shift in (0..64).rev() {
+                        if (col as isize) >= region.left() &&
+                            (col as isize) < (region.left() + region.width() as isize) {
+                            let mut state = CellState::Wall;
+                            let c = (cells_word>>shift)&1 == 1;
+                            let w = (wall_word >>shift)&1 == 1;
+                            let k = (known_word>>shift)&1 == 1;
+                            if c && w {
+                                panic!("Cannot be both cell and wall at ({}, {})", col, row);
+                            }
+                            if !k && ((c && !w) || (!c && w)) {
+                                panic!("Unspecified invalid state at ({}, {})", col, row);
+                            }
+                            if c && !w && k {
+                                // It's known and it's a cell; check cells + fog for every player
+                                // (expensive step since this is per-bit).
+
+                                let mut opt_player_id = None;
+                                for player_id in 0 .. self.num_players {
+                                    let player_state = &self.gen_states[self.state_index].player_states[player_id];
+                                    let pc = (player_state.cells[row][col_idx] >> shift) & 1 == 1;
+                                    let pf = (player_state.fog[row][col_idx] >> shift) & 1 == 1;
+                                    if pc && pf {
+                                        panic!("Player cell and player fog at ({}, {}) for player {}", col, row, player_id);
+                                    }
+                                    if pc {
+                                        if let Some(other_player_id) = opt_player_id {
+                                            panic!("Cell ({}, {}) belongs to player {} and player {}!", col, row, other_player_id, player_id);
+                                        }
+                                        opt_player_id = Some(player_id);
+                                    }
+                                }
+                                state = CellState::Alive(opt_player_id);
+                            } else {
+                                // (B) other states
+                                if !c && !w {
+                                    state = if k { CellState::Dead } else { CellState::Fog };
+                                } else if !c && w {
+                                    state = CellState::Wall;
+                                }
+                            }
+                            if let Some((player_cells_word, player_fog_word)) = opt_player_words {
+                                let pc = (player_cells_word>>shift)&1 == 1;
+                                let pf = (player_fog_word>>shift)&1 == 1;
+                                if !k && pc {
+                                    panic!("Player can't have cells where unknown, at ({}, {})", col, row);
+                                }
+                                if w && pc {
+                                    panic!("Player can't have cells where wall, at ({}, {})", col, row);
+                                }
+                                if pf {
+                                    state = CellState::Fog;
+                                }
+                            }
+                            if state != CellState::Dead {
+                                callback(col, row, state);
+                            }
+                        }
+                        col += 1;
+                    }
+                }
+            }
+        }
+    }
+
+
+    /// Iterate over every non-dead cell in the universe for the current generation.
+    /// `visibility` is an optional player_id, allowing filtering based on fog.
+    /// Callback receives (col, row, cell_state).
+    pub fn each_non_dead_full(&self, visibility: Option<usize>, callback: &mut FnMut(usize, usize, CellState)) {
+        self.each_non_dead(self.region(), visibility, callback);
+    }
+
+
+    /// Get a Region of the same size as the universe.
+    pub fn region(&self) -> Region {
+        Region::new(0, 0, self.width, self.height)
+    }
+
+
+    /// Copies from `src` BitGrid to this GenState as the player specified by `opt_player_id`,
+    /// unless `opt_player_id` is `None`.
+    ///
+    /// This function is similar to `GenState::copy_from_bit_grid` except that 1) when a `player_id`
+    /// is specified, the specified player's writable region is used, and 2) the latest generation
+    /// is written to.
+    ///
+    /// Panics if `opt_player_id` is `Some(player_id)` and `player_id` is out of range.
+    pub fn copy_from_bit_grid(&mut self, src: &BitGrid, dst_region: Region, opt_player_id: Option<usize>) {
+        let region;
+        if let Some(player_id) = opt_player_id {
+            if let Some(_region) = dst_region.intersection(self.player_writable[player_id]) {
+                region = _region;
+            } else {
+                // nothing to do because `dst_region` completely outside of player's writable region
+                return;
+            }
+        } else {
+            region = dst_region;
+        }
+        let latest_gen = &mut self.gen_states[self.state_index];
+        latest_gen.copy_from_bit_grid(src, region, opt_player_id);
+    }
+
+
+    /// Utility function to mutably borrow two separate GenStates from self.gen_states, specified
+    /// by `idx0` and `idx1`.
+    ///
+    /// # Returns
+    ///
+    /// A tuple containing mutable references to the `GenState`s referenced by `idx0` and `idx1`,
+    /// respectively.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the indices are equal.
+    fn borrow_two_gen_state_mut(&mut self, idx0: usize, idx1: usize) -> (&mut GenState, &mut GenState) {
+        assert_ne!(idx0, idx1, "indices into self.gen_states must not be the same");
+        let cut_idx = cmp::max(idx0, idx1);
+        {
+            let (lower, upper): (&mut [GenState], &mut [GenState]) = self.gen_states.split_at_mut(cut_idx);
+            if idx1 < cut_idx {
+                (&mut upper[idx0 - cut_idx], &mut lower[idx1])
+            } else {
+                (&mut lower[idx0], &mut upper[idx1 - cut_idx])
+            }
+        }
+    }
+
+
+    /// Apply `diff` to our `Universe`. Generally this is executed by the client in response to an
+    /// update from the server.
+    ///
+    /// # Arguments
+    ///
+    /// * `diff`: reference to a `GenStateDiff` containing a base generation number, a new
+    /// generation number, and a pattern showing how to make the new generation out of the base.
+    /// * `visibility`: an optional `player_id` indicating the player to apply this for. If `None`,
+    /// the pattern must not have any fog.
+    ///
+    /// # Return values
+    ///
+    /// * `Ok(Some(new_gen))` if the update was applied.
+    /// * `Ok(None)` if the update is valid but was not applied because either:
+    ///     - the generation to be applied is already present,
+    ///     - there is already a greater generation present, or
+    ///     - the base generation of this diff (that is, `diff.gen0`) could not be found.
+    ///       A base generation of 0 is a special case -- it is always found.
+    /// * `Err(InvalidData{reason: msg})` if the update is invalid, either because:
+    ///     - the difference between `diff.gen0` and `diff.gen1` is too large. Since the server
+    ///     knows the client's buffer size, this should not happen. In this case, no updates are
+    ///     made to the `Universe`. A base generation of 0 is a special case -- the difference is
+    ///     never too large.
+    ///     - the RLE pattern is invalid. NOTE: in this case, the pattern is only partially written
+    ///     and all other updates (e.g., increasing the generation count) are made as if it were
+    ///     valid.
+    ///
+    /// # Panics
+    ///
+    /// This will panic if:
+    /// * `gen0` is not less than `gen1`.
+    /// * `visibility` is out of range.
+    pub fn apply(&mut self, diff: &GenStateDiff, visibility: Option<usize>) -> ConwayResult<Option<usize>> {
+        use ConwayError::*;
+        assert!(diff.gen0 < diff.gen1, format!("expected gen0 < gen1, but {} >= {}",
+                                               diff.gen0, diff.gen1));
+        // if diff too large, return Err(...)
+        let gen_state_len = self.gen_states.len();
+        if diff.gen0 > 0 && diff.gen1 - diff.gen0 >= gen_state_len {
+            return Err(InvalidData {
+                          reason: format!("diff is across too many generations to be applied: {} >= {}",
+                                          diff.gen1 - diff.gen0, gen_state_len)});
+        }
+
+        // 1) If incremental update, find the gen0 in our gen_states; if not found, return
+        //    Ok(None).
+        let mut opt_gen0_idx = None;
+        let mut opt_largest_gen_idx = None;
+        let mut opt_largest_gen_value = None;
+        for i in 0..self.gen_states.len() {
+            if let Some(gen) = self.gen_states[i].gen_or_none {
+                if diff.gen0 > 0 {
+                    if gen == diff.gen0 {
+                        opt_gen0_idx = Some(i);
+                    }
+                }
+                if let Some(largest_gen) = opt_largest_gen_value {
+                    if gen > largest_gen {
+                        opt_largest_gen_value = Some(gen);
+                        opt_largest_gen_idx   = Some(i);
+                    }
+                } else {
+                    opt_largest_gen_value = Some(gen);
+                    opt_largest_gen_idx   = Some(i);
+                }
+                // 2) ensure that no generation is >= gen1; if so, return Ok(None)
+                if gen >= diff.gen1 {
+                    return Ok(None);
+                }
+            }
+        }
+        if diff.gen0 > 0 && opt_gen0_idx.is_none() {
+            return Ok(None);
+        }
+
+        // 3) make room for the new gen_state (make room in the circular buffer)
+        for i in 0..self.gen_states.len() {
+            if let Some(gen) = self.gen_states[i].gen_or_none {
+                if gen + gen_state_len <= diff.gen1 {
+                    self.gen_states[i].gen_or_none = None; // indicate uninitialized
+                }
+            }
+        }
+
+        let gen1_idx = if let Some(largest_gen_idx) = opt_largest_gen_idx {
+            let largest_gen = opt_largest_gen_value.unwrap();
+            (largest_gen_idx + diff.gen1 - largest_gen) % gen_state_len
+        } else {
+            0
+        };
+        // 4) If incremental update, then copy from the gen_state for gen0 to what will be the
+        //    gen_state for gen1.
+        if diff.gen0 > 0 {
+            let gen0_idx = opt_gen0_idx.unwrap();
+            let (gen0, gen1) = self.borrow_two_gen_state_mut(gen0_idx, gen1_idx);
+            gen1.clear();
+            gen0.copy(gen1); // this is an |= operation, hence the clear before this
+        } else {
+            self.gen_states[gen1_idx].clear();
+        }
+
+        // 5) update self.generation, self.state_index, and self.gen_states[gen1_idx].gen_or_none
+        let new_gen = diff.gen1;
+        self.generation = new_gen;
+        self.state_index = gen1_idx;
+        self.gen_states[gen1_idx].gen_or_none = Some(new_gen);
+
+        // 6) apply the diff!
+        // TODO: wrap the error message rather than just passing it through
+        diff.pattern.to_grid(&mut self.gen_states[gen1_idx], visibility)?;
+
+        Ok(Some(new_gen))
+    }
+
+    /// If it's possible to generate a diff between the GenStates specified by `gen0` and `gen1`, do
+    /// so. Otherwise, return `None`.
+    ///
+    /// The optional `visibility` specifies the player this is viewed as.
+    ///
+    /// # Panics
+    ///
+    /// * Panics if `gen0` >= `gen1`.
+    /// * Panics if `visibility` is out of range.
+    pub fn diff(&self, gen0: usize, gen1: usize, visibility: Option<usize>) -> Option<GenStateDiff> {
+        assert!(gen0 < gen1, format!("expected gen0 < gen1, but {} >= {}", gen0, gen1));
+        let mut opt_genstate0 = None;
+        let mut opt_genstate1 = None;
+        for gen_idx in 0..self.gen_states.len() {
+            let gs = &self.gen_states[gen_idx];
+            if let Some(gen) = gs.gen_or_none {
+                if gen == gen0 {
+                    opt_genstate0 = Some(gs);
+                } else if gen == gen1 {
+                    opt_genstate1 = Some(gs);
+                }
+            }
+        }
+        if gen0 == 0 && opt_genstate1.is_some() {
+            let pattern = opt_genstate1.unwrap().to_pattern(visibility);
+            Some(GenStateDiff{gen0, gen1, pattern})
+        } else {
+            if opt_genstate0.is_none() || opt_genstate1.is_none() {
+                None
+            } else {
+                Some(opt_genstate0.unwrap().diff(opt_genstate1.unwrap(), visibility))
+            }
+        }
+    }
+}
+
+
+impl CharGrid for Universe {
+    fn is_valid(ch: char) -> bool {
+        GenState::is_valid(ch)
+    }
+
+    fn write_at_position(&mut self, _col: usize, _row: usize, _ch: char, _visibility: Option<usize>) {
+        unimplemented!("This interface is not intended for modifying Universes");
+    }
+
+    /// Return width in cells.
+    fn width(&self) -> usize {
+        return self.width;
+    }
+
+
+    /// Return height in cells.
+    fn height(&self) -> usize {
+        return self.height;
+    }
+
+
+    fn get_run(&self, col: usize, row: usize, visibility: Option<usize>) -> (usize, char) {
+        let gen_state = &self.gen_states[self.state_index];
+        gen_state.get_run(col, row, visibility)
+    }
+}
+
+
+/// Rectangular area within a `Universe`.
+#[derive(Eq,PartialEq,Ord,PartialOrd,Copy,Clone,Debug)]
+pub struct Region {
+    left:   isize,
+    top:    isize,
+    width:  usize,
+    height: usize,
+}
+
+/// A region is a rectangular area within a `Universe`. All coordinates are game coordinates.
+impl Region {
+    /// Creates a new region given x and y coordinates of top-left corner, and width and height,
+    /// all in units of cells (game coordinates). Width and height must both be positive.
+    pub fn new(left: isize, top: isize, width: usize, height: usize) -> Self {
+        assert!(width != 0);
+        assert!(height != 0);
+
+        Region {
+            left:   left,
+            top:    top,
+            width:  width,
+            height: height,
+        }
+    }
+
+    /// Returns the x coordinate of the leftmost cells of the Region, in game coordinates.
+    pub fn left(&self) -> isize {
+        self.left
+    }
+
+    /// Returns the x coordinate of the rightmost cells of the Region, in game coordinates.
+    pub fn right(&self) -> isize {
+        self.left + (self.width as isize) - 1
+    }
+
+    /// Returns the y coordinate of the uppermost cells of the Region, in game coordinates.
+    pub fn top(&self) -> isize {
+        self.top
+    }
+
+    /// Returns the y coordinate of the lowermost cells of the Region, in game coordinates.
+    pub fn bottom(&self) -> isize {
+        self.top + (self.height as isize) - 1
+    }
+
+    /// Returns the width of the Region (along x axis), in game coordinates. 
+    pub fn width(&self) -> usize {
+        self.width
+    }
+
+    /// Returns the height of the Region (along y axis), in game coordinates. 
+    pub fn height(&self) -> usize {
+        self.height
+    }
+
+    /// Determines whether the specified cell is part of the Region. 
+    pub fn contains(&self, col: isize, row: isize) -> bool {
+        self.left    <= col &&
+        col <= self.right() &&
+        self.top     <= row &&
+        row <= self.bottom()
+    }
+
+    pub fn intersection(&self, other: Region) -> Option<Region> {
+        let left = cmp::max(self.left(), other.left());
+        let right = cmp::min(self.right(), other.right());
+        if left > right {
+            return None;
+        }
+        let width = right - left + 1;
+        let top = cmp::max(self.top(), other.top());
+        let bottom = cmp::min(self.bottom(), other.bottom());
+        if top > bottom {
+            return None;
+        }
+        let height = bottom - top + 1;
+        Some(Region::new(left, top, width as usize, height as usize))
+    }
+}
+
+
+#[cfg(test)]
+pub mod test_helpers {
+    use super::*;
+
+    #[derive(PartialEq)]
+    pub enum UniType {
+        Server,
+        Client,
+    }
+
+    pub const GEN_BUFSIZE: usize = 16;
+
+    pub fn generate_test_universe_with_default_params(uni_type: UniType) -> Universe {
+        let player0 = PlayerBuilder::new(Region::new(100, 70, 34, 16));   // used for the glider gun and predefined patterns
+        let player1 = PlayerBuilder::new(Region::new(0, 0, 80, 80));
+        let players = vec![player0, player1];
+
+        let bigbang = BigBang::new()
+            .width(256)
+            .height(128)
+            .server_mode(uni_type == UniType::Server)
+            .history(GEN_BUFSIZE)
+            .fog_radius(9)
+            .add_players(players)
+            .birth();
+
+        bigbang.unwrap()
+    }
+
+    pub fn make_gen_state() -> GenState {
+        let player0 = PlayerBuilder::new(Region::new(100, 70, 34, 16));
+        let player1 = PlayerBuilder::new(Region::new(0, 0, 80, 80));
+        let players = vec![player0, player1];
+
+        let mut uni = BigBang::new()
+            .history(1)
+            .add_players(players)
+            .birth()
+            .unwrap();
+        uni.gen_states.pop().unwrap()
+    }
+}
+
+/// The following tests are here because they use parts of Universe that are private.
+#[cfg(test)]
+mod universe_tests {
+    use super::*;
+    use super::test_helpers::*;
+    use crate::error::ConwayError::*;
+
+    #[test]
+    fn next_single_gen_test_data1_with_wrapping() {
+        // glider, blinker, glider
+        let nw = 0x0000000000000000;
+        let n  = 0x0000000400000002;
+        let ne = 0x8000000000000000;
+        let w  = 0x0000000000000001;
+        let cen= 0xC000000400000001;
+        let e  = 0x8000000000000000;
+        let sw = 0x0000000000000000;
+        let s  = 0x8000000400000001;
+        let se = 0x0000000000000000;
+        let next_center = Universe::next_single_gen(nw, n, ne, w, cen, e, sw, s, se);
+        assert_eq!(next_center, 0xC000000E00000002);
+    }
+
+    #[test]
+    fn set_checked_cannot_set_a_fog_cell() {
+        let mut uni = generate_test_universe_with_default_params(UniType::Server);
+        let player_id = 1; // writing into player 1's regions
+        let alive_player_cell = CellState::Alive(Some(player_id));
+        let state_index = uni.state_index;
+
+        // Let's hardcode this and try to set a fog'd cell
+        // within what was a players writable region.
+        uni.gen_states[state_index].player_states[player_id].fog[0][0] |= 1<<63;
+
+        uni.set(0, 0, alive_player_cell, player_id);
+        let cell_state = uni.get_cell_state(0,0, Some(player_id));
+        assert_eq!(cell_state, CellState::Dead);
+    }
+
+
+    #[test]
+    fn toggle_unchecked_cell_toggled_is_owned_by_player() {
+        let mut uni = generate_test_universe_with_default_params(UniType::Server);
+        let state_index = uni.state_index;
+        let row = 0;
+        let col = 0;
+        let bit = 63;
+        let player_one_opt = Some(0);
+        let player_two_opt = Some(1);
+
+        // Should transition from dead to alive. Player one will have their cell set, player two
+        // will not
+        assert_eq!(uni.toggle_unchecked(row, col, player_one_opt), CellState::Alive(player_one_opt));
+        assert_eq!(uni.gen_states[state_index].player_states[player_one_opt.unwrap()].cells[row][col] >> bit, 1);
+        assert_eq!(uni.gen_states[state_index].player_states[player_two_opt.unwrap()].cells[row][col] >> bit, 0);
+    }
+
+    #[test]
+    fn toggle_unchecked_cell_toggled_by_both_players_repetitively() {
+        let mut uni = generate_test_universe_with_default_params(UniType::Server);
+        let state_index = uni.state_index;
+        let row = 0;
+        let col = 0;
+        let bit = 63;
+        let player_one_opt = Some(0);
+        let player_two_opt = Some(1);
+
+        // Should transition from dead to alive. Player one will have their cell set, player two
+        // will not
+        assert_eq!(uni.toggle_unchecked(row, col, player_one_opt), CellState::Alive(player_one_opt));
+        assert_eq!(uni.gen_states[state_index].player_states[player_one_opt.unwrap()].cells[row][col] >> bit, 1);
+        assert_eq!(uni.gen_states[state_index].player_states[player_two_opt.unwrap()].cells[row][col] >> bit, 0);
+
+        // Player two will now toggle the cell, killing it as it was previously alive.
+        // Player one will be cleared as a result, the cell will not be set at all.
+        // Notice we are not checking for writable regions here (unchecked doesn't care) so this
+        // runs through
+        assert_eq!(uni.toggle_unchecked(row, col, player_two_opt), CellState::Dead);
+        assert_eq!(uni.gen_states[state_index].player_states[player_one_opt.unwrap()].cells[row][col] >> bit, 0);
+        assert_eq!(uni.gen_states[state_index].player_states[player_two_opt.unwrap()].cells[row][col] >> bit, 0);
+    }
+
+    #[test]
+    fn toggle_checked_players_cannot_toggle_a_wall_cell() {
+        let mut uni = generate_test_universe_with_default_params(UniType::Server);
+        //let player_one = 0;
+        let player_two = 1;
+        let row = 0;
+        let col = 0;
+        let state_index = uni.state_index;
+
+        uni.gen_states[state_index].wall_cells.modify_bits_in_word(row, col, 1<<63, BitOperation::Set);
+
+        // cannot test with player_one because this wall cell is outside their writable area
+        assert_eq!(uni.toggle(row, col, player_two),
+                   Err(AccessDenied{reason: "cannot write to wall cell: col=0, row=0".to_owned()}));
+    }
+
+    #[test]
+    fn toggle_checked_players_can_toggle_an_known_cell_if_writable() {
+        let mut uni = generate_test_universe_with_default_params(UniType::Server);
+        let player_one = 0;
+        let player_two = 1;
+        let row = 0;
+        let col = 0;
+        let state_index = uni.state_index;
+
+        uni.gen_states[state_index].known.modify_bits_in_word(row, col, 1<<63, BitOperation::Set);
+
+        assert_eq!(uni.toggle(row, col, player_one),
+                   Err(AccessDenied{reason: "outside writable area for player 0: col=0, row=0".to_owned()}));
+        assert_eq!(uni.toggle(row, col, player_two), Ok(CellState::Alive(Some(player_two))));
+    }
+
+    #[test]
+    fn toggle_checked_players_cannot_toggle_an_unknown_cell() {
+        let mut uni = generate_test_universe_with_default_params(UniType::Server);
+        //let player_one = 0;
+        let player_two = 1;
+        let row = 0;
+        let col = 0;
+        let state_index = uni.state_index;
+
+        uni.gen_states[state_index].known.modify_bits_in_word(row, col, 1<<63, BitOperation::Clear);
+
+        // cannot test with player_one because this wall cell is outside their writable area
+        assert_eq!(uni.toggle(row, col, player_two),
+                   Err(AccessDenied{reason: "not a known cell for player 1: col=0, row=0".to_owned()}));
+    }
+
+    #[test]
+    fn contagious_one_with_all_neighbors_set() {
+        let north = u64::max_value();
+        let northwest = u64::max_value();
+        let northeast = u64::max_value();
+        let west = u64::max_value();
+        let mut center = u64::max_value();
+        let east = u64::max_value();
+        let southwest = u64::max_value();
+        let south = u64::max_value();
+        let southeast = u64::max_value();
+
+
+        let mut output = Universe::contagious_one(northwest, north, northeast, west, center, east, southwest, south, southeast);
+        assert_eq!(output, u64::max_value());
+
+        center &= !(0x0000000F00000000);
+
+        output = Universe::contagious_one(northwest, north, northeast, west, center, east, southwest, south, southeast);
+        // 1 bit surrounding 'F', and inclusive, are cleared
+        assert_eq!(output, 0xFFFFFFFFFFFFFFFF);
+    }
+
+    #[test]
+    fn contagious_zero_with_all_neighbors_set() {
+        let north = u64::max_value();
+        let northwest = u64::max_value();
+        let northeast = u64::max_value();
+        let west = u64::max_value();
+        let mut center = u64::max_value();
+        let east = u64::max_value();
+        let southwest = u64::max_value();
+        let south = u64::max_value();
+        let southeast = u64::max_value();
+
+
+        let mut output = Universe::contagious_zero(northwest, north, northeast, west, center, east, southwest, south, southeast);
+        assert_eq!(output, u64::max_value());
+
+        center &= !(0x0000000F00000000);
+
+        output = Universe::contagious_zero(northwest, north, northeast, west, center, east, southwest, south, southeast);
+        // 1 bit surrounding 'F', and inclusive, are cleared
+        assert_eq!(output, 0xFFFFFFE07FFFFFFF);
+    }
+
+    #[test]
+    fn verify_fog_circle_bitmap_generation() {
+        let mut uni = generate_test_universe_with_default_params(UniType::Server);
+
+        let fog_radius_of_nine = vec![
+            vec![0xf007ffffffffffff],
+            vec![0xe003ffffffffffff],
+            vec![0xc001ffffffffffff],
+            vec![0x8000ffffffffffff],
+            vec![0x00007fffffffffff],
+            vec![0x00007fffffffffff],
+            vec![0x00007fffffffffff],
+            vec![0x00007fffffffffff],
+            vec![0x00007fffffffffff],
+            vec![0x00007fffffffffff],
+            vec![0x00007fffffffffff],
+            vec![0x00007fffffffffff],
+            vec![0x00007fffffffffff],
+            vec![0x8000ffffffffffff],
+            vec![0xc001ffffffffffff],
+            vec![0xe003ffffffffffff],
+            vec![0xf007ffffffffffff]];
+        uni.fog_radius = 9;
+        uni.generate_fog_circle_bitmap();
+        assert_eq!(fog_radius_of_nine, uni.fog_circle.0);
+
+        let fog_radius_of_four = vec![
+            vec![0x83ffffffffffffff],
+            vec![0x01ffffffffffffff],
+            vec![0x01ffffffffffffff],
+            vec![0x01ffffffffffffff],
+            vec![0x01ffffffffffffff],
+            vec![0x01ffffffffffffff],
+            vec![0x83ffffffffffffff],
+        ];
+        uni.fog_radius = 4;
+        uni.generate_fog_circle_bitmap();
+        assert_eq!(fog_radius_of_four, uni.fog_circle.0);
+
+        let fog_radius_of_thirtyfive = vec![
+            vec![0xffffffc0001fffff, 0xffffffffffffffff, ],
+            vec![0xfffffe000003ffff, 0xffffffffffffffff, ],
+            vec![0xfffff00000007fff, 0xffffffffffffffff, ],
+            vec![0xffffc00000001fff, 0xffffffffffffffff, ],
+            vec![0xffff0000000007ff, 0xffffffffffffffff, ],
+            vec![0xfffe0000000003ff, 0xffffffffffffffff, ],
+            vec![0xfffc0000000001ff, 0xffffffffffffffff, ],
+            vec![0xfff000000000007f, 0xffffffffffffffff, ],
+            vec![0xffe000000000003f, 0xffffffffffffffff, ],
+            vec![0xffc000000000001f, 0xffffffffffffffff, ],
+            vec![0xff8000000000000f, 0xffffffffffffffff, ],
+            vec![0xff00000000000007, 0xffffffffffffffff, ],
+            vec![0xfe00000000000003, 0xffffffffffffffff, ],
+            vec![0xfe00000000000003, 0xffffffffffffffff, ],
+            vec![0xfc00000000000001, 0xffffffffffffffff, ],
+            vec![0xf800000000000000, 0xffffffffffffffff, ],
+            vec![0xf000000000000000, 0x7fffffffffffffff, ],
+            vec![0xf000000000000000, 0x7fffffffffffffff, ],
+            vec![0xe000000000000000, 0x3fffffffffffffff, ],
+            vec![0xe000000000000000, 0x3fffffffffffffff, ],
+            vec![0xc000000000000000, 0x1fffffffffffffff, ],
+            vec![0xc000000000000000, 0x1fffffffffffffff, ],
+            vec![0xc000000000000000, 0x1fffffffffffffff, ],
+            vec![0x8000000000000000, 0x0fffffffffffffff, ],
+            vec![0x8000000000000000, 0x0fffffffffffffff, ],
+            vec![0x8000000000000000, 0x0fffffffffffffff, ],
+            vec![0x0000000000000000, 0x07ffffffffffffff, ],
+            vec![0x0000000000000000, 0x07ffffffffffffff, ],
+            vec![0x0000000000000000, 0x07ffffffffffffff, ],
+            vec![0x0000000000000000, 0x07ffffffffffffff, ],
+            vec![0x0000000000000000, 0x07ffffffffffffff, ],
+            vec![0x0000000000000000, 0x07ffffffffffffff, ],
+            vec![0x0000000000000000, 0x07ffffffffffffff, ],
+            vec![0x0000000000000000, 0x07ffffffffffffff, ],
+            vec![0x0000000000000000, 0x07ffffffffffffff, ],
+            vec![0x0000000000000000, 0x07ffffffffffffff, ],
+            vec![0x0000000000000000, 0x07ffffffffffffff, ],
+            vec![0x0000000000000000, 0x07ffffffffffffff, ],
+            vec![0x0000000000000000, 0x07ffffffffffffff, ],
+            vec![0x0000000000000000, 0x07ffffffffffffff, ],
+            vec![0x0000000000000000, 0x07ffffffffffffff, ],
+            vec![0x0000000000000000, 0x07ffffffffffffff, ],
+            vec![0x0000000000000000, 0x07ffffffffffffff, ],
+            vec![0x8000000000000000, 0x0fffffffffffffff, ],
+            vec![0x8000000000000000, 0x0fffffffffffffff, ],
+            vec![0x8000000000000000, 0x0fffffffffffffff, ],
+            vec![0xc000000000000000, 0x1fffffffffffffff, ],
+            vec![0xc000000000000000, 0x1fffffffffffffff, ],
+            vec![0xc000000000000000, 0x1fffffffffffffff, ],
+            vec![0xe000000000000000, 0x3fffffffffffffff, ],
+            vec![0xe000000000000000, 0x3fffffffffffffff, ],
+            vec![0xf000000000000000, 0x7fffffffffffffff, ],
+            vec![0xf000000000000000, 0x7fffffffffffffff, ],
+            vec![0xf800000000000000, 0xffffffffffffffff, ],
+            vec![0xfc00000000000001, 0xffffffffffffffff, ],
+            vec![0xfe00000000000003, 0xffffffffffffffff, ],
+            vec![0xfe00000000000003, 0xffffffffffffffff, ],
+            vec![0xff00000000000007, 0xffffffffffffffff, ],
+            vec![0xff8000000000000f, 0xffffffffffffffff, ],
+            vec![0xffc000000000001f, 0xffffffffffffffff, ],
+            vec![0xffe000000000003f, 0xffffffffffffffff, ],
+            vec![0xfff000000000007f, 0xffffffffffffffff, ],
+            vec![0xfffc0000000001ff, 0xffffffffffffffff, ],
+            vec![0xfffe0000000003ff, 0xffffffffffffffff, ],
+            vec![0xffff0000000007ff, 0xffffffffffffffff, ],
+            vec![0xffffc00000001fff, 0xffffffffffffffff, ],
+            vec![0xfffff00000007fff, 0xffffffffffffffff, ],
+            vec![0xfffffe000003ffff, 0xffffffffffffffff, ],
+            vec![0xffffffc0001fffff, 0xffffffffffffffff, ],
+            ];
+
+        uni.fog_radius = 35;
+        uni.generate_fog_circle_bitmap();
+        assert_eq!(fog_radius_of_thirtyfive, uni.fog_circle.0);
+    }
+
+    #[test]
+    fn clear_fog_with_standard_radius() {
+        let player0 = PlayerBuilder::new(Region::new(100, 70, 34, 16));   // used for the glider gun and predefined patterns
+        let player1 = PlayerBuilder::new(Region::new(0, 0, 80, 80));
+        let players = vec![player0, player1];
+
+        let mut uni = BigBang::new()
+            .width(256)
+            .height(128)
+            .server_mode(true)
+            .history(16)
+            .fog_radius(4)
+            .add_players(players)
+            .birth()
+            .unwrap();
+
+        let history = uni.gen_states.len();
+        let next_state_index = (uni.state_index + 1) % history;
+        let player_id = 0;
+
+        let gen_state_next = if uni.state_index < next_state_index {
+            let (_, p1) = uni.gen_states.split_at_mut(next_state_index);
+            &mut p1[player_id]
+        } else {
+            let (p0, _) = uni.gen_states.split_at_mut(next_state_index + 1);
+            &mut p0[player_id]
+        };
+        let row_index_outside_of_p0_region = 1;
+        let col_index_outside_of_p0_region = 1;
+        let one_bit_to_clear = 1;
+
+        Universe::clear_fog(&mut gen_state_next.player_states[player_id].fog, 
+                            &uni.fog_circle, 
+                            uni.fog_radius, 
+                            uni.width, 
+                            uni.height, 
+                            row_index_outside_of_p0_region, 
+                            col_index_outside_of_p0_region, 
+                            one_bit_to_clear);
+
+        for x in 0..4 {
+            for y in 1..2 {
+                assert_eq!(gen_state_next.player_states[0].fog[x][y], 0b1111111111111111111111111111111111111111111111111111111111110000);
+            }
+        }
+    }
+
+    #[test]
+    fn universe_copy_from_bit_grid_as_player() {
+        let mut uni = generate_test_universe_with_default_params(UniType::Server);
+        let grid = Pattern("64o$64o!".to_owned()).to_new_bit_grid(64, 2).unwrap();
+
+        let write_pattern_as = Some(1); // player 1
+        let dst_region = Region::new(0, 0, 32, 3);
+
+        uni.copy_from_bit_grid(&grid, dst_region, write_pattern_as);
+
+        {
+            let genstate = &uni.gen_states[uni.state_index];
+            assert_eq!(genstate.cells.to_pattern(None).0, "32o$32o!".to_owned());
+            assert_eq!(genstate.wall_cells.to_pattern(None).0, "!".to_owned());
+            assert_eq!(genstate.player_states[0].cells.to_pattern(None).0, "!".to_owned());
+            assert_eq!(genstate.player_states[0].fog[0][0], u64::max_value());  // complete fog for player 0
+            assert_eq!(genstate.player_states[0].fog[1][0], u64::max_value());  // complete fog for player 0
+            assert_eq!(genstate.player_states[1].cells.to_pattern(None).0, "32o$32o!".to_owned());
+        }
+    }
+
+    #[test]
+    fn universe_copy_from_bit_grid_as_player_out_of_range() {
+        let mut uni = generate_test_universe_with_default_params(UniType::Server);
+        let grid = Pattern("64o$64o!".to_owned()).to_new_bit_grid(64, 2).unwrap();
+
+        let write_pattern_as = Some(0); // player 0
+        let dst_region = Region::new(0, 0, 32, 3); // out of range for player 0
+
+        uni.copy_from_bit_grid(&grid, dst_region, write_pattern_as);
+
+        {
+            let genstate = &uni.gen_states[uni.state_index];
+            assert_eq!(genstate.cells.to_pattern(None).0, "!".to_owned());
+            assert_eq!(genstate.wall_cells.to_pattern(None).0, "!".to_owned());
+            assert_eq!(genstate.player_states[0].cells.to_pattern(None).0, "!".to_owned()); // no player 0 cells
+            assert_eq!(genstate.player_states[0].fog[0][0], u64::max_value());  // complete fog for player 0
+            assert_eq!(genstate.player_states[0].fog[1][0], u64::max_value());  // complete fog for player 0
+            assert_eq!(genstate.player_states[1].cells.to_pattern(None).0, "!".to_owned()); // no player 1 cells
+        }
+    }
+
+    #[test]
+    fn universe_apply_basic() {
+        let mut s_uni = generate_test_universe_with_default_params(UniType::Server);
+        let mut c_uni = generate_test_universe_with_default_params(UniType::Client); // client is missing generation 1
+        let player1 = 1;
+        // glider
+        s_uni.toggle(16, 15, player1).unwrap();
+        s_uni.toggle(17, 16, player1).unwrap();
+        s_uni.toggle(15, 17, player1).unwrap();
+        s_uni.toggle(16, 17, player1).unwrap();
+        s_uni.toggle(17, 17, player1).unwrap();
+        let gens = 4;
+        for _ in 0..gens {
+            s_uni.next();
+        }
+        let diff = s_uni.diff(0, 5, None).unwrap();
+        assert_eq!(c_uni.apply(&diff, None), Ok(Some(5)));
+        let s_idx = s_uni.state_index;
+        let c_idx = c_uni.state_index;
+        assert_eq!(s_uni.gen_states[s_idx].gen_or_none, c_uni.gen_states[c_idx].gen_or_none);
+        assert_eq!(s_uni.gen_states[s_idx].cells, c_uni.gen_states[c_idx].cells);
+    }
+
+    #[test]
+    fn universe_apply_basic_player_visibility() {
+        let mut s_uni = generate_test_universe_with_default_params(UniType::Server);
+        let mut c_uni = generate_test_universe_with_default_params(UniType::Client); // client is missing generation 1
+        let player1 = 1;
+        // glider
+        s_uni.toggle(16, 15, player1).unwrap();
+        s_uni.toggle(17, 16, player1).unwrap();
+        s_uni.toggle(15, 17, player1).unwrap();
+        s_uni.toggle(16, 17, player1).unwrap();
+        s_uni.toggle(17, 17, player1).unwrap();
+        // r-pentomino
+        s_uni.toggle(89+16, 68+15, 0).unwrap();
+        s_uni.toggle(89+17, 68+15, 0).unwrap();
+        s_uni.toggle(89+15, 68+16, 0).unwrap();
+        s_uni.toggle(89+16, 68+16, 0).unwrap();
+        s_uni.toggle(89+16, 68+17, 0).unwrap();
+        let gens = 4;
+        for _ in 0..gens {
+            s_uni.next();
+        }
+        let player_id = 0;
+        let diff = s_uni.diff(0, 5, Some(player_id)).unwrap();
+        assert_eq!(c_uni.apply(&diff, Some(player_id)), Ok(Some(5)));
+        let s_idx = s_uni.state_index;
+        let c_idx = c_uni.state_index;
+        assert_eq!(s_uni.gen_states[s_idx].gen_or_none, c_uni.gen_states[c_idx].gen_or_none);
+        assert!(s_uni.gen_states[s_idx].cells != c_uni.gen_states[c_idx].cells); // player 0 doesn't know about player 1's cells
+        assert_eq!(s_uni.gen_states[s_idx].player_states[0].cells, c_uni.gen_states[c_idx].player_states[0].cells);
+    }
+}
+
+#[cfg(test)]
+mod genstate_tests {
+    use super::*;
+    use super::test_helpers::*;
+
+    #[test]
+    fn write_at_position_server_wall() {
+        let mut genstate = make_gen_state();
+
+        genstate.write_at_position(63, 0, 'W', None);
+        assert_eq!(genstate.cells[0][0], 0);
+        assert_eq!(genstate.wall_cells[0][0], 1);
+        assert_eq!(genstate.known[0][0], u64::max_value());
+        assert_eq!(genstate.player_states[0].cells[0][0], 0);
+        assert_eq!(genstate.player_states[1].cells[0][0], 0);
+    }
+
+    #[test]
+    fn write_at_position_server_wall_overwrite() {
+        let mut genstate = make_gen_state();
+
+        genstate.write_at_position(63, 0, 'b', None);
+        genstate.write_at_position(63, 0, 'W', None);
+        assert_eq!(genstate.cells[0][0], 0);
+        assert_eq!(genstate.wall_cells[0][0], 1);
+        assert_eq!(genstate.known[0][0], u64::max_value());
+        assert_eq!(genstate.player_states[0].cells[0][0], 0);
+        assert_eq!(genstate.player_states[1].cells[0][0], 0);
+    }
+
+    #[test]
+    fn write_at_position_server_player0() {
+        let mut genstate = make_gen_state();
+
+        genstate.write_at_position(63, 0, 'A', None);
+        assert_eq!(genstate.cells[0][0], 1);
+        assert_eq!(genstate.wall_cells[0][0], 0);
+        assert_eq!(genstate.known[0][0], u64::max_value());
+        assert_eq!(genstate.player_states[0].cells[0][0], 1);
+        assert_eq!(genstate.player_states[1].cells[0][0], 0);
+    }
+
+    #[test]
+    fn write_at_position_server_player1() {
+        let mut genstate = make_gen_state();
+
+        genstate.write_at_position(63, 0, 'B', None);
+        assert_eq!(genstate.cells[0][0], 1);
+        assert_eq!(genstate.wall_cells[0][0], 0);
+        assert_eq!(genstate.known[0][0], u64::max_value());
+        assert_eq!(genstate.player_states[0].cells[0][0], 0);
+        assert_eq!(genstate.player_states[1].cells[0][0], 1);
+    }
+
+    #[test]
+    fn write_at_position_server_player0_then_1() {
+        let mut genstate = make_gen_state();
+
+        genstate.write_at_position(63, 0, 'A', None);
+        genstate.write_at_position(63, 0, 'B', None);
+        assert_eq!(genstate.cells[0][0], 1);
+        assert_eq!(genstate.player_states[0].cells[0][0], 0);
+        assert_eq!(genstate.player_states[1].cells[0][0], 1);
+    }
+
+    #[test]
+    fn write_at_position_server_player1_then_unowned() {
+        let mut genstate = make_gen_state();
+
+        genstate.write_at_position(63, 0, 'B', None);
+        genstate.write_at_position(63, 0, 'o', None);
+        assert_eq!(genstate.cells[0][0], 1);
+        assert_eq!(genstate.wall_cells[0][0], 0);
+        assert_eq!(genstate.known[0][0], u64::max_value());
+        assert_eq!(genstate.player_states[0].cells[0][0], 0);
+        assert_eq!(genstate.player_states[1].cells[0][0], 0);
+    }
+
+    #[test]
+    fn write_at_position_server_player1_then_blank() {
+        let mut genstate = make_gen_state();
+
+        genstate.write_at_position(63, 0, 'B', None);
+        genstate.write_at_position(63, 0, 'b', None);
+        assert_eq!(genstate.cells[0][0], 0);
+        assert_eq!(genstate.wall_cells[0][0], 0);
+        assert_eq!(genstate.known[0][0], u64::max_value());
+        assert_eq!(genstate.player_states[0].cells[0][0], 0);
+        assert_eq!(genstate.player_states[1].cells[0][0], 0);
+    }
+
+    #[test]
+    fn write_at_position_as_player0_player1_then_blank() {
+        let mut genstate = make_gen_state();
+
+        genstate.write_at_position(63, 0, 'B', Some(0));
+        genstate.write_at_position(63, 0, 'b', Some(0));
+        assert_eq!(genstate.cells[0][0], 0);
+        assert_eq!(genstate.wall_cells[0][0], 0);
+        assert_eq!(genstate.known[0][0], u64::max_value());
+        assert_eq!(genstate.player_states[0].cells[0][0], 0);
+        assert_eq!(genstate.player_states[1].cells[0][0], 0);
+    }
+
+    #[test]
+    fn write_at_position_as_player0_clears_only_that_players_fog() {
+        let mut genstate = make_gen_state();
+
+        // fog bits initially clear for both players
+        genstate.player_states[0].fog[0][0] = 0;
+        genstate.player_states[1].fog[0][0] = 0;
+        genstate.write_at_position(63, 0, '?', Some(0));
+        assert_eq!(genstate.cells[0][0], 0);
+        assert_eq!(genstate.wall_cells[0][0], 0);
+        assert_eq!(genstate.player_states[0].cells[0][0], 0);
+        assert_eq!(genstate.player_states[0].fog[0][0], 1);
+        assert_eq!(genstate.player_states[1].cells[0][0], 0);
+        assert_eq!(genstate.player_states[1].fog[0][0], 0);
+    }
+
+    #[test]
+    fn write_at_position_as_player0_sets_only_that_players_fog() {
+        let mut genstate = make_gen_state();
+
+        // fog bits initially set for both players
+        genstate.player_states[0].fog[0][0] = 1;
+        genstate.player_states[1].fog[0][0] = 1;
+        genstate.write_at_position(63, 0, 'o', Some(0));
+        assert_eq!(genstate.cells[0][0], 1);
+        assert_eq!(genstate.wall_cells[0][0], 0);
+        assert_eq!(genstate.player_states[0].cells[0][0], 0);
+        assert_eq!(genstate.player_states[0].fog[0][0], 0);
+        assert_eq!(genstate.player_states[1].cells[0][0], 0);
+        assert_eq!(genstate.player_states[1].fog[0][0], 1);
+    }
+
+    #[test]
+    fn gen_state_get_run_player0_fog() {
+        let mut genstate = make_gen_state();
+
+        // The following two are not really tests -- they are just consequences of the writable
+        // areas set up for these players when creating the Universe, and are here for
+        // "documentation".
+        assert_eq!(genstate.player_states[0].fog[0][0], u64::max_value());  // complete fog for player 0
+        assert_eq!(genstate.player_states[1].fog[0][0], 0);                 // no fog here for player 1
+
+        let write_pattern_as = Some(1);   // avoid clearing fog for players other than player 1
+        Pattern("o!".to_owned()).to_grid(&mut genstate, write_pattern_as).unwrap();
+        let visibility = Some(0); // as player 0
+        assert_eq!(genstate.get_run(0, 0, visibility), (genstate.width(), '?'));
+    }
+
+    #[test]
+    fn gen_state_copy_from_bit_grid_simple() {
+        let mut genstate = make_gen_state();
+        let grid = Pattern("64o$64o!".to_owned()).to_new_bit_grid(64, 2).unwrap();
+
+        let write_pattern_as = None;
+        let dst_region = Region::new(0, 0, 32, 3);
+        genstate.copy_from_bit_grid(&grid, dst_region, write_pattern_as);
+
+        assert_eq!(genstate.cells.to_pattern(None).0, "32o$32o!".to_owned());
+        assert_eq!(genstate.wall_cells.to_pattern(None).0, "!".to_owned());
+        for player_id in 0..genstate.player_states.len() {
+            assert_eq!(genstate.player_states[player_id].cells.to_pattern(None).0, "!".to_owned());
+        }
+    }
+
+    #[test]
+    fn gen_state_copy_from_bit_grid_as_player() {
+        let mut genstate = make_gen_state();
+        let grid = Pattern("64o$64o!".to_owned()).to_new_bit_grid(64, 2).unwrap();
+
+        assert_eq!(genstate.player_states[0].fog[0][0], u64::max_value());  // complete fog for player 0
+        assert_eq!(genstate.player_states[1].fog[0][0], 0);                 // no fog here for player 1
+
+        let write_pattern_as = Some(1); // player 1
+        let raw_dst_region = Region::new(0, 0, 32, 3);
+
+        // intersect with player 1 writable region from make_gen_state()
+        let dst_region = raw_dst_region.intersection(Region::new(0, 0, 80, 80)).unwrap();
+
+        genstate.copy_from_bit_grid(&grid, dst_region, write_pattern_as);
+
+        assert_eq!(genstate.cells.to_pattern(None).0, "32o$32o!".to_owned());
+        assert_eq!(genstate.wall_cells.to_pattern(None).0, "!".to_owned());
+        assert_eq!(genstate.player_states[0].cells.to_pattern(None).0, "!".to_owned());
+        assert_eq!(genstate.player_states[0].fog[0][0], u64::max_value());  // complete fog for player 0
+        assert_eq!(genstate.player_states[0].fog[1][0], u64::max_value());  // complete fog for player 0
+        assert_eq!(genstate.player_states[1].cells.to_pattern(None).0, "32o$32o!".to_owned());
+    }
+
+
+    #[test]
+    fn gen_state_pair_get_run_simple() {
+        let gs0 = make_gen_state();
+        let mut gs1 = make_gen_state();
+        Pattern("o!".to_owned()).to_grid(&mut gs1, None).unwrap();
+
+        let pair = GenStatePair {
+            gen_state0: &gs0,
+            gen_state1: &gs1,
+        };
+
+        assert_eq!(pair.get_run(0, 0, None), (1, 'o'));
+        assert_eq!(pair.get_run(1, 0, None), (gs0.width() - 1, '"'));
+    }
+
+    #[test]
+    fn gen_state_diff_and_restore_complex1() {
+        let gs0 = make_gen_state();
+        let mut gs1 = make_gen_state();
+        let visibility = None;
+        let pat_str = "b2o23b2o21b$b2o23bo22b$24bobo22b$15b2o7b2o23b$2o13bobo31b$2o13bob2o30b$16b2o31b$16bo32b$44b2o3b$16bo27b2o3b$16b2o31b$2o13bob2o13bo3bo12b$2o13bobo13bo5bo7b2o2b$15b2o14bo13b2o2b$31b2o3bo12b$b2o30b3o13b$b2o46b$33b3o13b$31b2o3bo12b$31bo13b2o2b$31bo5bo7b2o2b$32bo3bo12b2$44b2o3b$44b2o3b5$37b2o10b$37bobo7b2o$39bo7b2o$37b3o9b$22bobo24b$21b3o25b$21b3o25b$21bo15b3o9b$25bobo11bo9b$21b2o4bo9bobo9b$16b2o4bo3b2o9b2o10b$15bobo6bo24b$15bo33b$14b2o!".to_owned();
+        Pattern(pat_str).to_grid(&mut gs1, visibility).unwrap();
+
+        let gsdiff = gs0.diff(&gs1, visibility);
+
+        let mut new_gs = make_gen_state();
+
+        gsdiff.pattern.to_grid(&mut new_gs, visibility).unwrap();
+        assert_eq!(new_gs.gen_or_none, gs1.gen_or_none);
+        assert_eq!(new_gs.cells, gs1.cells);
+        assert_eq!(new_gs.known, gs1.known);
+        assert_eq!(new_gs.wall_cells, gs1.wall_cells);
+        for i in 0..new_gs.player_states.len() {
+            assert_eq!(new_gs.player_states[i].cells, gs1.player_states[i].cells);
+            //assert_eq!(new_gs.player_states[i].fog, gs1.player_states[i].fog);  // OK for fog to differ, because normally the fog would already
+                                                                                  // be cleared where pattern is being written.
+        }
+    }
+
+    #[test]
+    fn gen_state_diff_and_restore_complex1_with_visibility() {
+        let gs0 = make_gen_state();
+        let mut gs1 = make_gen_state();
+        let visibility = Some(1);
+        let pat_str = "b2o23b2o21b$b2o23bo22b$24bobo22b$15b2o7b2o23b$2o13bobo31b$2o13bob2o30b$16b2o31b$16bo32b$44b2o3b$16bo27b2o3b$16b2o31b$2o13bob2o13bo3bo12b$2o13bobo13bo5bo7b2o2b$15b2o14bo13b2o2b$31b2o3bo12b$b2o30b3o13b$b2o46b$33b3o13b$31b2o3bo12b$31bo13b2o2b$31bo5bo7b2o2b$32bo3bo12b2$44b2o3b$44b2o3b5$37b2o10b$37bobo7b2o$39bo7b2o$37b3o9b$22bobo24b$21b3o25b$21b3o25b$21bo15b3o9b$25bobo11bo9b$21b2o4bo9bobo9b$16b2o4bo3b2o9b2o10b$15bobo6bo24b$15bo33b$14b2o!".to_owned();
+        Pattern(pat_str).to_grid(&mut gs1, visibility).unwrap();
+
+        let gsdiff = gs0.diff(&gs1, visibility);
+
+        let mut new_gs = make_gen_state();
+
+        gsdiff.pattern.to_grid(&mut new_gs, visibility).unwrap();
+        assert_eq!(new_gs.gen_or_none, gs1.gen_or_none);
+        assert_eq!(new_gs.cells, gs1.cells);
+        assert_eq!(new_gs.known, gs1.known);
+        assert_eq!(new_gs.wall_cells, gs1.wall_cells);
+        for i in 0..new_gs.player_states.len() {
+            assert_eq!(new_gs.player_states[i].cells, gs1.player_states[i].cells);
+            assert_eq!(new_gs.player_states[i].fog, gs1.player_states[i].fog);
+        }
+    }
+
+    #[test]
+    fn gen_state_pair_get_run_simple2() {
+        let mut gs0 = make_gen_state();
+        Pattern("2o3b5o!".to_owned()).to_grid(&mut gs0, None).unwrap();
+        let mut gs1 = make_gen_state();
+        Pattern("2o3b5o!".to_owned()).to_grid(&mut gs1, None).unwrap();
+
+        let pair = GenStatePair {
+            gen_state0: &gs0,
+            gen_state1: &gs1,
+        };
+
+        assert_eq!(pair.get_run(0, 0, None), (gs0.width(), '"'));
+    }
+
+    #[test]
+    fn gen_state_pair_get_run_simple3() {
+        let mut gs0 = make_gen_state();
+        Pattern("4b5o!".to_owned()).to_grid(&mut gs0, None).unwrap();
+        let mut gs1 = make_gen_state();
+        Pattern("3b5o!".to_owned()).to_grid(&mut gs1, None).unwrap();
+
+        let pair = GenStatePair {
+            gen_state0: &gs0,
+            gen_state1: &gs1,
+        };
+
+        assert_eq!(pair.get_run(0,       0, None), (3, '"'));
+        assert_eq!(pair.get_run(3,       0, None), (1, 'o'));
+        assert_eq!(pair.get_run(3+1,     0, None), (4, '"'));
+        assert_eq!(pair.get_run(3+1+4,   0, None), (1, 'b'));
+        assert_eq!(pair.get_run(3+1+4+1, 0, None), (gs0.width() - (3+1+4+1), '"'));
+    }
+
+}

--- a/netwayste/.gitignore
+++ b/netwayste/.gitignore
@@ -1,0 +1,4 @@
+/target/
+**/*.rs.bk
+.?.sw?
+rusty-tags.vi

--- a/netwayste/.gitignore
+++ b/netwayste/.gitignore
@@ -1,4 +1,0 @@
-/target/
-**/*.rs.bk
-.?.sw?
-rusty-tags.vi

--- a/netwayste/Cargo.toml
+++ b/netwayste/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "netwayste"
+version = "0.2.0"
+authors = ["Aaron Miller <aaron.miller04@gmail.com>", "manghi <manghirs@gmail.com>"]
+edition = "2018"
+
+[[bin]]
+name = "server"
+path = "src/server.rs"
+
+[dependencies]
+futures              = "0.1.17"
+tokio-core           = "0.1.9"
+log                  = "0.4.6"
+chrono               = "0.4.6"
+env_logger           = "0.6.1"
+serde                = {version="1.0.90", features=["derive"]}
+bincode              = "0.9.2"
+base64               = "0.10.1"
+rand                 = "0.6.5"
+time                 = "0.1"
+proptest             = "0.7.2"
+semver               = "0.9.0"
+tokio-dns-unofficial = "0.4"
+regex                = "1"
+clap                 = "2"
+color-backtrace      = "0.1"

--- a/netwayste/LICENSE.txt
+++ b/netwayste/LICENSE.txt
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/netwayste/README.md
+++ b/netwayste/README.md
@@ -1,0 +1,15 @@
+netwayste
+=========
+
+This crate is part of [Conwayste](https://github.com/conwayste/conwayste), a multi-player version of [Conway's game of life](https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life). In particular, this crate implements [UDP](https://en.wikipedia.org/wiki/User_Datagram_Protocol) networking based on [Tokio](https://tokio.rs/).
+
+See the documentation for the latest published version at [docs.rs](https://docs.rs/netwayste/latest/netwayste/).
+
+## Usage
+
+Put this in your Cargo.toml and hack away, friend:
+
+```
+[dependencies]
+netwayste = "*"
+```

--- a/netwayste/examples/cli-client.rs
+++ b/netwayste/examples/cli-client.rs
@@ -1,0 +1,716 @@
+/*
+ * A networking library for the multiplayer game, Conwayste.
+ *
+ * Copyright (C) 2018-2019 The Conwayste Developers
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#[macro_use] extern crate log;
+extern crate color_backtrace;
+extern crate env_logger;
+extern crate futures;
+extern crate netwayste;
+extern crate tokio_core;
+
+use std::io::{self, Read, Write};
+use std::process;
+use std::str::FromStr;
+use std::sync::mpsc::channel as std_channel;
+use std::sync::mpsc::TryRecvError;
+use std::thread;
+use std::time::Duration;
+
+use chrono::Local;
+use futures::sync::mpsc;
+use log::LevelFilter;
+use netwayste::{
+    client::{ClientNetState, CLIENT_VERSION},
+    net::{NetwaysteEvent, RequestAction, Packet, ResponseCode},
+};
+
+const SLEEP: Duration = Duration::from_millis(33);  // 30 "frames" per second
+
+#[derive(PartialEq, Debug, Clone)]
+enum UserInput {
+    Command { cmd: String, args: Vec<String> },
+    Chat(String),
+}
+
+// At this point we should only have command or chat message to work with
+fn parse_stdin(mut input: String) -> UserInput {
+    if input.get(0..1) == Some("/") {
+        // this is a command
+        input.remove(0); // remove initial slash
+
+        let mut words: Vec<String> = input.split_whitespace().map(|w| w.to_owned()).collect();
+
+        let command = if words.len() > 0 {
+            words.remove(0).to_lowercase()
+        } else {
+            "".to_owned()
+        };
+
+        UserInput::Command {
+            cmd: command,
+            args: words,
+        }
+    } else {
+        UserInput::Chat(input)
+    }
+}
+
+// Our helper method which will read data from stdin and send it along the
+// sender provided. This is blocking so should be on separate thread.
+fn read_stdin(channel_to_netwayste: mpsc::UnboundedSender<NetwaysteEvent>) {
+    let mut stdin = io::stdin();
+    loop {
+        let mut buf = vec![0; 1024];
+        let n = match stdin.read(&mut buf) {
+            Err(_) | Ok(0) => break,
+            Ok(n) => n,
+        };
+        buf.truncate(n);
+        let string = String::from_utf8(buf).unwrap();
+        let string = String::from_str(string.trim()).unwrap();
+        if !string.is_empty() && string != "" {
+            let user_input = parse_stdin(string);
+            let event = handle_user_input_event(user_input);
+            match channel_to_netwayste.unbounded_send(event) {
+                Ok(_) => {}
+                Err(e) => error!("Could not send event to netwayste thread: {}", e),
+            }
+        }
+    }
+}
+
+fn print_help() {
+    info!("");
+    info!("/help                  - print this text");
+    info!("/connect <player_name> - connect to server");
+    info!("/disconnect            - disconnect from server");
+    info!("/list                  - list rooms when in lobby, or players when in game");
+    info!("/new <room_name>       - create a new room (when not in game)");
+    info!("/join <room_name>      - join a room (when not in game)");
+    info!("/leave                 - leave a room (when in game)");
+    info!("/part                  - alias of leave");
+    info!("/quit                  - exit the program");
+    info!("...or just type text to chat!");
+}
+
+fn build_command_request_action(cmd: String, args: Vec<String>) -> NetwaysteEvent {
+    let mut new_event: NetwaysteEvent = NetwaysteEvent::None;
+    // keep these in sync with print_help function
+    match cmd.as_str() {
+        "help" | "?" | "h" => {
+            print_help();
+        }
+        "connect" | "c" => {
+            if args.len() == 1 {
+                new_event = NetwaysteEvent::Connect(args[0].clone(), CLIENT_VERSION.to_owned());
+            } else {
+                error!("Expected client name as the sole argument (no spaces allowed).");
+            }
+        }
+        "disconnect" | "d" => {
+            if args.len() == 0 {
+                new_event = NetwaysteEvent::Disconnect;
+            } else {
+                debug!("Command failed: Expected no arguments to disconnect");
+            }
+        }
+        "list" | "l" => {
+            if args.len() == 0 {
+                new_event = NetwaysteEvent::List;
+            } else {
+                debug!("Command failed: Expected no arguments to list");
+            }
+        }
+        "new" | "n" => {
+            if args.len() == 1 {
+                new_event = NetwaysteEvent::NewRoom(args[0].clone());
+            } else {
+                debug!("Command failed: Expected name of room (no spaces allowed)");
+            }
+        }
+        "join" | "j" => {
+            if args.len() == 1 {
+                new_event = NetwaysteEvent::JoinRoom(args[0].clone());
+            } else {
+                debug!("Command failed: Expected room name only (no spaces allowed)");
+            }
+        }
+        "part" | "leave" => {
+            if args.len() == 0 {
+                new_event = NetwaysteEvent::LeaveRoom;
+            } else {
+                debug!("Command failed: Expected no arguments to leave");
+            }
+        }
+        "quit" | "q" | "exit" => {
+            trace!("Peace out!");
+            new_event = NetwaysteEvent::Disconnect;
+        }
+        _ => {
+            debug!("Command not recognized: {}", cmd);
+        }
+    }
+    new_event
+}
+
+fn handle_user_input_event(user_input: UserInput) -> NetwaysteEvent {
+    match user_input {
+        UserInput::Chat(string) => NetwaysteEvent::ChatMessage(string),
+        UserInput::Command { cmd, args } => build_command_request_action(cmd, args),
+    }
+}
+
+fn main() {
+    color_backtrace::install();
+    env_logger::Builder::new()
+        .format(|buf, record| {
+            writeln!(
+                buf,
+                "{} [{:5}] - {}",
+                Local::now().format("%a %Y-%m-%d %H:%M:%S%.6f"),
+                record.level(),
+                record.args(),
+            )
+        })
+        .filter(None, LevelFilter::Trace)
+        .filter(Some("futures"), LevelFilter::Off)
+        .filter(Some("tokio_core"), LevelFilter::Off)
+        .filter(Some("tokio_reactor"), LevelFilter::Off)
+        .filter(Some("conway"), LevelFilter::Off)
+        .filter(Some("ggez"), LevelFilter::Off)
+        .filter(Some("gfx_device_gl"), LevelFilter::Off)
+        .filter(Some("netwayste"), LevelFilter::Info) //Ignore Trace events can be noisy, keep all others
+        .init();
+
+    let (ggez_client_request, nw_client_request) = mpsc::unbounded::<NetwaysteEvent>();
+    let (nw_server_response, ggez_server_response) = std_channel::<NetwaysteEvent>();
+    thread::spawn(move || {
+        ClientNetState::start_network(nw_server_response, nw_client_request);
+    });
+
+    thread::spawn(move || {
+        read_stdin(ggez_client_request);
+    });
+
+    info!("Type /help for more info...");
+
+    loop {
+        // This is inefficient -- it would be better not to poll for messages on the channel.
+        // However, we are polling in GUI client's update() function so do it here as well.
+        match ggez_server_response.try_recv() {
+            Ok(response_code) => {
+                println!("{:?}", response_code);
+            }
+            Err(TryRecvError::Empty) => {
+                // Nothing to do in the empty case
+            }
+            Err(TryRecvError::Disconnected) => {
+                println!("Communications channel link with netwayste disconnected unexpectedly. Shutting down...");
+                process::exit(1);
+            }
+        }
+        // sleep as if we were in ggez and are waiting for the next call to update()
+        thread::sleep(SLEEP);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_stdin_input_has_no_leading_forward_slash() {
+        let chat = parse_stdin("some text".to_owned());
+        assert_eq!(chat, UserInput::Chat("some text".to_owned()));
+    }
+
+    #[test]
+    fn parse_stdin_input_no_arguments() {
+        let cmd = parse_stdin("/helpusobi".to_owned());
+        assert_eq!(
+            cmd,
+            UserInput::Command {
+                cmd: "helpusobi".to_owned(),
+                args: vec![]
+            }
+        );
+    }
+
+    #[test]
+    fn parse_stdin_input_multiple_arguments() {
+        let cmd = parse_stdin("/helpusobi 1".to_owned());
+        assert_eq!(
+            cmd,
+            UserInput::Command {
+                cmd: "helpusobi".to_owned(),
+                args: vec!["1".to_owned()]
+            }
+        );
+
+        let cmd = parse_stdin("/helpusobi 1 you".to_owned());
+        assert_eq!(
+            cmd,
+            UserInput::Command {
+                cmd: "helpusobi".to_owned(),
+                args: vec!["1".to_owned(), "you".to_owned()]
+            }
+        );
+
+        let cmd = parse_stdin("/helpusobi 1 you are our only hope".to_owned());
+        assert_eq!(
+            cmd,
+            UserInput::Command {
+                cmd: "helpusobi".to_owned(),
+                args: vec![
+                    "1".to_owned(),
+                    "you".to_owned(),
+                    "are".to_owned(),
+                    "our".to_owned(),
+                    "only".to_owned(),
+                    "hope".to_owned()
+                ]
+            }
+        );
+    }
+
+    /* XXX testXXX
+    #[test]
+    fn build_command_request_action_unknown_command() {
+        let command = UserInput::Command {
+            cmd: "helpusobi".to_owned(),
+            args: vec!["1".to_owned()],
+        };
+
+        match command {
+            UserInput::Command { cmd, args } => {
+                let action = build_command_request_action(cmd, args);
+                assert_eq!(action, RequestAction::None);
+            }
+            UserInput::Chat(_) => unreachable!(),
+        }
+    }
+    */
+
+    /* XXX testXXX
+    #[test]
+    fn build_command_request_action_help_returns_no_action() {
+        let command = UserInput::Command {
+            cmd: "help".to_owned(),
+            args: vec![],
+        };
+
+        match command {
+            UserInput::Command { cmd, args } => {
+                let action = build_command_request_action(cmd, args);
+                assert_eq!(action, RequestAction::None);
+            }
+            UserInput::Chat(_) => unreachable!(),
+        }
+    }
+    */
+
+    /* XXX testXXX
+    #[test]
+    fn build_command_request_action_disconnect() {
+        let command = UserInput::Command {
+            cmd: "disconnect".to_owned(),
+            args: vec![],
+        };
+
+        match command {
+            UserInput::Command { cmd, args } => {
+                let action = build_command_request_action(cmd, args);
+                assert_eq!(action, RequestAction::Disconnect);
+            }
+            UserInput::Chat(_) => unreachable!(),
+        }
+    }
+    */
+
+    /* XXX testXXX
+    #[test]
+    fn build_command_request_action_disconnect_with_args_returns_no_action() {
+        let command = UserInput::Command {
+            cmd: "disconnect".to_owned(),
+            args: vec!["1".to_owned()],
+        };
+
+        match command {
+            UserInput::Command { cmd, args } => {
+                let action = build_command_request_action(cmd, args);
+                assert_eq!(action, RequestAction::None);
+            }
+            UserInput::Chat(_) => unreachable!(),
+        }
+    }
+    */
+
+    /* XXX testXXX
+    #[test]
+    fn build_command_request_action_list_in_lobby() {
+        let command = UserInput::Command {
+            cmd: "list".to_owned(),
+            args: vec![],
+        };
+
+        match command {
+            UserInput::Command { cmd, args } => {
+                let action = build_command_request_action(cmd, args);
+                assert_eq!(action, RequestAction::ListRooms);
+            }
+            UserInput::Chat(_) => unreachable!(),
+        }
+    }
+    */
+
+    /* XXX testXXX
+    #[test]
+    fn build_command_request_action_list_in_game() {
+        let command = UserInput::Command {
+            cmd: "list".to_owned(),
+            args: vec![],
+        };
+
+        client_state.room = Some("some room".to_owned());
+        match command {
+            UserInput::Command { cmd, args } => {
+                let action = client_state.build_command_request_action(cmd, args);
+                assert_eq!(action, RequestAction::ListPlayers);
+            }
+            UserInput::Chat(_) => unreachable!(),
+        }
+    }
+    */
+
+    /* XXX testXXX
+    #[test]
+    fn build_command_request_action_leave_cases() {
+        let command = UserInput::Command {
+            cmd: "leave".to_owned(),
+            args: vec![],
+        };
+
+        // Not in a room
+        match command.clone() {
+            UserInput::Command { cmd, args } => {
+                let action = build_command_request_action(cmd, args);
+                assert_eq!(action, RequestAction::None);
+            }
+            UserInput::Chat(_) => unreachable!(),
+        }
+
+        // Happy to leave
+        client_state.room = Some("some room".to_owned());
+        match command {
+            UserInput::Command { cmd, args } => {
+                let action = build_command_request_action(cmd, args);
+                assert_eq!(action, RequestAction::LeaveRoom);
+            }
+            UserInput::Chat(_) => unreachable!(),
+        }
+
+        // Even though we're in a room, you cannot specify anything else
+        let command = UserInput::Command {
+            cmd: "leave".to_owned(),
+            args: vec!["some room".to_owned()],
+        };
+        match command {
+            UserInput::Command { cmd, args } => {
+                let action = build_command_request_action(cmd, args);
+                assert_eq!(action, RequestAction::None);
+            }
+            UserInput::Chat(_) => unreachable!(),
+        }
+    }
+    */
+
+    /* XXX testXXX
+    #[test]
+    fn build_command_request_action_join_cases() {
+        let command = UserInput::Command {
+            cmd: "join".to_owned(),
+            args: vec![],
+        };
+
+        let mut client_state = create_client_net_state();
+        // no room specified
+        match command.clone() {
+            UserInput::Command { cmd, args } => {
+                let action = client_state.build_command_request_action(cmd, args);
+                assert_eq!(action, RequestAction::None);
+            }
+            UserInput::Chat(_) => unreachable!(),
+        }
+
+        // Already in game
+        client_state.room = Some("some room".to_owned());
+        match command {
+            UserInput::Command { cmd, args } => {
+                let action = client_state.build_command_request_action(cmd, args);
+                assert_eq!(action, RequestAction::None);
+            }
+            UserInput::Chat(_) => unreachable!(),
+        }
+
+        // Happily join one
+        client_state.room = None;
+        let command = UserInput::Command {
+            cmd: "join".to_owned(),
+            args: vec!["some room".to_owned()],
+        };
+        match command {
+            UserInput::Command { cmd, args } => {
+                let action = client_state.build_command_request_action(cmd, args);
+                assert_eq!(action, RequestAction::JoinRoom("some room".to_owned()));
+            }
+            UserInput::Chat(_) => unreachable!(),
+        }
+    }
+    */
+
+    /* XXX testXXX
+    #[test]
+    fn handle_user_input_event_increment_sequence_number() {
+        // There is a lot that _could_ be tested here but most of it is handled in the above test cases.
+        let mut client_state = create_client_net_state();
+        let (udp_tx, _) = mpsc::unbounded();
+        let (exit_tx, _) = mpsc::unbounded();
+        let user_input = UserInput::Chat("memes".to_owned());
+
+        client_state.cookie = Some("ThisDoesNotReallyMatterAsLongAsItExists".to_owned());
+        client_state.handle_user_input_event(&udp_tx, &exit_tx, user_input);
+        assert_eq!(client_state.sequence, 1);
+
+        let user_input = UserInput::Chat("and another one".to_owned());
+        client_state.handle_user_input_event(&udp_tx, &exit_tx, user_input);
+        assert_eq!(client_state.sequence, 2);
+    }
+    */
+
+    /* XXX testXXX
+    #[test]
+    fn handle_incoming_event_basic_tx_rx_queueing() {
+        let mut client_state = create_client_net_state();
+        let (udp_tx, _) = mpsc::unbounded();
+        let (exit_tx, _) = mpsc::unbounded();
+        let connect_cmd = UserInput::Command {
+            cmd: "connect".to_owned(),
+            args: vec!["name".to_owned()],
+        };
+        let new_room_cmd = UserInput::Command {
+            cmd: "new".to_owned(),
+            args: vec!["room_name".to_owned()],
+        };
+        let join_room_cmd = UserInput::Command {
+            cmd: "join".to_owned(),
+            args: vec!["room_name".to_owned()],
+        };
+        let leave_room_cmd = UserInput::Command {
+            cmd: "leave".to_owned(),
+            args: vec![],
+        };
+
+        client_state.sequence = 0;
+        client_state.response_sequence = 1;
+        client_state.handle_user_input_event(&udp_tx, &exit_tx, connect_cmd); // Seq 0
+        client_state.cookie = Some("ThisDoesNotReallyMatterAsLongAsItExists".to_owned());
+        // dequeue connect since we don't actually want to process it later
+        client_state.network.tx_packets.clear();
+        client_state.handle_user_input_event(&udp_tx, &exit_tx, new_room_cmd); // Seq 1
+        client_state.handle_user_input_event(&udp_tx, &exit_tx, join_room_cmd); // Seq 2
+        client_state.room = Some("room_name".to_owned());
+        client_state.handle_user_input_event(&udp_tx, &exit_tx, leave_room_cmd); // Seq 3
+        assert_eq!(client_state.sequence, 3);
+        assert_eq!(client_state.response_sequence, 1);
+        assert_eq!(client_state.network.tx_packets.len(), 3);
+        assert_eq!(client_state.network.rx_packets.len(), 0);
+
+        let room_response = Packet::Response {
+            sequence: 1,
+            request_ack: Some(1),
+            code: ResponseCode::OK,
+        };
+        let join_response = Packet::Response {
+            sequence: 2,
+            request_ack: Some(2),
+            code: ResponseCode::OK,
+        };
+        let leave_response = Packet::Response {
+            sequence: 3,
+            request_ack: Some(3),
+            code: ResponseCode::OK,
+        };
+
+        client_state.handle_incoming_event(&udp_tx, Some(leave_response)); // 3 arrives
+        assert_eq!(client_state.network.tx_packets.len(), 2);
+        assert_eq!(client_state.network.rx_packets.len(), 1);
+        client_state.handle_incoming_event(&udp_tx, Some(join_response)); // 2 arrives
+        assert_eq!(client_state.network.tx_packets.len(), 1);
+        assert_eq!(client_state.network.rx_packets.len(), 2);
+        client_state.handle_incoming_event(&udp_tx, Some(room_response)); // 1 arrives
+        assert_eq!(client_state.network.tx_packets.len(), 0);
+        // RX should be cleared out because upon processing packet sequence '1', RX queue will be contiguous
+        assert_eq!(client_state.network.rx_packets.len(), 0);
+    }
+    */
+
+    /* XXX testXXX
+    #[test]
+    fn handle_incoming_event_basic_tx_rx_queueing_cannot_process_all_responses() {
+        let mut client_state = create_client_net_state();
+        let (udp_tx, _) = mpsc::unbounded();
+        let (exit_tx, _) = mpsc::unbounded();
+        let connect_cmd = UserInput::Command {
+            cmd: "connect".to_owned(),
+            args: vec!["name".to_owned()],
+        };
+        let new_room_cmd = UserInput::Command {
+            cmd: "new".to_owned(),
+            args: vec!["room_name".to_owned()],
+        };
+        let join_room_cmd = UserInput::Command {
+            cmd: "join".to_owned(),
+            args: vec!["room_name".to_owned()],
+        };
+        let leave_room_cmd = UserInput::Command {
+            cmd: "leave".to_owned(),
+            args: vec![],
+        };
+
+        client_state.sequence = 0;
+        client_state.response_sequence = 1;
+        client_state.handle_user_input_event(&udp_tx, &exit_tx, connect_cmd); // Seq 0
+        client_state.cookie = Some("ThisDoesNotReallyMatterAsLongAsItExists".to_owned());
+        // dequeue connect since we don't actually want to process it later
+        client_state.network.tx_packets.clear();
+        client_state.handle_user_input_event(&udp_tx, &exit_tx, new_room_cmd); // Seq 1
+        client_state.handle_user_input_event(&udp_tx, &exit_tx, join_room_cmd.clone()); // Seq 2
+        client_state.room = Some("room_name".to_owned());
+        client_state.handle_user_input_event(&udp_tx, &exit_tx, leave_room_cmd); // Seq 3
+        client_state.room = None; // Temporarily set to None so we can process the next join
+        client_state.handle_user_input_event(&udp_tx, &exit_tx, join_room_cmd); // Seq 4
+        client_state.room = Some("room_name".to_owned());
+        assert_eq!(client_state.sequence, 4);
+        assert_eq!(client_state.response_sequence, 1);
+        assert_eq!(client_state.network.tx_packets.len(), 4);
+        assert_eq!(client_state.network.rx_packets.len(), 0);
+
+        let room_response = Packet::Response {
+            sequence: 1,
+            request_ack: Some(1),
+            code: ResponseCode::OK,
+        };
+        let join_response = Packet::Response {
+            sequence: 2,
+            request_ack: Some(2),
+            code: ResponseCode::OK,
+        };
+        let _leave_response = Packet::Response {
+            sequence: 3,
+            request_ack: Some(3),
+            code: ResponseCode::OK,
+        };
+        let join2_response = Packet::Response {
+            sequence: 4,
+            request_ack: Some(4),
+            code: ResponseCode::OK,
+        };
+
+        // The intent is that 3 never arrives
+        client_state.handle_incoming_event(&udp_tx, Some(join2_response)); // 4 arrives
+        assert_eq!(client_state.network.tx_packets.len(), 3);
+        assert_eq!(client_state.network.rx_packets.len(), 1);
+        client_state.handle_incoming_event(&udp_tx, Some(join_response)); // 2 arrives
+        assert_eq!(client_state.network.tx_packets.len(), 2);
+        assert_eq!(client_state.network.rx_packets.len(), 2);
+        client_state.handle_incoming_event(&udp_tx, Some(room_response)); // 1 arrives
+        assert_eq!(client_state.network.tx_packets.len(), 1);
+        assert_eq!(client_state.network.rx_packets.len(), 1);
+    }
+*/
+
+    /* XXX testXXX
+    #[test]
+    fn handle_incoming_event_basic_tx_rx_queueing_arrives_at_server_out_of_order() {
+        let mut client_state = create_client_net_state();
+        let (udp_tx, _) = mpsc::unbounded();
+        let (exit_tx, _) = mpsc::unbounded();
+        let connect_cmd = UserInput::Command {
+            cmd: "connect".to_owned(),
+            args: vec!["name".to_owned()],
+        };
+        let new_room_cmd = UserInput::Command {
+            cmd: "new".to_owned(),
+            args: vec!["room_name".to_owned()],
+        };
+        let join_room_cmd = UserInput::Command {
+            cmd: "join".to_owned(),
+            args: vec!["room_name".to_owned()],
+        };
+        let leave_room_cmd = UserInput::Command {
+            cmd: "leave".to_owned(),
+            args: vec![],
+        };
+
+        client_state.sequence = 0;
+        client_state.response_sequence = 1;
+        client_state.handle_user_input_event(&udp_tx, &exit_tx, connect_cmd); // Seq 0
+        client_state.cookie = Some("ThisDoesNotReallyMatterAsLongAsItExists".to_owned());
+        // dequeue connect since we don't actually want to process it later
+        client_state.network.tx_packets.clear();
+        client_state.handle_user_input_event(&udp_tx, &exit_tx, new_room_cmd); // Seq 1
+        client_state.handle_user_input_event(&udp_tx, &exit_tx, join_room_cmd); // Seq 2
+        client_state.room = Some("room_name".to_owned());
+        client_state.handle_user_input_event(&udp_tx, &exit_tx, leave_room_cmd); // Seq 3
+        assert_eq!(client_state.sequence, 3);
+        assert_eq!(client_state.response_sequence, 1);
+        assert_eq!(client_state.network.tx_packets.len(), 3);
+        assert_eq!(client_state.network.rx_packets.len(), 0);
+
+        // An out-of-order arrival at the server means the response packet's sequence number will not be 1:1 mapping
+        // as in the first basic tested above. End result should be the same in both cases.
+        let room_response = Packet::Response {
+            sequence: 2,
+            request_ack: Some(1),
+            code: ResponseCode::OK,
+        };
+        let join_response = Packet::Response {
+            sequence: 3,
+            request_ack: Some(2),
+            code: ResponseCode::OK,
+        };
+        let leave_response = Packet::Response {
+            sequence: 1,
+            request_ack: Some(3),
+            code: ResponseCode::OK,
+        };
+
+        client_state.handle_incoming_event(&udp_tx, Some(leave_response)); // client 3 arrives, can process
+        assert_eq!(client_state.network.tx_packets.len(), 2);
+        assert_eq!(client_state.network.rx_packets.len(), 0);
+        client_state.handle_incoming_event(&udp_tx, Some(join_response)); // client 2 arrives, cannot process
+        assert_eq!(client_state.network.tx_packets.len(), 1);
+        assert_eq!(client_state.network.rx_packets.len(), 1);
+        client_state.handle_incoming_event(&udp_tx, Some(room_response)); // client 1 arrives, can process all
+        assert_eq!(client_state.network.tx_packets.len(), 0);
+        assert_eq!(client_state.network.rx_packets.len(), 0);
+    }
+    */
+
+}

--- a/netwayste/notes/linux_tc.txt
+++ b/netwayste/notes/linux_tc.txt
@@ -1,0 +1,46 @@
+# Handle "1:" is equivalent to <major>:<minor>... minor of qdisc is always 0.
+#   This is the "root" qdisc with a handle of 1:
+# Classes need to have the same major number as their parent.
+#   The following command instantly creates classes 1:1, 1:2, and 1:3.
+
+#tc qdisc add dev eth0 root handle 1: prio
+
+
+# 1:3 refers to the third band of the PRIO queue.
+# This described by qdisc ID of 30:
+
+#tc class add dev lo parent 1:3 classid 1:10 netem delay 200ms 20ms distribution normal    # Delayed 200
+#tc class add dev eth0 parent 1:3 classid 1:20 netem loss 1%                                 # Dropped 1%
+# 20% of packets sent immediately, rest delayed 10ms
+#tc class add dev eth0 parent 1:3 classid 1:30 netem delay 10ms reorder 25% 50%              # out-of-order
+#tc class add dev eth0 parent 1:3 classid 1:30 netem delay 10ms duplicate 10%                # duplicate 10%
+#tc class add dev eth0 parent 1:3 classid 1:40 netem corrupt 1%                              # corrupt 1%
+
+
+# What packets belong in what qdisc?
+#
+# protocol ip   -- We are accepting IP traffic
+# parent        -- Must already exist (1:0 as specified above)
+# prio          -- Priority of this filter is set to 3. Lower the quicker.
+# fw flowid     -- Bases the decision on how the firewall (iptables) marked the packet, to be processed by the 1:3 class
+# handle        -- filter ID
+
+#tc filter add dev eth0 parent 1:0 protocol ip prio 3 handle 1 fw flowid 1:3
+
+# -o is for outbound; -i is for inbound
+# Mangle (modify) packets before they leave (POSTROUTING) on eth0 udp traffic.
+# Applied to class 1:3 <parent>:<child>
+
+#iptables -t mangle -A POSTROUTING -o eth0 -p udp -j CLASSIFY --set-class 1:3
+
+# So all in all, IP tables marks that all UDP packets sent out are processed by '1:3' which enacts on the IP protocol,
+# adding a delay of 200ms to each UDP packet.
+
+# Goal will be to set up a few netem filters and use IP tables to control which one is in use.
+#   1. Outgoing packet delay
+#   2. Dropping outgoing packets
+#   3. Re-ordering packets
+#   4. Packet duplication
+#   5. Packet corruption
+#   6. Enable ALL in some fashion (dying connection)
+

--- a/netwayste/src/client.rs
+++ b/netwayste/src/client.rs
@@ -1,0 +1,565 @@
+/*
+ * A networking library for the multiplayer game, Conwayste.
+ *
+ * Copyright (C) 2018-2019 The Conwayste Developers
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use std::env;
+use std::io;
+use std::iter;
+use std::error::Error;
+use std::net::SocketAddr;
+use std::process::exit;
+use std::time::Instant;
+use std::time::Duration;
+
+use futures::{Future, Sink, Stream, stream, future::ok, sync::mpsc};
+use regex::Regex;
+use tokio_core::reactor::{Core, Timeout};
+
+use crate::net::{
+    RequestAction, ResponseCode, Packet,
+    BroadcastChatMessage, NetworkManager, NetworkQueue,
+    VERSION, has_connection_timed_out, bind, DEFAULT_PORT,
+    LineCodec, NetwaysteEvent
+};
+
+const TICK_INTERVAL_IN_MS:          u64    = 1000;
+const NETWORK_INTERVAL_IN_MS:       u64    = 1000;
+
+pub const CLIENT_VERSION: &str = "0.0.1";
+
+//////////////// Event Handling /////////////////
+enum Event {
+    TickEvent,
+    Incoming((SocketAddr, Option<Packet>)),
+    NetworkEvent,
+    ConwaysteEvent(NetwaysteEvent)
+}
+
+pub struct ClientNetState {
+    pub sequence:         u64,          // Sequence number of requests
+    pub response_sequence: u64,         // Value of the next expected sequence number from the server,
+                                        // and indicates the sequence number of the next process-able rx packet
+    pub name:             Option<String>,
+    pub room:             Option<String>,
+    pub cookie:           Option<String>,
+    pub chat_msg_seq_num: u64,
+    pub tick:             usize,
+    pub network:          NetworkManager,
+    pub heartbeat:        Option<Instant>,
+    pub disconnect_initiated: bool,
+    pub server_address:   Option<SocketAddr>,
+    pub channel_to_conwayste:     std::sync::mpsc::Sender<NetwaysteEvent>,
+}
+
+impl ClientNetState {
+
+    pub fn new(channel_to_conwayste: std::sync::mpsc::Sender<NetwaysteEvent>) -> Self {
+        ClientNetState {
+            sequence:        0,
+            response_sequence: 0,
+            name:            None,
+            room:            None,
+            cookie:          None,
+            chat_msg_seq_num: 0,
+            tick:            0,
+            network:         NetworkManager::new().with_message_buffering(),
+            heartbeat:       None,
+            disconnect_initiated: false,
+            server_address:  None,
+            channel_to_conwayste: channel_to_conwayste,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        // Design pattern taken from https://blog.getseq.net/rust-at-datalust-how-we-organize-a-complex-rust-codebase/
+        // The intention is that new fields added to ClientNetState will cause compiler errors unless
+        // we add them here.
+        #![deny(unused_variables)]
+        let Self {
+            ref mut sequence,
+            ref mut response_sequence,
+            name: ref _name,
+            ref mut room,
+            ref mut cookie,
+            ref mut chat_msg_seq_num,
+            ref mut tick,
+            ref mut network,
+            ref mut heartbeat,
+            ref mut disconnect_initiated,
+            ref mut server_address,
+            channel_to_conwayste: ref _channel_to_conwayste,          // Don't clear the channel to conwayste
+        } = *self;
+        *sequence         = 0;
+        *response_sequence = 0;
+        *room             = None;
+        *cookie           = None;
+        *chat_msg_seq_num = 0;
+        *tick             = 0;
+        *heartbeat        = None;
+        *disconnect_initiated = false;
+        *server_address   = None;
+        network.reset();
+
+        trace!("ClientNetState reset!");
+    }
+
+
+    pub fn in_game(&self) -> bool {
+        self.room.is_some()
+    }
+
+    fn check_for_upgrade(&self, server_version: &String) {
+        let client_version = &VERSION.to_owned();
+        if client_version < server_version {
+            warn!("\tClient Version: {}\n\tServer Version: {}\nnWarning: Client out-of-date. Please upgrade.", client_version, server_version);
+        }
+        else if client_version > server_version {
+            warn!("\tClient Version: {}\n\tServer Version: {}\nWarning: Client Version greater than Server Version.", client_version, server_version);
+        }
+    }
+
+    fn process_queued_server_responses(&mut self) {
+        // If we can, start popping off the RX queue and handle contiguous packets immediately
+        let mut dequeue_count = 0;
+
+        let rx_queue_count = self.network.rx_packets.get_contiguous_packets_count(self.response_sequence);
+        while dequeue_count < rx_queue_count {
+            let packet = self.network.rx_packets.as_queue_type_mut().pop_front().unwrap();
+            trace!("{:?}", packet);
+            match packet {
+                Packet::Response{sequence: _, request_ack: _, code} => {
+                    dequeue_count += 1;
+                    self.response_sequence += 1;
+                    self.process_event_code(code);
+                }
+                _ => panic!("Development bug: Non-response packet found in client RX queue")
+            }
+        }
+    }
+
+    fn process_event_code(&mut self, code: ResponseCode) {
+        match code.clone() {
+            ResponseCode::OK => {
+                match self.handle_response_ok() {
+                    Ok(_) => {},
+                    Err(e) => error!("{:?}", e)
+                }
+            }
+            ResponseCode::LoggedIn(ref cookie, ref server_version) => {
+                self.handle_logged_in(cookie.to_string(), server_version.to_string());
+            }
+            ResponseCode::LeaveRoom => {
+                self.handle_left_room();
+            }
+            ResponseCode::JoinedRoom(ref room_name) => {
+                self.handle_joined_room(room_name);
+            }
+            ResponseCode::PlayerList(ref player_names) => {
+                self.handle_player_list(player_names.to_vec());
+            }
+            ResponseCode::RoomList(ref rooms) => {
+                self.handle_room_list(rooms.to_vec());
+            }
+            ResponseCode::KeepAlive => {},
+            // errors
+            ResponseCode::Unauthorized(opt_error) => {
+                info!("Unauthorized action attempted by client: {:?}", opt_error);
+            }
+            _ => {
+                error!("unknown response from server: {:?}", code);
+            }
+        }
+
+        if code != ResponseCode::OK && code != ResponseCode::KeepAlive {
+            let nw_response: NetwaysteEvent = NetwaysteEvent::build_netwayste_event_from_response_code(code);
+            match self.channel_to_conwayste.send(nw_response) {
+                Err(e) => error!("Could not send a netwayste response via channel_to_conwayste: {:?}", e),
+                Ok(_) => ()
+            }
+        }
+    }
+
+    pub fn handle_incoming_event(&mut self, udp_tx: &mpsc::UnboundedSender<(SocketAddr, Packet)>, opt_packet: Option<Packet>) {
+        // All `None` packets should get filtered out up the hierarchy
+        let packet = opt_packet.unwrap();
+        match packet.clone() {
+            Packet::Response{sequence, request_ack: _, code} => {
+                self.heartbeat = Some(Instant::now());
+                let code = code.clone();
+                if code != ResponseCode::KeepAlive {
+                    // When a packet is acked, we can remove it from the TX buffer and buffer the response for
+                    // later processing.
+                    // Removing a "Response packet" from the client's request TX buffer appears to be nonsense at first.
+                    // This works because remove() targets different ID's depending on the Packet type. In the case of
+                    // a Response packet, the target identifier is the `request_ack`.
+
+                    // Only process responses we haven't seen
+                    if self.response_sequence <= sequence {
+                        trace!("RX Buffering: Resp.Seq.: {}, {:?}", self.response_sequence, packet);
+                        // println!("TX packets: {:?}", self.network.tx_packets);
+                        // None means the packet was not found so we've probably already removed it.
+                        if let Some(_) = self.network.tx_packets.remove(&packet)
+                        {
+                            self.network.rx_packets.buffer_item(packet);
+                        }
+
+                        self.process_queued_server_responses();
+                    }
+                }
+            }
+            // TODO game_updates, universe_update
+            Packet::Update{chats, game_updates: _, universe_update: _} => {
+                self.handle_incoming_chats(chats);
+
+                // Reply to the update
+                let packet = Packet::UpdateReply {
+                    cookie:               self.cookie.clone().unwrap(),
+                    last_chat_seq:        Some(self.chat_msg_seq_num),
+                    last_game_update_seq: None,
+                    last_gen:             None,
+                };
+
+                netwayste_send!(udp_tx, (self.server_address.unwrap().clone(), packet),
+                         ("Could not send UpdateReply{{ {} }} to server", self.chat_msg_seq_num));
+            }
+            Packet::Request{..} => {
+                warn!("Ignoring packet from server normally sent by clients: {:?}", packet);
+            }
+            Packet::UpdateReply{..} => {
+                warn!("Ignoring packet from server normally sent by clients: {:?}", packet);
+            }
+        }
+    }
+
+    pub fn handle_network_event(&mut self, udp_tx: &mpsc::UnboundedSender<(SocketAddr, Packet)>) {
+        if self.cookie.is_some() {
+            // Determine what can be processed
+            // Determine what needs to be resent
+            // Resend anything remaining in TX queue if it has also expired.
+            self.process_queued_server_responses();
+
+            let indices = self.network.tx_packets.get_retransmit_indices();
+
+            self.network.retransmit_expired_tx_packets(udp_tx, self.server_address.unwrap().clone(), Some(self.response_sequence), &indices);
+        }
+    }
+
+    fn handle_tick_event(&mut self, udp_tx: &mpsc::UnboundedSender<(SocketAddr, Packet)>) {
+        // Every 100ms, after we've connected
+        if self.cookie.is_some() {
+            // Send a keep alive heartbeat if the connection is live
+            let keep_alive = Packet::Request {
+                cookie: self.cookie.clone(),
+                sequence: self.sequence,
+                response_ack: None,
+                action: RequestAction::KeepAlive(self.response_sequence),
+            };
+            let timed_out = has_connection_timed_out(self.heartbeat);
+
+            if timed_out || self.disconnect_initiated {
+                if timed_out {
+                    info!("Server is non-responsive, disconnecting.");
+                }
+                if self.disconnect_initiated {
+                    info!("Disconnected from the server.")
+                }
+                self.reset();
+            } else {
+                netwayste_send!(udp_tx, (self.server_address.unwrap().clone(), keep_alive), ("Could not send KeepAlive packets"));
+            }
+        }
+
+        self.tick = 1usize.wrapping_add(self.tick);
+    }
+
+
+    pub fn handle_response_ok(&mut self) -> Result<(), Box<Error>> {
+            info!("OK :)");
+            return Ok(());
+    }
+
+    pub fn handle_logged_in(&mut self, cookie: String, server_version: String) {
+        self.cookie = Some(cookie);
+
+        if let Some(name) = self.name.as_ref() {
+            info!("Logged in with client name {:?}", name);
+        } else {
+            warn!("Logged in, but no name set!");
+        }
+        self.check_for_upgrade(&server_version);
+    }
+
+    pub fn handle_joined_room(&mut self, room_name: &String) {
+            self.room = Some(room_name.clone());
+            info!("Joined room: {}", room_name);
+    }
+
+    pub fn handle_left_room(&mut self) {
+        if self.in_game() {
+            info!("Left room {}.", self.room.clone().unwrap());
+        }
+        self.room = None;
+        self.chat_msg_seq_num = 0;
+    }
+
+    pub fn handle_player_list(&mut self, player_names: Vec<String>) {
+        info!("---BEGIN PLAYER LIST---");
+        for (i, player_name) in player_names.iter().enumerate() {
+            info!("{}\tname: {}", i, player_name);
+        }
+        info!("---END PLAYER LIST---");
+    }
+
+    pub fn handle_room_list(&mut self, rooms: Vec<(String, u64, bool)>) {
+        info!("---BEGIN GAME ROOM LIST---");
+        for (game_name, num_players, game_running) in rooms {
+            info!("#players: {},\trunning? {:?},\tname: {:?}",
+                        num_players,
+                        game_running,
+                        game_name);
+        }
+        info!("---END GAME ROOM LIST---");
+    }
+
+    pub fn handle_incoming_chats(&mut self, chats: Option<Vec<BroadcastChatMessage>> ) {
+        if let Some(mut chat_messages) = chats {
+            chat_messages.retain(|ref chat_message| {
+                self.chat_msg_seq_num < chat_message.chat_seq.unwrap()
+            });
+            // This loop does two things:
+            //  1) update chat_msg_seq_num, and
+            //  2) prints messages from other players
+            for chat_message in chat_messages {
+                let chat_seq = chat_message.chat_seq.unwrap();
+                self.chat_msg_seq_num = std::cmp::max(chat_seq, self.chat_msg_seq_num);
+
+                let queue = self.network.rx_chat_messages.as_mut().unwrap();
+                queue.buffer_item(chat_message.clone());
+
+                if let Some(client_name) = self.name.as_ref() {
+                    if client_name != &chat_message.player_name {
+                        info!("{}: {}", chat_message.player_name, chat_message.message);
+                    }
+                } else {
+                   panic!("Client name not set!");
+                }
+            }
+        }
+    }
+
+    /// Send a request action to the connected server
+    fn try_server_send(&mut self,
+            udp_tx: &mpsc::UnboundedSender<(SocketAddr, Packet)>,
+            exit_tx: &mpsc::UnboundedSender<()>,
+            action: RequestAction) {
+        if action != RequestAction::None {
+            // Sequence number can increment once we're talking to a server
+            if self.cookie != None {
+                self.sequence += 1;
+            }
+
+            if action == RequestAction::Disconnect {
+                // TODO: we don't necessarily want the netwayste thread to exit when we Disconnect
+                // from a server!
+                self.disconnect_initiated = true;
+                netwayste_send!(exit_tx, ());
+            }
+
+            let packet = Packet::Request {
+                sequence:     self.sequence,
+                response_ack: Some(self.response_sequence),
+                cookie:       self.cookie.clone(),
+                action:       action,
+            };
+
+            trace!("{:?}", packet);
+
+            self.network.tx_packets.buffer_item(packet.clone());
+
+            netwayste_send!(udp_tx, (self.server_address.unwrap().clone(), packet),
+                            ("Could not send user input cmd to server"));
+
+        }
+    }
+
+    /// Main executor for the client-side network layer for conwayste and should be run from a thread.
+    /// Its two arguments are halves of a channel used for communication to send and receive Netwayste events.
+    pub fn start_network(channel_to_conwayste: std::sync::mpsc::Sender<NetwaysteEvent>,
+                         channel_from_conwayste: mpsc::UnboundedReceiver<NetwaysteEvent>) {
+
+        let has_port_re = Regex::new(r":\d{1,5}$").unwrap(); // match a colon followed by number up to 5 digits (16-bit port)
+        let mut server_str = env::args().nth(1).unwrap_or("localhost".to_owned());
+        // if no port, add the default port
+        if !has_port_re.is_match(&server_str) {
+            debug!("Appending default port to {:?}", server_str);
+            server_str = format!("{}:{}", server_str, DEFAULT_PORT);
+        }
+
+        // synchronously resolve DNS because... why not?
+        trace!("Resolving {:?}...", server_str);
+        let addr_vec = tokio_dns::resolve_sock_addr(&server_str[..]).wait()      // wait() is synchronous!!!
+                        .unwrap_or_else(|e| {
+                                error!("failed to resolve: {:?}", e);
+                                exit(1);
+                            });
+        if addr_vec.len() == 0 {
+            error!("resolution found 0 addresses");
+            exit(1);
+        }
+        // TODO: support IPv6
+        let addr_vec_len = addr_vec.len();
+        let v4_addr_vec: Vec<_> = addr_vec.into_iter().filter(|addr| addr.is_ipv4()).collect(); // filter out IPv6
+        if v4_addr_vec.len() < addr_vec_len {
+            warn!("Filtered out {} IPv6 addresses -- IPv6 is not implemented.", addr_vec_len - v4_addr_vec.len() );
+        }
+        if v4_addr_vec.len() > 1 {
+            // This is probably not the best option -- could pick based on ping time, random choice,
+            // and could also try other ones on connection failure.
+            warn!("Multiple ({:?}) addresses returned; arbitrarily picking the first one.", v4_addr_vec.len());
+        }
+
+        let addr = v4_addr_vec[0];
+
+        trace!("Connecting to {:?}", addr);
+
+        let mut core = Core::new().unwrap();
+        let handle = core.handle();
+
+        // Unwrap ok because bind will abort if unsuccessful
+        let udp = bind(&handle, Some("0.0.0.0"), Some(0)).unwrap();
+        let local_addr = udp.local_addr().unwrap();
+
+        // Channels
+        let (udp_sink, udp_stream) = udp.framed(LineCodec).split();
+        let (udp_tx, udp_rx) = mpsc::unbounded();    // create a channel because we can't pass the sink around everywhere
+        let (exit_tx, exit_rx) = mpsc::unbounded();  // send () to exit_tx channel to quit the client
+
+        trace!("Locally bound to {:?}.", local_addr);
+        trace!("Will connect to remote {:?}.", addr);
+
+        // initialize state
+        let mut initial_client_state = ClientNetState::new(channel_to_conwayste);
+        initial_client_state.server_address = Some(addr);
+
+        let iter_stream = stream::iter_ok::<_, io::Error>(iter::repeat( () )); // just a Stream that emits () forever
+        // .and_then is like .map except that it processes returned Futures
+        let tick_stream = iter_stream.and_then(|_| {
+            let timeout = Timeout::new(Duration::from_millis(TICK_INTERVAL_IN_MS), &handle).unwrap();
+            timeout.and_then(move |_| {
+                ok(Event::TickEvent)
+            })
+        }).map_err(|e| {
+            error!("Got error from tick stream: {:?}", e);
+            exit(1);
+        });
+
+        let packet_stream = udp_stream
+            .filter(|&(_, ref opt_packet)| {
+                *opt_packet != None
+            })
+            .map(|packet_tuple| {
+                Event::Incoming(packet_tuple)
+            })
+            .map_err(|e| {
+                error!("Got error from packet_stream {:?}", e);
+                exit(1);
+            });
+
+        let network_stream = stream::iter_ok::<_, io::Error>(iter::repeat( () ));
+        let network_stream = network_stream.and_then(|_| {
+            let timeout = Timeout::new(Duration::from_millis(NETWORK_INTERVAL_IN_MS), &handle).unwrap();
+            timeout.and_then(move |_| {
+                ok(Event::NetworkEvent)
+            })
+        }).map_err(|e| {
+            error!("Got error from network_stream {:?}", e);
+            exit(1);
+        });
+
+        let conwayste_rx = channel_from_conwayste.map_err(|_| panic!());
+        let conwayste_stream = conwayste_rx
+            .filter(|event| {
+                *event != NetwaysteEvent::None
+            })
+            .map(|event| {
+                Event::ConwaysteEvent(event)
+            })
+            .map_err(|e| {
+                error!("Got error from conwayste event channel {:?}", e);
+                exit(1);
+            });
+
+        let main_loop_fut = tick_stream
+            .select(packet_stream)
+            .select(network_stream)
+            .select(conwayste_stream)
+            .fold(initial_client_state, move |mut client_state: ClientNetState, event| {
+                match event {
+                    Event::Incoming((_addr, opt_packet)) => {
+                        client_state.handle_incoming_event(&udp_tx, opt_packet);
+                    }
+                    Event::TickEvent => {
+                        client_state.handle_tick_event(&udp_tx);
+                    }
+                    Event::NetworkEvent => {
+                        client_state.handle_network_event(&udp_tx);
+                    }
+                    Event::ConwaysteEvent(netwayste_request) => {
+                        let action: RequestAction = NetwaysteEvent::build_request_action_from_netwayste_event(netwayste_request, client_state.in_game());
+                        match action {
+                            RequestAction::Connect{ref name, ..} => {
+                                // TODO: do not store the name on client_state since that's the wrong
+                                // place for it.
+                                client_state.name = Some(name.to_owned());
+                            }
+                            _ => {}
+                        }
+                        client_state.try_server_send(&udp_tx, &exit_tx, action);
+                    }
+                }
+
+                // finally, return the updated client state for the next iteration
+                ok(client_state)
+            })
+            .map(|_| ())
+            .map_err(|_| ());
+
+        // listen on the channel created above and send it to the UDP sink
+        let sink_fut = udp_rx.fold(udp_sink, |udp_sink, outgoing_item| {
+            udp_sink.send(outgoing_item).map_err(|e| {
+                    error!("Got error while attempting to send UDP packet: {:?}", e);
+                    exit(1);
+                })
+        }).map(|_| ()).map_err(|_| ());
+
+        let exit_fut = exit_rx
+                        .into_future()
+                        .map(|_| ())
+                        .map_err(|e| {
+                                    error!("Got error from exit_fut: {:?}", e);
+                                    exit(1);
+                                });
+
+        let combined_fut = exit_fut
+                            .select(main_loop_fut).map(|_| ()).map_err(|_| ())
+                            .select(sink_fut).map_err(|_| ());
+
+        drop(core.run(combined_fut).unwrap());
+    }
+}
+

--- a/netwayste/src/lib.rs
+++ b/netwayste/src/lib.rs
@@ -1,0 +1,36 @@
+/*  Copyright 2019 the Conwayste Developers.
+ *
+ *  This file is part of netwayste.
+ *
+ *  netwayste is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  netwayste is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with netwayste.  If not, see <http://www.gnu.org/licenses/>. */
+
+extern crate base64;
+extern crate bincode;
+extern crate chrono;
+extern crate env_logger;
+extern crate futures;
+#[macro_use]
+extern crate log;
+extern crate rand;
+extern crate semver;
+extern crate serde;
+extern crate tokio_core;
+extern crate clap;
+
+#[macro_use]
+pub mod net;
+pub mod client;
+
+#[cfg(test)]
+pub mod tests;

--- a/netwayste/src/net.rs
+++ b/netwayste/src/net.rs
@@ -1,0 +1,1064 @@
+/*
+ * Herein lies a networking library for the multiplayer game, Conwayste.
+ *
+ * Copyright (C) 2018-2019 The Conwayste Developers
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use std::cmp::{PartialEq, PartialOrd, Ordering};
+use std::fmt::Debug;
+use std::{io, fmt, str, result, time::{Duration, Instant}};
+use std::net::{self, SocketAddr};
+use std::collections::VecDeque;
+
+use futures::sync::mpsc;
+use tokio_core::net::{UdpSocket, UdpCodec};
+use tokio_core::reactor::Handle;
+use bincode::{serialize, deserialize, Infinite};
+use semver::{Version, SemVerError};
+use serde::{Serialize, Deserialize};
+
+pub const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+pub const DEFAULT_HOST: &str = "0.0.0.0";
+pub const DEFAULT_PORT: u16 = 2016;
+pub const TIMEOUT_IN_SECONDS:    u64   = 5;
+pub const NETWORK_QUEUE_LENGTH: usize = 600;        // spot testing with poor network (~675 cmds) showed a max of ~512 length
+                                                // keep this for now until the performance issues are resolved
+const RETRANSMISSION_THRESHOLD_IN_MS: Duration = Duration::from_millis(400);
+const RETRY_THRESHOLD_IN_MS: usize = 2;             //
+const RETRY_AGGRESSIVE_THRESHOLD_IN_MS: usize = 5;
+const RETRANSMISSION_COUNT: usize = 32;   // Testing some ideas out:. Resend length 16x2, 16=libconway::history_size)
+
+// For unit testing, I cover duplicate sequence numbers. The search returns Ok(index) on a slice with a matching value.
+// Instead of returning that index, I return this much larger value and avoid insertion into the queues.
+// (110 is the avg weight of an amino acid in daltons :] Much larger than our current queue size)
+const MATCH_FOUND_SENTINEL: usize = 110;
+
+//////////////// Public Macros /////////////////
+
+#[macro_export]
+macro_rules! netwayste_send {
+    ($tx:ident, $dest:expr, ($failmsg:expr $(, $args:expr)*)) => {
+        let result = $tx.unbounded_send($dest);
+        if result.is_err() {
+            warn!($failmsg, $( $args)*);
+        }
+    };
+    // for client for exit()
+    ($tx:expr, ()) => {
+        let result = $tx.unbounded_send(());
+        if result.is_err() {
+            error!("Something really bad is going on... client cannot exit!");
+        }
+    };
+}
+
+//////////////// Error handling ////////////////
+#[derive(Debug)]
+pub enum NetError {
+    AddrParseError(net::AddrParseError),
+    IoError(io::Error),
+}
+
+impl From<net::AddrParseError> for NetError {
+    fn from(e: net::AddrParseError) -> Self {
+        NetError::AddrParseError(e)
+    }
+}
+
+impl From<io::Error> for NetError {
+    fn from(e: io::Error) -> Self {
+        NetError::IoError(e)
+    }
+}
+
+
+////////////////////// Data model ////////////////////////
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+pub enum RequestAction {
+    None,   // never actually sent
+    Connect{name: String, client_version: String},
+    Disconnect,
+    KeepAlive(u64),     // Send latest response ack on each heartbeat
+    ListPlayers,
+    ChatMessage(String),
+    ListRooms,
+    NewRoom(String),
+    JoinRoom(String),
+    LeaveRoom,
+}
+
+// server response codes -- mostly inspired by https://en.wikipedia.org/wiki/List_of_HTTP_status_codes
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+pub enum ResponseCode {
+    // success - these are all 200 in HTTP
+    OK,                              // 200 no data
+    LoggedIn(String, String),        // player is logged in -- (cookie, server version)
+    JoinedRoom(String),              // player has joined the room
+    LeaveRoom,                       // player has left the room
+    PlayerList(Vec<String>),         // list of players in room or lobby
+    RoomList(Vec<(String, u64, bool)>), // (room name, # players, game has started?
+
+    // errors
+    BadRequest(Option<String>),      // 400 unspecified error that is client's fault
+    Unauthorized(Option<String>),    // 401 not logged in
+    TooManyRequests(Option<String>), // 429
+    ServerError(Option<String>),     // 500
+    NotConnected(Option<String>),    // no equivalent in HTTP due to handling at lower (TCP) level
+    KeepAlive,                       // Server's heart is beating
+}
+
+// chat messages sent from server to all clients other than originating client
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct BroadcastChatMessage {
+    pub chat_seq:    Option<u64>,   // Some(<number>) when sent to clients (starts at 0 for first
+                                    // chat message sent to this client in this room); None when
+                                    // internal to server
+    pub player_name: String,
+    pub message:     String,        // should not contain newlines
+}
+
+impl PartialEq for BroadcastChatMessage {
+    fn eq(&self, other: &BroadcastChatMessage) -> bool {
+        let self_seq_num = self.sequence_number();
+        let other_seq_num = other.sequence_number();
+        self_seq_num == other_seq_num
+    }
+}
+
+impl Eq for BroadcastChatMessage {}
+
+impl PartialOrd for BroadcastChatMessage {
+    fn partial_cmp(&self, other: &BroadcastChatMessage) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for BroadcastChatMessage {
+    fn cmp(&self, other: &BroadcastChatMessage) -> Ordering {
+        let self_seq_num = self.sequence_number();
+        let other_seq_num = other.sequence_number();
+
+        self_seq_num.cmp(&other_seq_num)
+    }
+}
+
+impl BroadcastChatMessage {
+    #[allow(unused)]
+    pub fn new(sequence: u64, name: String, msg: String) -> BroadcastChatMessage {
+        BroadcastChatMessage {
+            chat_seq: Some(sequence),
+            player_name: name,
+            message: msg
+        }
+    }
+
+    fn sequence_number(&self) -> u64 {
+        if let Some(v) = self.chat_seq {
+            v
+        } else { 0 }
+    }
+}
+
+// TODO: adapt or import following from libconway
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+pub struct GenState {
+    // state of the Universe
+    pub gen:        u64,
+    pub dummy_data: u8,
+}
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+pub struct GenDiff  {
+    // difference between states of Universe
+    pub old_gen:    u64,
+    pub new_gen:    u64,
+    pub dummy_data: u8,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+pub struct GameOutcome {
+    pub winner: Option<String>,     // Some(<name>) if winner, or None, meaning it was a tie/forfeit
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+pub enum GameUpdateType {
+    GameStart,
+    NewUserList(Vec<String>),   // list of names of all users including current user
+    GameFinish(GameOutcome),
+    GameClose,   // kicks user back to arena
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+pub struct GameUpdate {
+    pub game_update_seq: Option<u64>,  // see BroadcastChatMessage chat_seq field for Some/None meaning
+    update_type:         GameUpdateType,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+pub enum UniUpdateType {
+    State(GenState),
+    Diff(GenDiff),
+    NoChange,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub enum Packet {
+    Request {
+        // sent by client
+        sequence:        u64,
+        response_ack:    Option<u64>,    // Next expected  sequence number the Server responds with to the Client.
+                                         // Stated differently, the client has seen Server responses from 0 to response_ack-1.
+        cookie:          Option<String>, // present if and only if action != connect
+        action:          RequestAction,
+    },
+    Response {
+        // sent by server in reply to client
+        sequence:        u64,
+        request_ack:     Option<u64>,     // most recent request sequence number received
+        code:            ResponseCode,
+    },
+    Update {
+        // in-game: sent by server
+        chats:           Option<Vec<BroadcastChatMessage>>, // All non-acknowledged chats are sent each update
+        game_updates:    Option<Vec<GameUpdate>>,           //
+        universe_update: UniUpdateType,                     //
+    },
+    UpdateReply {
+        // in-game: sent by client in reply to server
+        cookie:               String,
+        last_chat_seq:        Option<u64>, // sequence number of latest chat msg. received from server
+        last_game_update_seq: Option<u64>, // seq. number of latest game update from server
+        last_gen:             Option<u64>, // generation number client is currently at
+    }
+}
+
+impl Packet {
+    #[allow(unused)]
+    pub fn sequence_number(&self) -> u64 {
+        if let Packet::Request{ sequence, response_ack: _, cookie: _, action: _ } = self {
+            *sequence
+        } else if let Packet::Response{ sequence, request_ack: _, code: _ } = self {
+            *sequence
+        } else if let Packet::Update{ chats: _, game_updates: _, universe_update } = self {
+            // TODO revisit once mechanics are fleshed out
+            match universe_update {
+                UniUpdateType::State(gs) => { gs.gen },
+                UniUpdateType::Diff(gd) => { gd.new_gen },
+                UniUpdateType::NoChange => 0
+            }
+        } else {
+            unimplemented!(); // UpdateReply is not saved
+        }
+    }
+
+    #[allow(unused)]
+    pub fn set_response_sequence(&mut self, new_ack: Option<u64>) {
+        if let Packet::Request{ sequence: _, ref mut response_ack, cookie: _, action: _ } = *self {
+            *response_ack = new_ack;
+        }
+        else if let Packet::Response{ sequence: _, ref mut request_ack, code: _ } = *self {
+            *request_ack = new_ack;
+        }
+        else {
+            unimplemented!();
+        }
+    }
+
+    #[allow(unused)]
+    pub fn response_sequence(&self) -> u64 {
+        if let Packet::Request{sequence: _, ref response_ack, cookie: _, action: _} = *self {
+            if let Some(response_ack) = response_ack
+            {
+                *response_ack
+            } else {
+                0
+            }
+        } else {
+            unimplemented!();
+        }
+    }
+}
+
+impl fmt::Debug for Packet {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Packet::Request{ sequence, response_ack, cookie, action } => {
+                write!(f, "[Request] cookie: {:?} sequence: {} resp_ack: {:?} event: {:?}", cookie, sequence, response_ack, action)
+            }
+            Packet::Response{ sequence, request_ack, code } => {
+                write!(f, "[Response] sequence: {} req_ack: {:?} event: {:?}", sequence, request_ack, code)
+            }
+            Packet::Update{ chats: _, game_updates, universe_update } => {
+                write!(f, "[Update] game_updates: {:?} universe_update: {:?}", game_updates, universe_update)
+            }
+            #[cfg(not(test))]
+            _ => {unimplemented!()}
+            #[cfg(test)]
+            _ => {Result::Ok(())}
+        }
+    }
+}
+
+impl PartialEq for Packet {
+    fn eq(&self, other: &Packet) -> bool {
+        let self_seq_num = self.sequence_number();
+        let other_seq_num = other.sequence_number();
+        self_seq_num == other_seq_num
+    }
+}
+
+impl Eq for Packet {}
+
+impl PartialOrd for Packet {
+    fn partial_cmp(&self, other: &Packet) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Packet {
+    fn cmp(&self, other: &Packet) -> Ordering {
+        let self_seq_num = self.sequence_number();
+        let other_seq_num = other.sequence_number();
+
+        self_seq_num.cmp(&other_seq_num)
+    }
+}
+
+//////////////// Packet (de)serialization ////////////////
+#[allow(dead_code)]
+pub struct LineCodec;
+impl UdpCodec for LineCodec {
+    type In = (SocketAddr, Option<Packet>);   // if 2nd element is None, it means deserialization failure
+    type Out = (SocketAddr, Packet);
+
+    fn decode(&mut self, addr: &SocketAddr, buf: &[u8]) -> io::Result<Self::In> {
+        match deserialize(buf) {
+            Ok(decoded) => Ok((*addr, Some(decoded))),
+            Err(_) => {
+                /*
+                // TODO: do not create this SocketAddr every time a packet arrives!
+                // TODO: DEFAULT_PORT could be wrong. We need to know the real port
+                let local: SocketAddr = format!("{}:{}", "127.0.0.1", DEFAULT_PORT.to_string()).parse().unwrap();
+                // We only want to warn when the incoming packet is external to the host system
+                if local != *addr {
+                    warn!("WARNING: error during packet deserialization: {:?}", e);
+                }
+                */
+                Ok((*addr, None))
+            }
+        }
+    }
+
+    fn encode(&mut self, (addr, player_packet): Self::Out, into: &mut Vec<u8>) -> SocketAddr {
+        let encoded: Vec<u8> = serialize(&player_packet, Infinite).unwrap();
+        into.extend(encoded);
+        addr
+    }
+}
+
+//////////////// Network interface ////////////////
+#[allow(dead_code)]
+pub fn bind(handle: &Handle, opt_host: Option<&str>, opt_port: Option<u16>) -> Result<UdpSocket, NetError> {
+
+    let host = if let Some(host) = opt_host { host } else { DEFAULT_HOST };
+    let port = if let Some(port) = opt_port { port } else { DEFAULT_PORT };
+    let addr: SocketAddr = format!("{}:{}", host, port).parse()?;
+    let sock = UdpSocket::bind(&addr, &handle).expect("failed to bind socket");
+    Ok(sock)
+}
+
+#[allow(dead_code)]
+pub fn get_version() -> result::Result<Version, SemVerError> {
+    Version::parse(VERSION)
+}
+
+#[allow(dead_code)]
+pub fn has_connection_timed_out(heartbeat: Option<Instant>) -> bool {
+    if let Some(heartbeat) = heartbeat {
+        (Instant::now() - heartbeat) > Duration::from_secs(TIMEOUT_IN_SECONDS)
+    } else { false }
+}
+
+pub struct NetworkStatistics {
+    pub tx_packets_failed: u64,     // From the perspective of the Network OSI layer
+    pub tx_packets_success: u64,    // From the perspective of the Network OSI layer
+}
+
+impl NetworkStatistics {
+    fn new() -> Self {
+        NetworkStatistics {
+            tx_packets_failed: 0,
+            tx_packets_success: 0,
+        }
+    }
+
+    fn reset(&mut self) {
+        #![deny(unused_variables)]
+        let Self {
+            ref mut tx_packets_failed,
+            ref mut tx_packets_success,
+        } = *self;
+        *tx_packets_failed     = 0;
+        *tx_packets_success    = 0;
+    }
+}
+
+
+pub trait Sequenced: Ord {
+    fn sequence_number(&self) -> u64;
+}
+
+impl Sequenced for Packet {
+    fn sequence_number(&self) -> u64 {
+        self.sequence_number()
+    }
+}
+
+impl Sequenced for BroadcastChatMessage {
+    fn sequence_number(&self) -> u64 {
+        self.sequence_number()
+    }
+}
+
+pub trait NetworkQueue<T: Ord+Sequenced+Debug+Clone> {
+    fn new() -> Self;
+
+    fn head_of_queue(&self) -> Option<&T> {
+        self.as_queue_type().back()
+    }
+
+    fn tail_of_queue(&self) -> Option<&T> {
+        self.as_queue_type().front()
+    }
+
+    fn newest_seq_num(&self) -> Option<u64> {
+        let opt_newest_packet: Option<&T> = self.head_of_queue();
+
+        if opt_newest_packet.is_some() {
+            let newest_packet: &T = opt_newest_packet.unwrap();
+            Some(newest_packet.sequence_number())
+        } else { None }
+    }
+
+    fn oldest_seq_num(&self) -> Option<u64> {
+        let opt_oldest_packet: Option<&T> = self.tail_of_queue();
+
+        if opt_oldest_packet.is_some() {
+            let oldest_packet: &T = opt_oldest_packet.unwrap();
+            Some(oldest_packet.sequence_number())
+        } else { None }
+    }
+
+    fn push_back(&mut self, item: T) {
+        self.as_queue_type_mut().push_back(item);
+    }
+
+    fn push_front(&mut self, item: T) {
+        self.as_queue_type_mut().push_front(item);
+    }
+
+    fn len(&self) -> usize {
+        self.as_queue_type().len()
+    }
+
+    fn insert(&mut self, index: usize, item: T) {
+        self.as_queue_type_mut().insert(index, item);
+    }
+
+    /// I've deemed 'far away' to mean the half of the max value of the type.
+    fn is_seq_sufficiently_far_away(&self, a: u64, b: u64) -> bool {
+        static HALFWAYPOINT: u64 = u64::max_value()/2;
+        if a > b {
+            a - b > HALFWAYPOINT
+        } else {
+            b - a > HALFWAYPOINT
+        }
+    }
+
+    /// Checks if the insertion of `sequence` induces a newly wrapped queue state.
+    /// If we have already wrapped in the buffer, then it shouldn't cause another wrap due to the nature of the problem.
+    fn will_seq_cause_a_wrap(&self,
+                            buffer_wrap_index: Option<usize>,
+                            sequence: u64,
+                            oldest_seq_num: u64,
+                            newest_seq_num: u64) -> bool {
+        if buffer_wrap_index.is_none() {
+            self.is_seq_sufficiently_far_away(sequence, oldest_seq_num)
+            && self.is_seq_sufficiently_far_away(sequence, newest_seq_num)
+        } else {
+            false
+        }
+    }
+
+    fn clear(&mut self) {
+        self.as_queue_type_mut().clear();
+    }
+
+    fn remove(&mut self, pkt: &T) -> Option<T>;
+
+    fn discard_older_items(&mut self);
+    fn buffer_item(&mut self, item: T) -> bool;
+    fn as_queue_type(&self) -> &ItemQueue<T>;
+    fn as_queue_type_mut(&mut self) -> &mut ItemQueue<T>;
+}
+
+pub struct NetAttempt {
+    pub time: Instant,
+    pub retries: usize,
+}
+
+impl NetAttempt {
+    #[allow(unused)]
+    pub fn new() -> Self {
+        Self {
+            time: Instant::now(),
+            retries: 0,
+        }
+    }
+
+    #[allow(unused)]
+    pub fn increment_retries(&mut self) {
+        self.retries += 1;
+        self.time = Instant::now();
+    }
+}
+
+type ItemQueue<T> = VecDeque<T>;
+
+pub struct NetQueue<T> {
+    pub queue: ItemQueue<T>,
+    pub attempts: VecDeque<NetAttempt>,
+    pub buffer_wrap_index: Option<usize>,
+}
+
+impl NetQueue<Packet> {
+    #[allow(unused)]
+    pub fn get_retransmit_indices(&self) -> Vec<usize> {
+        let iter = self.attempts.iter();
+        iter.enumerate()
+            .filter(|(_, ts)|
+                (
+                    (Instant::now() - ts.time) >= RETRANSMISSION_THRESHOLD_IN_MS)
+                    || (ts.retries >= RETRY_THRESHOLD_IN_MS)
+                    || (ts.retries >= RETRY_AGGRESSIVE_THRESHOLD_IN_MS)
+                )
+            .map(|(i, _)| i)
+            .take(RETRANSMISSION_COUNT)
+            .collect::<Vec<usize>>()
+    }
+
+}
+
+impl<T> NetworkQueue<T> for NetQueue<T>
+        where T: Sequenced+Debug+Clone {
+
+    fn new() -> Self {
+        NetQueue {
+            queue:          ItemQueue::<T>::with_capacity(NETWORK_QUEUE_LENGTH),
+            attempts:     VecDeque::<NetAttempt>::with_capacity(NETWORK_QUEUE_LENGTH),
+            buffer_wrap_index: None
+        }
+    }
+
+    fn as_queue_type(&self) -> &ItemQueue<T> {
+        &self.queue
+    }
+
+    fn as_queue_type_mut(&mut self) -> &mut ItemQueue<T> {
+        &mut self.queue
+    }
+
+    fn discard_older_items(&mut self) {
+        let queue = self.as_queue_type_mut();
+        let queue_size = queue.len();
+        if queue_size >= NETWORK_QUEUE_LENGTH {
+            for _ in 0..(queue_size-NETWORK_QUEUE_LENGTH) {
+                queue.pop_front();
+            }
+        }
+    }
+
+    fn clear(&mut self) {
+        let Self {
+            ref mut queue,
+            ref mut attempts,
+            ref mut buffer_wrap_index,
+        } = *self;
+
+        queue.clear();
+        attempts.clear();
+        *buffer_wrap_index = None;
+    }
+
+    fn remove(&mut self, pkt: &T) -> Option<T> {
+        let result = {
+            let search_space: Vec<&T> = self.as_queue_type_mut().iter().collect();
+            search_space.as_slice().binary_search(&pkt)
+        };
+        match result {
+            Err(_) => {
+                warn!("Packet (Seq: {}) not present in queue! Was it removed already?", pkt.sequence_number());
+                return None;
+            }
+            Ok(index) => {
+                let pkt = self.as_queue_type_mut().remove(index).unwrap();
+                self.attempts.remove(index);
+                return Some(pkt);
+            }
+        }
+    }
+
+    /// Upon packet tx or rx, we must maintain linearly increasing sequence number order of items of type `T`.
+    /// In a perfect world, all `T`'s arrive in order, but this is not the case in reality. All T's are `Sequenced and
+    /// have a corresponding sequence number to delineate order.
+    ///
+    /// This also handles the case where the sequence number numerically wraps.
+    /// `buffer_wrap_index` is maintained to denote the queue index at which the numerical wrap occurs.
+    /// It is used to determine if a wrap has occurred yet, and if so, helps narrow the queue subset we will insert into.
+    ///
+    /// For sequence numbers of type 'Byte':
+    ///     [253, 254, 1, 2, 4]
+    ///                ^ wrapping index
+    ///     Inserting '255' performs a search on the subset [253, 254] only.
+    ///     After insertion, the wrapping index increments since we modified the left half.
+    ///     [253, 254, 255, 1, 2, 4]
+    ///                     ^ wrapping index
+    ///     Inserting '3' performs a linear search on [1, 2, 4]. Does not impact wrapping index.
+    ///     [253, 254, 255, 1, 2, 3, 4]
+    ///                     ^ wrapping index
+    ///
+    /// Because we may tx or rx `T`'s out-of-order even when wrapped, there are checks added below to safeguard
+    /// against this. Primarily, they cover the cases where out-of-order insertion would transition the queue into a
+    /// wrapped state from a non-wrapped state.
+    ///
+    /// boolean return value states whether or not the packet we are buffering is already present within the queue.
+    fn buffer_item(&mut self, item: T) -> bool {
+        let mut packet_exists: bool = false;
+        let sequence = item.sequence_number();
+
+        // Empty queue
+        let opt_head_seq_num: Option<u64> = self.newest_seq_num();
+        if opt_head_seq_num.is_none() {
+            self.push_back(item);
+            self.attempts.push_back(NetAttempt::new());
+            return packet_exists;
+        }
+        let opt_tail_seq_num: Option<u64> = self.oldest_seq_num();
+        let newest_seq_num = opt_head_seq_num.unwrap();
+        let oldest_seq_num = opt_tail_seq_num.unwrap();
+
+        if sequence < oldest_seq_num {
+            // Special case with max_value where we do not need to search for the insertion spot.
+            if newest_seq_num == u64::max_value() {
+                if self.will_seq_cause_a_wrap(self.buffer_wrap_index, sequence, oldest_seq_num, newest_seq_num) {
+                    self.push_back(item);
+                    self.attempts.push_back(NetAttempt::new());
+                    self.buffer_wrap_index = Some(self.len() - 1);
+                } else {
+                    self.push_front(item);
+                    self.attempts.push_back(NetAttempt::new());
+                }
+            } else if sequence > newest_seq_num && self.buffer_wrap_index.is_some() {
+                // When wrapped, either this is the newest sequence number so far, or
+                // an older sequence number arrived late.
+                if self.is_seq_sufficiently_far_away(sequence, newest_seq_num) {
+                    if let Some(buffer_wrap_index) = self.buffer_wrap_index {
+                        let insertion_index = self.find_rx_insertion_index_in_subset(0, buffer_wrap_index, &item);
+                        self.buffer_wrap_index = Some(buffer_wrap_index + 1);
+                        packet_exists = self.insert_into_rx_queue(insertion_index, item);
+                    }
+                } else {
+                    self.push_back(item);
+                    self.attempts.push_back(NetAttempt::new());
+                }
+            } else if sequence < newest_seq_num {
+                // The new seq num appears to be older than everything,
+                // but it may be far enough in value to induce a wrap.
+                let insertion_index: Option<usize>;
+                if self.will_seq_cause_a_wrap(self.buffer_wrap_index, sequence, oldest_seq_num, newest_seq_num) {
+                    insertion_index = Some(self.len());
+                    self.buffer_wrap_index = insertion_index;
+                } else if let Some(buffer_wrap_index) = self.buffer_wrap_index {
+                    insertion_index = self.find_rx_insertion_index_in_subset(buffer_wrap_index, self.len(), &item);
+                } else {
+                    insertion_index = self.find_rx_insertion_index(&item);
+                }
+
+                packet_exists = self.insert_into_rx_queue(insertion_index, item);
+            } else {
+                // Smallest sequence number (in value) that we have seen thus far.
+                self.push_front(item);
+                self.attempts.push_back(NetAttempt::new());
+
+                if self.buffer_wrap_index.is_some() {
+                    self.buffer_wrap_index = Some(self.buffer_wrap_index.unwrap() + 1);
+                }
+                panic!("Previously thought to be dead code. Prove us wrong!");
+            }
+        } else { // Sequence >= oldest_seq_num
+            let insertion_index: Option<usize>;
+            if sequence < newest_seq_num {
+                insertion_index = self.find_rx_insertion_index(&item);
+            } else {
+                // Greater than the oldest and newest seq num in the queue.
+                // Time to see if we have wrapped already, and if not, we
+                // need to see if we are about to wrap based on this insertion.
+                if let Some(buffer_wrap_index) = self.buffer_wrap_index {
+                    insertion_index = self.find_rx_insertion_index_in_subset(0, buffer_wrap_index, &item);
+                    self.buffer_wrap_index = Some(buffer_wrap_index + 1);
+                } else {
+                    if self.will_seq_cause_a_wrap(self.buffer_wrap_index, sequence, oldest_seq_num, newest_seq_num) {
+                        // Sequence is far enough, and we haven't wrapped, so it arrived late.
+                        // Push it to the front of the queue
+                        insertion_index = Some(0);
+                        self.buffer_wrap_index = Some(1);
+                    } else {
+                        // No wrap yet, and not about to either, use a blind binary search.
+                        insertion_index = self.find_rx_insertion_index(&item);
+                    }
+                }
+            }
+            packet_exists = self.insert_into_rx_queue(insertion_index, item);
+        }
+        packet_exists
+    }
+}
+
+impl<T> NetQueue<T> where T: Sequenced+Debug+Clone {
+
+    /// Searching within the queue, but when we have no idea where to insert.
+    /// We accomplish this by splitting the VecDequeue into a slice tuple and then binary searching on each slice.
+    /// Small note: The splitting of VecDequeue is into its 'front' and 'back' halves, based on how 'push_front'
+    /// and 'push_back' were used.
+    fn find_rx_insertion_index(&self, item: &T) -> Option<usize> {
+        let (front_slice, back_slice) = self.queue.as_slices();
+        let f_result = front_slice.binary_search(&item);
+        let b_result = back_slice.binary_search(&item);
+
+        match (f_result, b_result) {
+            (Err(loc1), Err(loc2)) => {
+                // We will not insert at the front of front_slice or end of back_slice,
+                // because these cases are covered by "oldest" and "newest" already.
+                // This leaves us with:
+                //      1. a) At the end of the front slice
+                //         b) Somewhere in the middle of front slice
+                //      2. a) At the start of the back slice (same as "end of front slice")
+                //         b) Somewhere in the middle of the back slice
+                // loc1 and loc2 are the index at which we would insert at each slice
+                match (loc1, loc2) {
+                    // Case 1a)/2a)
+                    (g, 0) if g == front_slice.len() => Some(front_slice.len()),
+                    // Case 2b)
+                    (g, n) if g == front_slice.len() => Some(front_slice.len() + n),
+                    // Case 1b)
+                    (n, 0) => Some(n),
+                    // Could not find a place to insert
+                    (_, _) => None,
+                }
+            },
+            #[cfg(test)]
+            (_,_) => Some(MATCH_FOUND_SENTINEL),
+            #[cfg(not(test))]
+            (_,_) => None,
+        }
+    }
+
+    // Search within the RX queue when we know which subset interests us.
+    fn find_rx_insertion_index_in_subset(&self, start: usize, end: usize, item: &T) -> Option<usize> {
+        let search_space: Vec<&T> = self.queue.iter().skip(start).take(end).collect();
+        let result = search_space.as_slice().binary_search(&item);
+        match result {
+            Err(loc) => Some(loc + start),
+            #[cfg(test)]
+            Ok(_) => Some(MATCH_FOUND_SENTINEL),
+            #[cfg(not(test))]
+            Ok(_) => None,
+        }
+    }
+
+    // Checked insertion against the sentinel used during unit testing
+    fn insert_into_rx_queue(&mut self, index: Option<usize>, item: T) -> bool {
+        let mut exists: bool = false;
+        if let Some(insertion_index) = index {
+            if insertion_index != MATCH_FOUND_SENTINEL {
+                if cfg!(test) {
+                    self.as_queue_type_mut().insert(insertion_index, item.clone());
+                    self.attempts.push_back(NetAttempt::new());
+                }
+            }
+            if !(cfg!(test)) {
+                self.as_queue_type_mut().insert(insertion_index, item);
+                self.attempts.push_back(NetAttempt::new());
+            }
+        } else { exists = true; } // Packet is present in queue, hence None.
+        return exists;
+    }
+
+    /// `seq_num` as a parameter specifies the starting sequence number to iterate over. Since packets can arrive
+    /// out-of-order, the queue may be contiguous but not complete.
+    /// Ex: Assume the next packet SN to process is 10, and the queue has buffered [10, 11, 12, 14, 16],
+    /// the contiguous packet count would be 3.
+    #[allow(unused)]
+    pub fn get_contiguous_packets_count(&self, mut seq_num: u64) -> usize {
+        let iter = self.queue.iter().take_while(move |x| {
+            let ready = x.sequence_number() == seq_num;
+            if ready {
+                seq_num += 1;
+            }
+            ready
+        });
+        iter.count()
+    }
+}
+
+pub struct NetworkManager {
+    pub statistics:       NetworkStatistics,
+    pub tx_packets:       NetQueue<Packet>,                       // Back = Newest, Front = Oldest
+    pub rx_packets:       NetQueue<Packet>,                       // Back = Newest, Front = Oldest
+    pub rx_chat_messages: Option<NetQueue<BroadcastChatMessage>>, // Back = Newest, Front = Oldest;
+                                                                 //     Messages are drained into the Client;
+                                                                 //     Server does not use this structure.
+}
+
+impl NetworkManager {
+    #[allow(unused)]
+    pub fn new() -> Self {
+        NetworkManager {
+            statistics: NetworkStatistics::new(),
+            tx_packets:  NetQueue::<Packet>::new(),
+            rx_packets:  NetQueue::<Packet>::new(),
+            rx_chat_messages: None,
+        }
+    }
+
+    #[allow(unused)]
+    pub fn with_message_buffering(self) -> NetworkManager {
+        NetworkManager {
+            statistics: self.statistics,
+            tx_packets: self.tx_packets,
+            rx_packets: self.rx_packets,
+            rx_chat_messages:  Some(NetQueue::<BroadcastChatMessage>::new()),
+        }
+    }
+
+    #[allow(unused)]
+    pub fn reset(&mut self) {
+        #![deny(unused_variables)]
+        let Self {
+            ref mut statistics,
+            ref mut tx_packets,
+            ref mut rx_packets,
+            ref mut rx_chat_messages,
+        } = *self;
+        statistics.reset();
+        tx_packets.clear();
+        rx_packets.clear();
+        if let Some(chat_messages) = rx_chat_messages {
+            chat_messages.clear();
+            chat_messages.buffer_wrap_index = None;
+        }
+    }
+
+    #[allow(unused)]
+    pub fn print_statistics(&self) {
+        info!("Tx Successes: {}", self.statistics.tx_packets_success);
+        info!("Tx Failures:  {}", self.statistics.tx_packets_failed);
+    }
+
+    #[allow(unused)]
+    pub fn retransmit_expired_tx_packets(&mut self,
+         udp_tx: &mpsc::UnboundedSender<(SocketAddr, Packet)>,
+         addr: SocketAddr,
+         confirmed_ack: Option<u64>,
+         indices: &Vec<usize>) {
+
+        let mut error_occurred = false;
+        let mut failed_index = 0;
+
+        // Retransmit all packets after that are still in the queue after RETRANSMISSION_THRESHOLD_IN_MS
+        for &index in indices.iter() {
+
+            let mut send_counter = 1;
+
+            if let Some(ts) = self.tx_packets.attempts.get_mut(index) {
+                ts.increment_retries();
+                if ts.retries >= RETRY_AGGRESSIVE_THRESHOLD_IN_MS {
+                    send_counter += 1;
+                    ts.increment_retries()
+                }
+                if ts.retries >= RETRY_THRESHOLD_IN_MS {
+                    send_counter += 1;
+                    ts.increment_retries()
+                }
+            }
+
+            if let Some(pkt) = self.tx_packets.queue.get_mut(index) {
+                // `response_sequence` may have advanced since this was last queued
+                pkt.set_response_sequence(confirmed_ack);
+                trace!("[Retransmitting (Times={})] {:?}", send_counter, pkt);
+                for _ in 0..send_counter {
+                    netwayste_send!(udp_tx, (addr, (*pkt).clone()),
+                                ("Could not retransmit packet to server: {:?}", pkt));
+                }
+            } else {
+                error_occurred = true;
+                failed_index = index;
+                break;
+            }
+
+        }
+
+        if error_occurred {
+            // Panic during development, probably want to make this error later on
+            panic!("ERROR: Index ({}) in attempt queue out-of-bounds in tx packets queue,
+                            or perhaps `None`?:\n\t {:?}\n{:?}\n{:?}",
+                    failed_index, indices, self.tx_packets.queue.len(), self.tx_packets.attempts.len());
+        }
+    }
+
+    #[allow(unused)]
+    pub fn tx_pop_front_with_count(&mut self, mut num_to_remove: usize) {
+        if num_to_remove > self.tx_packets.len() {
+            return;
+        }
+
+        while num_to_remove > 0 {
+            self.tx_packets.as_queue_type_mut().pop_front();
+            self.tx_packets.attempts.pop_front();
+            num_to_remove -= 1;
+        }
+    }
+
+}
+
+#[derive(PartialEq, Debug, Clone)]
+#[allow(dead_code)]
+pub enum NetwaysteEvent {
+    None,
+
+    // Requests
+    Connect(String, String),            // Player name, version
+    Disconnect,
+    List,
+    ChatMessage(String),                // chat message
+    NewRoom(String),                    // room name
+    JoinRoom(String),                   // room name
+    LeaveRoom,
+
+    // Responses
+    LoggedIn(String),                   // player is logged in -- (version)
+    JoinedRoom(String),                 // player has joined the room
+    PlayerList(Vec<String>),     // list of players in room or lobby with ping (ms)
+    RoomList(Vec<(String, u64, bool)>), // (room name, # players, game has started?)
+    LeftRoom,
+    BadRequest(Option<String>),
+    ServerError(Option<String>),
+
+    // Updates
+    ChatMessages(Vec<(String, String)>), // (player name, message)
+    UniverseUpdate,                       // TODO add libconway stuff for current universe gen
+
+}
+
+impl NetwaysteEvent {
+
+    #[allow(dead_code)]
+    pub fn build_request_action_from_netwayste_event(nw_event: NetwaysteEvent, is_in_game: bool) -> RequestAction {
+        match nw_event {
+            NetwaysteEvent::None => {
+                RequestAction::None
+            }
+            NetwaysteEvent::Connect(name, version) => {
+                RequestAction::Connect{name: name, client_version: version}
+            }
+            NetwaysteEvent::Disconnect => {
+                RequestAction::Disconnect
+            }
+            NetwaysteEvent::List => {
+                // players or rooms
+                if is_in_game {
+                    RequestAction::ListPlayers
+                } else {
+                    // lobby
+                    RequestAction::ListRooms
+                }
+            }
+            NetwaysteEvent::ChatMessage(msg) => {
+                RequestAction::ChatMessage(msg)
+            }
+            NetwaysteEvent::NewRoom(name) => {
+                if !is_in_game {
+                    RequestAction::NewRoom(name)
+                } else {
+                    debug!("Command failed: You are in a game");
+                    RequestAction::None
+                }
+            }
+            NetwaysteEvent::JoinRoom(name) => {
+                if !is_in_game {
+                    RequestAction::JoinRoom(name)
+                } else {
+                    debug!("Command failed: You are already in a game");
+                    RequestAction::None
+                }
+            }
+            NetwaysteEvent::LeaveRoom => {
+                if is_in_game {
+                    RequestAction::LeaveRoom
+                } else {
+                    debug!("Command failed: You are already in the lobby");
+                    RequestAction::None
+                }
+            }
+            _ => {
+                panic!("Unexpected netwayste event during request action construction! {:?}", nw_event);
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn build_netwayste_event_from_response_code(code: ResponseCode) -> NetwaysteEvent {
+        match code {
+            ResponseCode::LoggedIn(_cookie, server_version) => {
+                NetwaysteEvent::LoggedIn(server_version)
+            }
+            ResponseCode::JoinedRoom(name) => {
+                NetwaysteEvent::JoinedRoom(name)
+            }
+            ResponseCode::PlayerList(list) => {
+                NetwaysteEvent::PlayerList(list)
+            }
+            ResponseCode::RoomList(list) => {
+                NetwaysteEvent::RoomList(list)
+            }
+            ResponseCode::LeaveRoom => {
+                NetwaysteEvent::LeftRoom
+            }
+            ResponseCode::BadRequest(opt_error) => {
+                NetwaysteEvent::BadRequest(opt_error)
+            }
+            ResponseCode::ServerError( opt_error) => {
+                NetwaysteEvent::ServerError(opt_error)
+            }
+            ResponseCode::Unauthorized(opt_error) => {
+                NetwaysteEvent::BadRequest(opt_error)
+            }
+            _ => {
+                panic!("Unexpected response code during netwayste event construction: {:?}", code);
+            }
+        }
+    }
+
+}

--- a/netwayste/src/server.rs
+++ b/netwayste/src/server.rs
@@ -1,0 +1,2700 @@
+/*
+ * Herein lies a networking library for the multiplayer game, Conwayste.
+ *
+ * Copyright (C) 2018-2019 The Conwayste Developers
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#[macro_use] extern crate log;
+#[macro_use] mod net;
+
+#[cfg(test)]
+#[macro_use]
+extern crate proptest;
+
+use netwayste::net::{
+    RequestAction, ResponseCode, Packet, LineCodec, bind,
+    UniUpdateType, BroadcastChatMessage, NetworkManager,
+    NetworkQueue, get_version, VERSION, has_connection_timed_out,
+    DEFAULT_HOST, DEFAULT_PORT,
+};
+
+use std::error::Error;
+use std::io::{self, ErrorKind, Write};
+use std::iter;
+use std::net::SocketAddr;
+use std::process::exit;
+use std::time::{Duration, Instant};
+use std::collections::HashMap;
+use std::fmt;
+use std::time;
+use std::collections::VecDeque;
+
+use tokio_core::reactor::{Core, Timeout};
+use chrono::Local;
+use log::LevelFilter;
+use futures::{Future, Sink, Stream, stream, future::ok, sync::mpsc};
+use rand::RngCore;
+use semver::Version;
+use clap::{App, Arg};
+
+pub const TICK_INTERVAL_IN_MS:    u64      = 10;
+pub const NETWORK_INTERVAL_IN_MS: u64      = 100;    // Arbitrarily chosen
+pub const HEARTBEAT_INTERVAL_IN_MS: u64    = 1000;    // Arbitrarily chosen
+pub const MAX_ROOM_NAME:          usize    = 16;
+pub const MAX_NUM_CHAT_MESSAGES:  usize    = 128;
+pub const MAX_AGE_CHAT_MESSAGES:  usize    = 60*5; // seconds
+pub const SERVER_ID:              PlayerID = PlayerID(u64::max_value()); // 0xFFFF....FFFF
+
+#[derive(PartialEq, Debug, Clone, Copy, Eq, Hash)]
+pub struct PlayerID(pub u64);
+
+#[derive(PartialEq, Debug, Clone, Copy, Eq, Hash)]
+pub struct RoomID(pub u64);
+
+impl fmt::Display for PlayerID {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "({})", self.0)
+    }
+}
+
+impl fmt::Display for RoomID {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "({})", self.0)
+    }
+}
+
+#[derive(PartialEq, Debug, Clone)]
+pub struct Player {
+    pub player_id:     PlayerID,
+    pub cookie:        String,
+    pub addr:          SocketAddr,
+    pub name:          String,
+    pub request_ack:   Option<u64>,          // The next number we expect is request_ack + 1
+    pub next_resp_seq: u64,                  // This is the sequence number for the Response packet the Server sends to the Client
+    pub game_info:     Option<PlayerInGameInfo>,   // none means in lobby
+    pub heartbeat:     Option<time::Instant>,
+}
+
+// info for a player as it relates to a game/room
+#[derive(PartialEq, Debug, Clone)]
+pub struct PlayerInGameInfo {
+    room_id: RoomID,
+    chat_msg_seq_num: Option<u64>,    // Server has confirmed the client has received messages up to this value.
+    //XXX PlayerGenState ID within Universe
+    //XXX update statuses
+}
+
+impl Player {
+    pub fn increment_response_seq_num(&mut self) -> u64 {
+        let old_seq = self.next_resp_seq;
+        self.next_resp_seq += 1;
+        old_seq
+    }
+
+    // Update the Server's record of what chat messsage the player has obtained.
+    // If the player is in a game, and the player has seen newer chat messages since the last time
+    // they updated us on what messages they had, save their sequence number.
+    pub fn update_chat_seq_num(&mut self, opt_chat_seq_num: Option<u64>) {
+        if self.game_info.is_none() {
+            return;
+        }
+        let game_info: &mut PlayerInGameInfo = self.game_info.as_mut().unwrap();
+
+        if game_info.chat_msg_seq_num.is_none() || game_info.chat_msg_seq_num < opt_chat_seq_num {
+            game_info.chat_msg_seq_num = opt_chat_seq_num;
+        }
+    }
+
+    // If the player has chatted, we'll return Some(N),
+    // where N is the last chat message the player has
+    // notified the Server it got.
+    // Otherwise, None
+    pub fn get_confirmed_chat_seq_num(&self) -> Option<u64> {
+        if self.game_info.is_none() {
+            return None;
+        }
+
+        if let Some(ref game_info) = self.game_info {
+            return game_info.chat_msg_seq_num;
+        }
+        return None;
+    }
+
+    // Allow dead_code for unit testing
+    #[allow(dead_code)]
+    pub fn has_chatted(&self) -> bool {
+        if self.game_info.is_none() {
+            return false;
+        }
+
+        if let Some(ref game_info) = self.game_info {
+            return game_info.chat_msg_seq_num.is_some();
+        }
+        return false;
+    }
+
+}
+
+#[derive(PartialEq, Debug, Clone)]
+pub struct ServerChatMessage {
+    pub seq_num:     u64,     // sequence number
+    pub player_id:   PlayerID,
+    pub player_name: String,
+    pub message:     String,
+    pub timestamp:   Instant,
+}
+
+#[derive(Clone, PartialEq)]
+pub struct Room {
+    pub room_id: RoomID,
+    pub name:         String,
+    pub player_ids:   Vec<PlayerID>,
+    pub game_running: bool,
+    pub universe:     u64,    // Temp until we integrate
+    pub latest_seq_num: u64,
+    pub messages:     VecDeque<ServerChatMessage>    // Front == Oldest, Back == Newest
+}
+
+pub struct ServerState {
+    pub tick:           usize,
+    pub players:        HashMap<PlayerID, Player>,
+    pub player_map:     HashMap<String, PlayerID>,  // map cookie to player ID
+    pub rooms:          HashMap<RoomID, Room>,
+    pub room_map:       HashMap<String, RoomID>,    // map room name to room ID
+    pub network_map:    HashMap<PlayerID, NetworkManager>,  // map Player ID to Player's network data
+}
+
+//////////////// Utilities ///////////////////////
+
+pub fn new_cookie() -> String {
+    let mut buf = [0u8; 16];
+    rand::thread_rng().fill_bytes(&mut buf);
+    base64::encode(&buf)
+}
+
+/*
+*  Entity (Player/Room) IDs are comprised of:
+*      1) Current timestamp (lower 24 bits)
+*      2) A random salt
+*
+*       64 bits total
+*  _________________________
+*  |  32 bits  |  32 bits  |
+*  | timestamp | rand_salt |
+*  |___________|___________|
+*/
+pub fn new_uuid() -> u64 {
+    let hash: u64;
+
+    let mut timestamp: u64 = time::Instant::now().elapsed().as_secs().into();
+    timestamp = timestamp & 0xFFFFFFFF;
+
+    let mut rand_salt: u64 = rand::thread_rng().next_u32().into();
+    rand_salt = rand_salt & 0xFFFFFFFF;
+
+    hash = (timestamp << 32) | rand_salt;
+    hash
+}
+
+pub fn validate_client_version(client_version: String) -> bool {
+    let server_version = get_version();
+
+    // Client cannot be newer than server
+    server_version >= Version::parse(&client_version)
+}
+
+impl ServerChatMessage {
+    pub fn new(id: PlayerID, name: String, msg: String, seq_num: u64) -> Self {
+        ServerChatMessage {
+            player_id: id,
+            player_name: name,
+            message: msg,
+            seq_num: seq_num,
+            timestamp: time::Instant::now()
+        }
+    }
+}
+
+impl Room {
+    /// Instantiates a `Room` with the provided `name` and adds
+    /// the players (via `player_ids`) immediately to it.
+    pub fn new(name: String, player_ids: Vec<PlayerID>) -> Self {
+        Room {
+            room_id: RoomID(new_uuid()),
+            name: name,
+            player_ids:   player_ids,
+            game_running: false,
+            universe:     0,
+            messages:     VecDeque::<ServerChatMessage>::with_capacity(MAX_NUM_CHAT_MESSAGES),
+            latest_seq_num: 0,
+        }
+    }
+
+    /// The room message queue cannot exceed `MAX_NUM_CHAT_MESSAGES` so we
+    /// will dequeue the oldest messages until we are within limits.
+    pub fn discard_older_messages(&mut self) {
+        let queue_size = self.messages.len();
+        if queue_size >= MAX_NUM_CHAT_MESSAGES {
+            for _ in 0..(queue_size-MAX_NUM_CHAT_MESSAGES+1) {
+                self.messages.pop_front();
+            }
+        }
+    }
+
+    pub fn has_players(&mut self) -> bool {
+        !self.player_ids.is_empty()
+    }
+
+    /// Increments the room's latest sequence number
+    pub fn increment_seq_num(&mut self) -> u64 {
+        self.latest_seq_num += 1;
+        self.latest_seq_num
+    }
+
+    /// Adds a new message to the room message queue
+    pub fn add_message(&mut self, new_message: ServerChatMessage) {
+        self.messages.push_back(new_message);
+    }
+
+    /// Gets the oldest message in the room message queue
+    pub fn get_oldest_msg(&self) -> Option<&ServerChatMessage> {
+        return self.messages.front();
+    }
+
+    /// Gets the newest message in the room message queue
+    pub fn get_newest_msg(&self) -> Option<&ServerChatMessage> {
+        return self.messages.back();
+    }
+
+    /// This function retrieves the number of messages that have
+    /// already been acknowledged by the client. One use of this is
+    /// to only send unread messages.
+    pub fn get_message_skip_count(&self, chat_msg_seq_num: u64) -> u64 {
+        let opt_newest_msg = self.get_newest_msg();
+        if opt_newest_msg.is_none() {
+            return 0;
+        }
+        let newest_msg = opt_newest_msg.unwrap();
+
+        let opt_oldest_msg = self.get_oldest_msg();
+        if opt_oldest_msg.is_none() {
+            return 0;
+        }
+        let oldest_msg = opt_oldest_msg.unwrap();
+
+        // Skip over these messages since we've already acked them
+        let amount_to_consume: u64 =
+            if chat_msg_seq_num >= oldest_msg.seq_num {
+                ((chat_msg_seq_num - oldest_msg.seq_num) + 1) % (MAX_NUM_CHAT_MESSAGES as u64)
+            } else if chat_msg_seq_num < oldest_msg.seq_num && oldest_msg.seq_num != newest_msg.seq_num {
+                // Sequence number has wrapped
+                (<u64>::max_value() - oldest_msg.seq_num) + chat_msg_seq_num + 1
+            } else {
+                0
+            };
+
+        return amount_to_consume;
+    }
+
+    /// Send a message to all players in room notifying that an event took place.
+    pub fn broadcast(&mut self, event: String) {
+        self.discard_older_messages();
+        let seq_num = self.increment_seq_num();
+        self.add_message(ServerChatMessage::new(SERVER_ID, "Server".to_owned(), event, seq_num));
+    }
+}
+
+impl ServerState {
+
+    pub fn get_player(&self, player_id: PlayerID) -> &Player {
+        let opt_player = self.players.get(&player_id);
+
+        if opt_player.is_none() {
+            panic!("player_id: {} could not be found!", player_id);
+        }
+
+        opt_player.unwrap()
+    }
+
+    pub fn get_player_mut(&mut self, player_id: PlayerID) -> &mut Player {
+        let opt_player = self.players.get_mut(&player_id);
+
+        if opt_player.is_none() {
+            panic!("player_id: {} could not be found!", player_id);
+        }
+
+        opt_player.unwrap()
+    }
+
+    pub fn get_room_id(&self, player_id: PlayerID) -> Option<RoomID> {
+        let player = self.get_player(player_id);
+        if player.game_info == None {
+            return None;
+        };
+
+        Some(player.game_info.as_ref().unwrap().room_id)  // unwrap ok because of test above
+    }
+
+    pub fn get_room_mut(&mut self, player_id: PlayerID) -> Option<&mut Room> {
+        let opt_room_id = self.get_room_id(player_id);
+
+        if opt_room_id.is_none() {
+            return None;
+        }
+        self.rooms.get_mut(&opt_room_id.unwrap())
+    }
+
+    pub fn get_room(&self, player_id: PlayerID) -> Option<&Room> {
+        let opt_room_id = self.get_room_id(player_id);
+
+        if opt_room_id.is_none() {
+            return None;
+        }
+        self.rooms.get(&opt_room_id.unwrap())
+    }
+
+    pub fn list_players(&self, player_id: PlayerID) -> ResponseCode {
+        let opt_room = self.get_room(player_id);
+        if opt_room.is_none() {
+            return ResponseCode::BadRequest(Some("cannot list players because in lobby.".to_owned()));
+        }
+        let room = opt_room.unwrap();
+
+        let mut players = vec![];
+        self.players.values().for_each(|p| {
+            if room.player_ids.contains(&p.player_id) {
+                players.push(p.name.clone());
+            }
+        });
+
+        return ResponseCode::PlayerList(players);
+    }
+
+    pub fn handle_chat_message(&mut self, player_id: PlayerID, msg: String) -> ResponseCode {
+        let player_in_game = self.is_player_in_game(player_id);
+
+        if !player_in_game {
+            return ResponseCode::BadRequest(Some(format!("Player {} has not joined a game.", player_id)));
+        }
+
+        // We're borrowing self mutably below, so let's grab this now
+        let player_name = {
+            let player = self.players.get(&player_id);
+            player.unwrap().name.clone()
+        };
+
+        // User is in game, Server needs to broadcast this to Room
+        let opt_room = self.get_room_mut(player_id);
+
+        if opt_room.is_none() {
+            return ResponseCode::BadRequest(Some( format!("Player \"{}\" should be in a room! None found.", player_id )));
+        }
+
+        let room = opt_room.unwrap();
+        let seq_num = room.increment_seq_num();
+
+        room.discard_older_messages();
+        room.add_message(ServerChatMessage::new(player_id, player_name, msg, seq_num));
+
+        return ResponseCode::OK;
+    }
+
+    pub fn list_rooms(&mut self) -> ResponseCode {
+        let mut rooms = vec![];
+        self.rooms.values().for_each(|gs| {
+            rooms.push((gs.name.clone(), gs.player_ids.len() as u64, gs.game_running));
+        });
+        ResponseCode::RoomList(rooms)
+    }
+
+    pub fn new_room(&mut self, name: String) {
+        let room = Room::new(name.clone(), vec![]);
+
+        self.room_map.insert(name, room.room_id);
+        self.rooms.insert(room.room_id, room);
+    }
+
+    pub fn create_new_room(&mut self, opt_player_id: Option<PlayerID>, room_name: String) -> ResponseCode {
+        // validate length
+        if room_name.len() > MAX_ROOM_NAME {
+            return ResponseCode::BadRequest(Some(format!("room name too long; max {} characters",
+                                                            MAX_ROOM_NAME)));
+        }
+
+        if let Some(player_id) = opt_player_id {
+            if self.is_player_in_game(player_id) {
+                return ResponseCode::BadRequest(Some("cannot create room because in-game".to_owned()));
+            }
+        }
+
+        // Create room if the room name is not already taken
+        if !self.room_map.get(&room_name).is_some() {
+            self.new_room(room_name.clone());
+
+            return ResponseCode::OK;
+        } else {
+            return ResponseCode::BadRequest(Some(format!("room name already in use")));
+        }
+    }
+
+    pub fn join_room(&mut self, player_id: PlayerID, room_name: String) -> ResponseCode {
+        let already_playing = self.is_player_in_game(player_id);
+        if already_playing {
+            return ResponseCode::BadRequest(Some("cannot join game because in-game".to_owned()));
+        }
+
+        let player: &mut Player = self.players.get_mut(&player_id).unwrap();
+
+        // TODO replace loop with `get_key_value` once it reaches stable. Same thing with `leave_room` algorithm
+        for ref mut gs in self.rooms.values_mut() {
+            if gs.name == room_name {
+                gs.player_ids.push(player_id);
+                player.game_info = Some(PlayerInGameInfo {
+                    room_id: gs.room_id.clone(),
+                    chat_msg_seq_num: None
+                });
+                return ResponseCode::JoinedRoom(room_name);
+            }
+        }
+        return ResponseCode::BadRequest(Some(format!("no room named {:?}", room_name)));
+    }
+
+    pub fn leave_room(&mut self, player_id: PlayerID) -> ResponseCode {
+        let already_playing = self.is_player_in_game(player_id);
+        if !already_playing {
+            return ResponseCode::BadRequest(Some("cannot leave game because in lobby".to_owned()));
+        }
+
+        let player: &mut Player = self.players.get_mut(&player_id).unwrap();
+        {
+            let room_id = &player.game_info.as_ref().unwrap().room_id;  // unwrap ok because of test above
+            for ref mut gs in self.rooms.values_mut() {
+                if gs.room_id == *room_id {
+                    // remove player_id from room's player_ids
+                    gs.player_ids.retain(|&p_id| p_id != player.player_id);
+                    break;
+                }
+            }
+        }
+        player.game_info = None;
+
+        return ResponseCode::LeaveRoom;
+    }
+
+    pub fn remove_player(&mut self, player_id: PlayerID, player_cookie: String) {
+        self.player_map.remove(&player_cookie);
+        self.players.remove(&player_id);
+    }
+
+    pub fn handle_disconnect(&mut self, player_id: PlayerID) -> ResponseCode {
+        let (player_name, player_cookie) = {
+            let player = self.get_player(player_id);
+            let name = player.name.to_owned();
+            let cookie = player.cookie.clone();
+            (name, cookie)
+        };
+
+        if self.is_player_in_game(player_id) {
+            {
+                let room: &mut Room = self.get_room_mut(player_id).unwrap(); // safe because in game check verifies room's existence
+                room.broadcast(format!("Player {} has left.", player_name));
+            }
+            let _left = self.leave_room(player_id);     // Ignore return since we don't care
+        }
+
+        self.remove_player(player_id, player_cookie);
+
+        ResponseCode::OK
+    }
+
+    // not used for connect
+    pub fn process_request_action(&mut self, player_id: PlayerID, action: RequestAction) -> ResponseCode {
+        match action {
+            RequestAction::Disconnect      => {
+                return self.handle_disconnect(player_id);
+            },
+            RequestAction:: KeepAlive(_) => {
+                let player: &mut Player = self.get_player_mut(player_id);
+                player.heartbeat = Some(time::Instant::now());
+                return ResponseCode::OK;
+            },
+            RequestAction::ListPlayers     => {
+                return self.list_players(player_id);
+            },
+            RequestAction::ChatMessage(msg)  => {
+                return self.handle_chat_message(player_id, msg);
+            },
+            RequestAction::ListRooms   => {
+                return self.list_rooms();
+            }
+            RequestAction::NewRoom(name)  => {
+                return self.create_new_room(Some(player_id), name);
+            }
+            RequestAction::JoinRoom(room_name) => {
+                return self.join_room(player_id, room_name);
+            }
+            RequestAction::LeaveRoom   => {
+                return self.leave_room(player_id);
+            }
+            RequestAction::Connect{..}     => {
+                return ResponseCode::BadRequest( Some("already connected".to_owned()) );
+            },
+            RequestAction::None => {
+                return ResponseCode::BadRequest( Some("Invalid request".to_owned()) );
+            },
+        }
+    }
+
+    pub fn is_player_in_game(&self, player_id: PlayerID) -> bool {
+        let player: Option<&Player> = self.players.get(&player_id);
+        player.is_some() && player.unwrap().game_info.is_some()
+    }
+
+    pub fn is_unique_player_name(&self, name: &str) -> bool {
+        for ref player in self.players.values() {
+            if player.name == name {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // Request_ack contains the last processed sequence number. If one arrives older (less than)
+    // than the last processed, it must be rejected.
+    // FIXME Does not handle wrapped sequence number case yet.
+    pub fn is_previously_processed_packet(&mut self, player_id: PlayerID, sequence: u64) -> bool {
+        let player: &Player = self.get_player(player_id);
+        if let Some(request_ack) = player.request_ack {
+            if sequence <= request_ack {
+                return true;
+            }
+        }
+        false
+    }
+
+    pub fn get_player_id_by_cookie(&self, cookie: &str) -> Option<PlayerID> {
+        match self.player_map.get(cookie) {
+            Some(player_id) => Some(*player_id),
+            None => None
+        }
+    }
+
+    /// Returns true if the packet already exists in the queue, otherwise it will return false, and
+    /// will be added in sequence_number order.
+    pub fn add_packet_to_queue(&mut self, player_id: PlayerID, packet: Packet) -> bool {
+        // Unwrap should be safe since a player ID was already found.
+        let network: &mut NetworkManager = self.network_map.get_mut(&player_id).unwrap();
+        let already_exists = network.rx_packets.buffer_item(packet);
+        already_exists
+    }
+
+    /// Checks to see if the incoming packet is immediately processable
+    pub fn can_process_packet(&mut self, player_id: PlayerID, sequence_number: u64) -> bool {
+        let player: &mut Player = self.get_player_mut(player_id);
+        if let Some(ack) = player.request_ack {
+            trace!("[CAN PROCESS?] Ack: {} Sqn: {}", ack, sequence_number);
+            ack+1 == sequence_number
+        } else {
+            // request_ack has not been set yet, likely first packet
+            player.request_ack = Some(0);
+            true
+        }
+    }
+
+    /// Processes a player's request action for all non Connect requests. If necessary, a response is buffered
+    /// for later transmission
+    pub fn process_player_request_action(&mut self, player_id: PlayerID, action: RequestAction) -> Result<Option<Packet>, Box<Error>> {
+        match action {
+            RequestAction::Connect{..} => unreachable!(),
+            _ => {
+                if let Some(response) = self.prepare_response(player_id, action.clone()) {
+                    // Buffer all responses to the client for [re-]transmission
+                    let network: Option<&mut NetworkManager> = self.network_map.get_mut(&player_id);
+                    if let Some(player_net) = network {
+                        trace!("[A Response to Client Request added to TX Buffer]{:?}", response);
+                        player_net.tx_packets.buffer_item(response.clone());
+                    }
+                    Ok(Some(response))
+                } else {
+                    Ok(None)
+                }
+            }
+        }
+    }
+
+    /// Determine how many contiguous packets are processable and process their requests for the given player.
+    pub fn process_queued_rx_packets(&mut self, player_id: PlayerID) {
+        // If we can, start popping off the RX queue and handle contiguous packets immediately
+        let mut dequeue_count = 0;
+
+        // Get the last packet we've sent to this player
+        let player_processed_seq_num = self.get_player(player_id).request_ack;
+        let mut latest_processed_seq_num;
+
+        if let Some(seq_num) = player_processed_seq_num {
+            latest_processed_seq_num = seq_num;
+        } else {
+            // if request_ack is None, we shouldn't have processed anything yet
+            latest_processed_seq_num = 0;
+        }
+
+        // Collect the next batch of received packets we can process.
+        let rx_queue_count;
+        let mut processable_packets: Vec<Packet> = vec![];
+        {
+            let network: Option<&mut NetworkManager> = self.network_map.get_mut(&player_id);
+            if let Some(player_net) = network {
+                rx_queue_count = player_net.rx_packets.get_contiguous_packets_count(latest_processed_seq_num+1);
+                // ameen: can I use take().filter().collect()?
+                while dequeue_count < rx_queue_count {
+                    let packet = player_net.rx_packets.as_queue_type_mut().pop_front().unwrap();
+
+                    // It is possible that a previously buffered packet (due to out-of-order) was resent by the client,
+                    // and processed immediately upon receipt. We need to skip these.
+                    if packet.sequence_number() > latest_processed_seq_num
+                    {
+                        processable_packets.push(packet);
+                    }
+
+                    dequeue_count += 1;
+                }
+            }
+        }
+
+        for packet in processable_packets {
+            trace!("[Processing Client Request from RX Buffer]: {:?}", packet);
+            match packet {
+                Packet::Request{sequence, response_ack: _, cookie: _, action} => {
+                    latest_processed_seq_num += 1;
+                    assert!(sequence == latest_processed_seq_num);
+                    let _response_packet = self.process_player_request_action(player_id, action);
+                }
+                _ => panic!("Development bug: Non-response packet found in client buffered RX queue")
+            }
+        }
+    }
+
+    pub fn process_player_buffered_packets(&mut self, players_to_update: &Vec<PlayerID>) {
+        for player_id in players_to_update {
+            self.process_queued_rx_packets(*player_id);
+        }
+    }
+
+    pub fn process_buffered_packets_in_lobby(&mut self){
+        let mut players_to_update: Vec<PlayerID> = vec![];
+
+        if self.players.len() == 0 {
+            return;
+        }
+
+        // Skip players if they're in a game
+        for player in self.players.values() {
+            if player.game_info.is_some() {
+                continue;
+            }
+            players_to_update.push(player.player_id);
+        }
+
+        if players_to_update.len() != 0 {
+            self.process_player_buffered_packets(&players_to_update);
+        }
+    }
+
+    pub fn resend_expired_tx_packets(&mut self, udp_tx: &mpsc::UnboundedSender<(SocketAddr, Packet)>) {
+        let mut players_to_update: Vec<PlayerID> = vec![];
+
+        if self.players.len() == 0 {
+            return;
+        }
+
+        for player in self.players.values() {
+            players_to_update.push(player.player_id);
+        }
+
+        if players_to_update.len() != 0 {
+            for player_id in players_to_update {
+                // If any processed packets result in responses, prepare them below for transmission
+                let player_addr: SocketAddr = self.get_player_mut(player_id).addr;
+                let ack = self.get_player_mut(player_id).request_ack;
+
+                let player_network: Option<&mut NetworkManager> = self.network_map.get_mut(&player_id);
+                if let Some(player_net) = player_network {
+                    if player_net.tx_packets.len() == 0 {
+                        continue;
+                    }
+
+                    let indices = player_net.tx_packets.get_retransmit_indices();
+                    trace!("[Sending expired responses to client from TX Buffer]: {:?} Len: {}", player_id, indices.len());
+                    player_net.retransmit_expired_tx_packets(udp_tx, player_addr, ack, &indices);
+
+                } else {
+                    error!("I haven't found a NetworkManager for Player: {}", player_id);
+                    continue;
+                }
+            }
+        }
+    }
+
+    pub fn process_buffered_packets_in_rooms(&mut self) {
+        let mut players_to_update: Vec<PlayerID> = vec![];
+
+        if self.rooms.len() == 0 {
+            return;
+        }
+
+        for room in self.rooms.values() {
+            if room.player_ids.len() == 0 {
+                continue;
+            }
+
+            for &player_id in &room.player_ids {
+                let opt_player: Option<&Player> = self.players.get(&player_id);
+                if opt_player.is_none() { continue; }
+
+                let player: &Player = opt_player.unwrap();
+                if player.game_info.is_none() { continue; }
+
+                players_to_update.push(player_id);
+            }
+        }
+
+        if players_to_update.len() != 0 {
+            self.process_player_buffered_packets(&players_to_update);
+        }
+    }
+
+    /// Clear out the transmission queue of any packets the client has acknowledged
+    pub fn clear_transmission_queue_on_ack(&mut self, player_id: PlayerID, response_ack: Option<u64>) {
+        if let Some(response_ack) = response_ack {
+            if let Some(ref mut player_network) = self.network_map.get_mut(&player_id) {
+                let mut removal_count = 0;
+                for resp_pkt in player_network.tx_packets.as_queue_type_mut().iter() {
+                    if response_ack > 0 && (resp_pkt.sequence_number() <= response_ack-1)
+                    {
+                        removal_count += 1;
+                    } else {
+                        break;
+                    }
+                    // else {
+                        // TODO handle wrapped case & unit tests
+                    // }
+                }
+
+                if removal_count != 0 {
+                    player_network.tx_pop_front_with_count(removal_count);
+                }
+            }
+        }
+    }
+
+    /// Inspect the packet's contents for acceptance, or reject it.
+    /// `Response`/`Update` packets are invalid in this context
+    /// Acceptance criteria for `Request`
+    ///  1. Cookie must be present and valid
+    ///  2. Ignore KeepAlive
+    ///  3. Client should notified if version requires updating
+    ///  4. Ignore if already received or processed
+    /// Always returns either Ok(Some(Packet::Response{...})), Ok(None), or error.
+    pub fn decode_packet(&mut self, addr: SocketAddr, packet: Packet) -> Result<Option<Packet>, Box<Error>> {
+        match packet.clone() {
+            _pkt @ Packet::Response{..} | _pkt @ Packet::Update{..} => {
+                return Err(Box::new(io::Error::new(ErrorKind::InvalidData, "invalid packet type")));
+            }
+            Packet::Request{sequence, response_ack, cookie, action} => {
+
+                match action {
+                    RequestAction::Connect{..} => (),
+                    RequestAction::KeepAlive(_) => (),
+                    _ => {
+                        if cookie == None {
+                            return Err(Box::new(io::Error::new(ErrorKind::InvalidData, "no cookie")));
+                        } else {
+                            trace!("[Request] cookie: {:?} sequence: {} resp_ack: {:?} event: {:?}", cookie, sequence,
+                                                                                                 response_ack, action);
+                        }
+                    }
+                }
+                // handle connect (create user, and save cookie)
+                if let RequestAction::Connect{name, client_version} = action {
+                    if validate_client_version(client_version) {
+                        let response = self.handle_new_connection(name, addr);
+                        return Ok(Some(response));
+                    } else {
+                        return Err(Box::new(io::Error::new(ErrorKind::Other, "client out of date -- please upgrade")));
+                    };
+                } else {
+                    // look up player by cookie
+                    let cookie = match cookie {
+                        Some(cookie) => cookie,
+                        None => {
+                            return Err(Box::new(io::Error::new(ErrorKind::InvalidData, "cookie required for non-connect actions")));
+                        }
+                    };
+                    let player_id = match self.get_player_id_by_cookie(cookie.as_str()) {
+                        Some(player_id) => player_id,
+                        None => {
+                            return Err(Box::new(io::Error::new(ErrorKind::PermissionDenied, "invalid cookie")));
+                        }
+                    };
+
+                    match action.clone() {
+                        RequestAction::KeepAlive(resp_ack) => {
+                            // If the client does not send new requests, the Server will never get a reply for
+                            // the set of responses it may have sent. This will result in the transmission queue contents
+                            // flooding the Client on retranmission.
+                            self.clear_transmission_queue_on_ack(player_id, Some(resp_ack));
+                            return Ok(None);
+                        }
+                        _ => (),
+                    }
+
+                    // For the non-KeepAlive case
+                    self.clear_transmission_queue_on_ack(player_id, response_ack);
+
+                    // Check to see if it can be processed right away, otherwise buffer it for later consumption.
+                    // Not sure if I like this name but it'll do for now.
+                    if self.can_process_packet(player_id, sequence) {
+                        trace!("[PROCESS IMMEDIATE]");
+                        return self.process_player_request_action(player_id, action);
+                    }
+
+                    // Packet may be resent by client but has since been processed.
+                    if self.is_previously_processed_packet(player_id, sequence) {
+                        trace!("\t [ALREADY PROCESSED]");
+                        return Ok(None);
+                    }
+
+                    // Returns true if the packet already exists in the queue
+                    if self.add_packet_to_queue(player_id, packet) {
+                        trace!("\t [ALREADY QUEUED]");
+                        return Ok(None);
+                    }
+
+                    // In the event we buffered it, we do not send a response
+                    trace!("\t [BUFFERED]");
+                    Ok(None)
+                }
+            }
+            Packet::UpdateReply{cookie, last_chat_seq, last_game_update_seq: _, last_gen: _} => {
+                let opt_player_id = self.get_player_id_by_cookie(cookie.as_str());
+
+                if opt_player_id.is_none() {
+                    return Err(Box::new(io::Error::new(ErrorKind::PermissionDenied, "invalid cookie")));
+                }
+
+                let player_id = opt_player_id.unwrap();
+                let opt_player = self.players.get_mut(&player_id);
+
+                if opt_player.is_none() {
+                    return Err(Box::new(io::Error::new(ErrorKind::NotFound, "player not found")));
+                }
+
+                let player: &mut Player = opt_player.unwrap();
+
+                if player.game_info.is_some() {
+                    player.update_chat_seq_num(last_chat_seq);
+                }
+                Ok(None)
+            }
+
+        }
+    }
+
+    pub fn prepare_response(&mut self, player_id: PlayerID, action: RequestAction) -> Option<Packet> {
+        let response_code = self.process_request_action(player_id, action.clone());
+
+        let (sequence, request_ack);//= (0, None);
+
+        match action {
+            RequestAction::KeepAlive(_) => unreachable!(), // Filtered away at the decoding packet layer
+            _ => {
+                let opt_player: Option<&mut Player> = self.players.get_mut(&player_id);
+
+                match opt_player {
+                    Some(player) => {
+                        sequence = player.increment_response_seq_num();
+                        if let Some(ack) = player.request_ack {
+                            player.request_ack = Some(ack+1);
+                            request_ack = player.request_ack;
+                        } else {
+                            panic!("Player's request ack has never been set. It should have been set after the first packet!");
+                        }
+                    }
+                    None => {
+                        // This happens with Disconnect packets -- player was deleted at top of this
+                        // function.
+                        return None;
+                    }
+                }
+            }
+        }
+
+        Some(Packet::Response{
+            sequence:    sequence,
+            request_ack: request_ack,
+            code:        response_code,
+        })
+    }
+
+    pub fn handle_new_connection(&mut self, name: String, addr: SocketAddr) -> Packet {
+        if self.is_unique_player_name(&name) {
+            let player = self.add_new_player(name.clone(), addr.clone());
+            let cookie = player.cookie.clone();
+
+            // Sequence is assumed to start at 0 for all new connections
+            let response = Packet::Response{
+                sequence:    0,
+                request_ack: Some(0), // Should start at seq_num 0 unless client's network state was not properly reset
+                code:        ResponseCode::LoggedIn(cookie, VERSION.to_owned()),
+            };
+            return response;
+        } else {
+            // not a unique name
+            let response = Packet::Response{
+                sequence:    0,
+                request_ack: None,
+                code:        ResponseCode::Unauthorized(Some("not a unique name".to_owned())),
+            };
+            return response;
+        }
+    }
+
+    // Right now we'll be constructing all client Update packets for _every_ room.
+    pub fn construct_client_updates(&mut self) -> Result<Option<Vec<(SocketAddr, Packet)>>, Box<Error>> {
+        let mut client_updates: Vec<(SocketAddr, Packet)> = vec![];
+
+        if self.rooms.len() == 0 {
+            return Ok(None);
+        }
+
+        // For each room, determine if each player has unread messages based on chat_msg_seq_num
+        // TODO: POOR PERFORMANCE BOUNTY
+        for room in self.rooms.values() {
+
+            if room.messages.is_empty() || room.player_ids.len() == 0 {
+                continue;
+            }
+
+            for &player_id in &room.player_ids {
+                let opt_player = self.players.get(&player_id);
+                if opt_player.is_none() { continue; }
+
+                let player: &Player = opt_player.unwrap();
+                if player.game_info.is_none() { continue; }
+
+                let unsent_messages: Option<Vec<BroadcastChatMessage>> = self.collect_unacknowledged_messages(&room, player);
+                let messages_available = unsent_messages.is_some();
+
+                // XXX Requires implementation
+                let game_updates_available = false;
+                let universe_updates_available = false;
+
+                let update_packet = Packet::Update {
+                    chats:           unsent_messages,
+                    game_updates:    None,
+                    universe_update: UniUpdateType::NoChange,
+                };
+
+                if messages_available || game_updates_available || universe_updates_available {
+                    client_updates.push( (player.addr.clone(), update_packet) );
+                }
+            }
+        }
+
+        if client_updates.len() > 0 {
+            Ok(Some(client_updates))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Creates a vector of messages that the provided Player has not yet acknowledged.
+    /// Exits early if the player is already caught up.
+    pub fn collect_unacknowledged_messages(&self, room: &Room, player: &Player) -> Option<Vec<BroadcastChatMessage>> {
+        // Only send what a player has not yet seen
+        let raw_unsent_messages: VecDeque<ServerChatMessage>;
+        match player.get_confirmed_chat_seq_num() {
+            Some(chat_msg_seq_num) => {
+                let opt_newest_msg = room.get_newest_msg();
+                if opt_newest_msg.is_none() {
+                    return None;
+                }
+
+                let newest_msg = opt_newest_msg.unwrap();
+
+                if chat_msg_seq_num == newest_msg.seq_num {
+                    // Player is caught up
+                    return None;
+                } else if chat_msg_seq_num > newest_msg.seq_num {
+                    error!("Misbehaving client {:?};\nClient says it has more messages than we sent!", player);
+                    return None;
+                } else {
+                    let amount_to_consume = room.get_message_skip_count(chat_msg_seq_num);
+
+                    // Cast to usize is safe because our message containers are limited by MAX_NUM_CHAT_MESSAGES
+                    raw_unsent_messages = room.messages.iter().skip(amount_to_consume as usize).cloned().collect();
+                }
+            }
+            None => {
+                // Smithers, unleash the hounds!
+                raw_unsent_messages = room.messages.clone();
+            }
+        };
+
+        if raw_unsent_messages.len() == 0 {
+            return None;
+        }
+
+        let unsent_messages: Vec<BroadcastChatMessage> = raw_unsent_messages.iter().map(|msg| {
+            BroadcastChatMessage::new(msg.seq_num, msg.player_name.clone(), msg.message.clone())
+        }).collect();
+
+        return Some(unsent_messages);
+    }
+
+    pub fn expire_old_messages_in_all_rooms(&mut self) {
+        if self.rooms.len() != 0 {
+            let current_timestamp = time::Instant::now();
+            for room in self.rooms.values_mut() {
+                if room.has_players() && !room.messages.is_empty() {
+                    room.messages.retain(|ref m| current_timestamp - m.timestamp < Duration::from_secs(MAX_AGE_CHAT_MESSAGES as u64) );
+                }
+            }
+        }
+    }
+
+    pub fn add_new_player(&mut self, name: String, addr: SocketAddr) -> &mut Player {
+        let cookie = new_cookie();
+        let player_id = PlayerID(new_uuid());
+        let player = Player {
+            player_id:     player_id.clone(),
+            cookie:        cookie.clone(),
+            addr:          addr,
+            name:          name,
+            request_ack:   None,
+            next_resp_seq: 0,
+            game_info:     None,
+            heartbeat:     None,
+        };
+
+        // save player into players hash map, and save player ID into hash map using cookie
+        self.player_map.insert(cookie, player_id);
+        self.players.insert(player_id, player);
+        self.network_map.insert(player_id, NetworkManager::new());
+
+        let player = self.get_player_mut(player_id);
+
+        // We expect that the Server proceed with `1` after the connection has been established
+        player.increment_response_seq_num();
+        player
+    }
+
+    pub fn remove_timed_out_clients(&mut self) {
+        let mut timed_out_players: Vec<PlayerID> = vec![];
+
+        for (p_id, p) in self.players.iter() {
+            if has_connection_timed_out(p.heartbeat) {
+                info!("Player({}) has timed out", p.cookie);
+                timed_out_players.push(*p_id);
+            }
+        }
+
+        for player_id in timed_out_players {
+            self.handle_disconnect(player_id);
+        }
+
+    }
+
+    pub fn new() -> Self {
+        ServerState {
+            tick:       0,
+            players:    HashMap::<PlayerID, Player>::new(),
+            rooms:      HashMap::<RoomID, Room>::new(),
+            player_map: HashMap::<String, PlayerID>::new(),
+            room_map:   HashMap::<String, RoomID>::new(),
+            network_map: HashMap::<PlayerID, NetworkManager>::new(),
+        }
+    }
+}
+
+
+//////////////// Event Handling /////////////////
+#[allow(unused)]
+enum Event {
+    TickEvent,
+    Request((SocketAddr, Option<Packet>)),
+    NetworkEvent,
+    HeartBeat,
+//    Notify((SocketAddr, Option<Packet>)),
+}
+
+pub fn main() {
+    env_logger::Builder::new()
+    .format(|buf, record| {
+        writeln!(buf,
+            "{} [{:5}] - {}",
+            Local::now().format("%a %Y-%m-%d %H:%M:%S%.6f"),
+            record.level(),
+            record.args(),
+        )
+    })
+    .filter(None, LevelFilter::Trace)
+    .filter(Some("futures"), LevelFilter::Off)
+    .filter(Some("tokio_core"), LevelFilter::Off)
+    .filter(Some("tokio_reactor"), LevelFilter::Off)
+    .init();
+
+    let matches = App::new("server")
+        .about("game server for Conwayste")
+        .arg(Arg::with_name("address")
+             .short("l")
+             .long("listen")
+             .help(&format!("address to listen for connections on [default {}]", DEFAULT_HOST))
+             .takes_value(true))
+        .arg(Arg::with_name("port")
+             .short("p")
+             .long("port")
+             .help(&format!("port to listen for connections on [default {}]", DEFAULT_PORT))
+             .takes_value(true))
+        .get_matches();
+
+    let mut core = Core::new().unwrap();
+    let handle = core.handle();
+
+    let (tx, rx) = mpsc::unbounded();
+
+    let opt_port = matches.value_of("port").map(|p_str| {
+        p_str.parse::<u16>().unwrap_or_else(|e| {
+            error!("Error while attempting to parse {:?} as port number: {:?}", p_str, e);
+            exit(1);
+        })
+    });
+    let udp = bind(&handle,
+                        matches.value_of("address"),
+                        opt_port)
+        .unwrap_or_else(|e| {
+            error!("Error while trying to bind UDP socket: {:?}", e);
+            exit(1);
+        });
+
+    trace!("Listening for connections on {:?}...", udp.local_addr().unwrap());
+
+    let (udp_sink, udp_stream) = udp.framed(LineCodec).split();
+
+    let initial_server_state = ServerState::new();
+
+    let iter_stream = stream::iter_ok::<_, io::Error>(iter::repeat( () ));
+    let tick_stream = iter_stream.and_then(|_| {
+        let timeout = Timeout::new(Duration::from_millis(TICK_INTERVAL_IN_MS), &handle).unwrap();
+        timeout.and_then(move |_| {
+            ok(Event::TickEvent)
+        })
+    }).map_err(|_| ());
+
+    let packet_stream = udp_stream
+        .filter(|&(_, ref opt_packet)| {
+            *opt_packet != None
+        })
+        .map(|packet_tuple| {
+            Event::Request(packet_tuple)
+        })
+        .map_err(|_| ());
+
+    let network_stream = stream::iter_ok::<_, io::Error>(iter::repeat( () ));
+    let network_stream = network_stream.and_then(|_| {
+        let timeout = Timeout::new(Duration::from_millis(NETWORK_INTERVAL_IN_MS), &handle).unwrap();
+        timeout.and_then(move |_| {
+            ok(Event::NetworkEvent)
+        })
+    }).map_err(|_| ());
+
+    let heartbeat_stream = stream::iter_ok::<_, io::Error>(iter::repeat( () ));
+    let heartbeat_stream = heartbeat_stream.and_then(|_| {
+        let timeout = Timeout::new(Duration::from_millis(HEARTBEAT_INTERVAL_IN_MS), &handle).unwrap();
+        timeout.and_then(move |_| {
+            ok(Event::HeartBeat)
+        })
+    }).map_err(|_| ());
+
+    let server_fut = tick_stream
+        .select(packet_stream)
+        .select(network_stream)
+        .select(heartbeat_stream)
+        .fold(initial_server_state, move |mut server_state: ServerState, event: Event | {
+            match event {
+                Event::Request(packet_tuple) => {
+                     // With the above filter, `packet` should never be None
+                    let (addr, opt_packet) = packet_tuple;
+
+                    // Decode incoming and send a Response to the Requester
+                    if let Some(packet) = opt_packet {
+                        let decode_result = server_state.decode_packet(addr, packet.clone());
+                        if decode_result.is_ok() {
+                            let opt_response_packet = decode_result.unwrap();
+
+                            if let Some(response_packet) = opt_response_packet {
+                                let response = (addr.clone(), response_packet);
+                                netwayste_send!(tx, response, ("[EVENT::REQUEST] Immediate response failed."));
+                            }
+                        } else {
+                            let err = decode_result.unwrap_err();
+                            error!("Decoding packet failed, from {:?}: {:?}", addr, err);
+                        }
+                    }
+                }
+
+                Event::TickEvent => {
+                    server_state.expire_old_messages_in_all_rooms();
+                    let client_update_packets_result = server_state.construct_client_updates();
+                    if client_update_packets_result.is_ok() {
+                        let opt_update_packets = client_update_packets_result.unwrap();
+
+                        if let Some(update_packets) = opt_update_packets {
+                            for update in update_packets {
+                                netwayste_send!(tx, update, ("[EVENT::TICK] Could not send client update."));
+                            }
+                        }
+                    }
+
+                    /*
+                    for x in server_state.network_map.values() {
+                        trace!("\n\n\nNETWORK QUEUE CAPACITIES\n-----------------------\nTX: {}\nRX: {}\n\n\n", x.tx_packets.as_queue_type().capacity(), x.rx_packets.as_queue_type().capacity());
+                    }
+                    */
+
+                    server_state.remove_timed_out_clients();
+                    server_state.tick  = 1usize.wrapping_add(server_state.tick);
+                }
+
+                Event::NetworkEvent => {
+                    // Process players in rooms
+                    server_state.process_buffered_packets_in_rooms();
+
+                    // Process players in lobby
+                    server_state.process_buffered_packets_in_lobby();
+
+                    server_state.resend_expired_tx_packets(&tx);
+                }
+
+                Event::HeartBeat => {
+                    for player in server_state.players.values() {
+                        let keep_alive = Packet::Response {
+                            sequence: 0,
+                            request_ack: None,
+                            code: ResponseCode::KeepAlive
+                        };
+                        netwayste_send!(tx, (player.addr, keep_alive), ("[EVENT::HEARTBEAT] Could not send to Player: {:?}", player));
+                    }
+                }
+            }
+
+            // return the updated client for the next iteration
+            ok(server_state)
+        })
+        .map(|_| ())
+        .map_err(|_| ());
+
+    let sink_fut = rx.fold(udp_sink, |udp_sink, outgoing_item| {
+            let udp_sink = udp_sink.send(outgoing_item).map_err(|_| ());    // this method flushes (if too slow, use send_all)
+            udp_sink
+        }).map(|_| ()).map_err(|_| ());
+
+    let combined_fut = server_fut.map(|_| ())
+        .select(sink_fut)
+        .map(|_| ());   // wait for either server_fut or sink_fut to complete
+
+    drop(core.run(combined_fut));
+}
+
+#[cfg(test)]
+mod netwayste_server_tests {
+    use super::*;
+    use netwayste::net::NetAttempt;
+    use ::proptest::strategy::*;
+
+    fn fake_socket_addr() -> SocketAddr {
+        use std::net::{IpAddr, Ipv4Addr};
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 5678)
+    }
+
+    #[test]
+    fn list_players_player_shows_up_in_player_list() {
+        let mut server = ServerState::new();
+        let room_name = "some name";
+        // make a new room
+        server.create_new_room(None, String::from(room_name));
+
+        let (player_id, player_name) = {
+            let p: &mut Player = server.add_new_player(String::from("some name"), fake_socket_addr());
+
+            (p.player_id, p.name.clone())
+        };
+        // make the player join the room
+        {
+            server.join_room(player_id, String::from(room_name));
+        }
+        let resp_code: ResponseCode = server.list_players(player_id);
+        match resp_code {
+            ResponseCode::PlayerList(players) => {
+                assert_eq!(players.len(), 1);
+                assert_eq!(*players.first().unwrap(), player_name);
+            }
+            resp_code @ _ => panic!("Unexpected response code: {:?}", resp_code)
+        }
+    }
+
+    #[test]
+    fn has_chatted_player_did_not_chat_on_join() {
+        let mut server = ServerState::new();
+        let room_name = "some name";
+        // make a new room
+        server.create_new_room(None, String::from(room_name));
+        let player_id = {
+            let p: &mut Player = server.add_new_player(String::from("some name"), fake_socket_addr());
+            p.player_id
+        };
+        // make the player join the room
+        {
+            server.join_room(player_id, String::from(room_name));
+        }
+        let player = server.get_player(player_id);
+        assert_eq!(player.has_chatted(), false);
+    }
+
+    #[test]
+    fn get_confirmed_chat_seq_num_server_tracks_players_chat_updates() {
+        let mut server = ServerState::new();
+        let room_name = "some name";
+        // make a new room
+        server.create_new_room(None, String::from(room_name));
+
+        let (player_id, player_cookie) = {
+            let p: &mut Player = server.add_new_player(String::from("some name"), fake_socket_addr());
+
+            (p.player_id, p.cookie.clone())
+        };
+        // make the player join the room
+        {
+            server.join_room(player_id, String::from(room_name));
+        }
+
+        // A chat-less player now has something to to say
+        server.decode_packet(fake_socket_addr(), Packet::UpdateReply {
+            cookie: player_cookie.clone(),
+            last_chat_seq: Some(1),
+            last_game_update_seq: None,
+            last_gen: None
+        }).unwrap();
+
+        {
+            let player = server.get_player(player_id);
+            assert_eq!(player.get_confirmed_chat_seq_num(), Some(1));
+        }
+
+        // Older messages are ignored
+        server.decode_packet(fake_socket_addr(), Packet::UpdateReply {
+            cookie: player_cookie.clone(),
+            last_chat_seq: Some(0),
+            last_game_update_seq: None,
+            last_gen: None
+        }).unwrap();
+
+        {
+            let player = server.get_player(player_id);
+            assert_eq!(player.get_confirmed_chat_seq_num(), Some(1));
+        }
+
+        // So are absent messages
+        server.decode_packet(fake_socket_addr(), Packet::UpdateReply {
+            cookie: player_cookie,
+            last_chat_seq: None,
+            last_game_update_seq: None,
+            last_gen: None
+        }).unwrap();
+
+        {
+            let player = server.get_player(player_id);
+            assert_eq!(player.get_confirmed_chat_seq_num(), Some(1));
+        }
+    }
+
+    #[test]
+    fn get_message_skip_count_player_acked_messages_are_not_included_in_skip_count() {
+        let mut server = ServerState::new();
+        let room_name = "some name";
+
+        server.create_new_room(None, String::from(room_name));
+
+        let (player_id, _) = {
+            let p: &mut Player = server.add_new_player(String::from("some name"), fake_socket_addr());
+
+            (p.player_id, p.cookie.clone())
+        };
+        // make the player join the room
+        // Give it a single message
+        {
+            server.join_room(player_id, String::from(room_name));
+            server.handle_chat_message(player_id, "ChatMessage".to_owned());
+        }
+
+        {
+            let room: &Room = server.get_room(player_id).unwrap();
+            // The check below does not affect any player acknowledgement as we are not
+            // involving the player yet. This is a simple test to ensure that if a chat
+            // message decoded from a would-be player was less than the latest chat message,
+            // we handle it properly by not skipping any.
+            assert_eq!(room.get_message_skip_count(0), 0);
+        }
+
+        let number_of_messages = 6;
+        for _ in 1..number_of_messages {
+            server.handle_chat_message(player_id, "ChatMessage".to_owned());
+        }
+
+        {
+            //let player = server.get_player_mut(player_id);
+            let player = server.get_player_mut(player_id);
+            // player has not acknowledged any yet
+            #[should_panic]
+            assert_eq!(player.get_confirmed_chat_seq_num(), None);
+        }
+
+        // player acknowledged four of the six
+        let acked_message_count = {
+            let player = server.get_player_mut(player_id);
+            player.update_chat_seq_num(Some(4));
+
+            player.get_confirmed_chat_seq_num().unwrap()
+        };
+        {
+            let room: &Room = server.get_room(player_id).unwrap();
+            assert_eq!(room.get_message_skip_count(acked_message_count), acked_message_count);
+        }
+
+        // player acknowledged all six
+        let acked_message_count = {
+            let player = server.get_player_mut(player_id);
+            player.update_chat_seq_num(Some(6));
+
+            player.get_confirmed_chat_seq_num().unwrap()
+        };
+        {
+            let room: &Room = server.get_room(player_id).unwrap();
+            assert_eq!(room.get_message_skip_count(acked_message_count), acked_message_count);
+        }
+    }
+
+    #[test]
+    // Send fifteen messages, but only leave nine unacknowledged, while wrapping on the sequence number
+    fn get_message_skip_count_player_acked_messages_are_not_included_in_skip_count_wrapped_case() {
+        let mut server = ServerState::new();
+        let room_name = "some name";
+
+        server.create_new_room(None, String::from(room_name));
+
+        let player_id = {
+            let p: &mut Player = server.add_new_player(String::from("some name"), fake_socket_addr());
+
+            p.player_id
+        };
+        {
+            server.join_room(player_id, String::from(room_name));
+        }
+
+        // Picking a value slightly less than max of u64
+        let start_seq_num = u64::max_value() - 6;
+        // First pass, add messages with sequence numbers through the max of u64
+        for seq_num in start_seq_num..u64::max_value() {
+            let room: &mut Room = server.get_room_mut(player_id).unwrap();
+            room.add_message(ServerChatMessage::new(player_id, String::from("some name"), String::from("some msg"), seq_num));
+        }
+        // Second pass, from wrap-point, `0`, eight times
+        for seq_num in 0..8 {
+            let room: &mut Room = server.get_room_mut(player_id).unwrap();
+            room.add_message(ServerChatMessage::new(player_id, String::from("some name"), String::from("some msg"), seq_num));
+        }
+
+        let acked_message_count = {
+            // Ack up until 0xFFFFFFFFFFFFFFFD
+            let player = server.get_player_mut(player_id);
+            player.update_chat_seq_num(Some(start_seq_num + 4));
+
+            player.get_confirmed_chat_seq_num().unwrap()
+        };
+        {
+            let room: &Room = server.get_room(player_id).unwrap();
+            // Fifteen total messages sent.
+            // 2 unacked which are less than u64::max_value()
+            // 8 unacked which are after the numerical wrap
+            let unacked_count = 15 - (8 + 2);
+            assert_eq!(room.get_message_skip_count(acked_message_count), unacked_count);
+        }
+    }
+
+    #[test]
+    fn collect_unacknowledged_messages_a_rooms_unacknowledged_chat_messages_are_collected_for_their_player() {
+        let mut server = ServerState::new();
+        let room_name = "some name";
+
+        server.create_new_room(None, String::from(room_name));
+
+        let player_id = {
+            let p: &mut Player = server.add_new_player(String::from("some name"), fake_socket_addr());
+
+            p.player_id
+        };
+        {
+            server.join_room(player_id, String::from(room_name));
+        }
+
+        {
+            // Room has no messages, None to send to player
+            let room = server.get_room(player_id).unwrap();
+            let player = server.get_player(player_id);
+            let messages = server.collect_unacknowledged_messages(room, player);
+            assert_eq!(messages, None);
+        }
+
+        {
+            let room: &mut Room = server.get_room_mut(player_id).unwrap();
+            room.add_message(ServerChatMessage::new(player_id, String::from("some name"), String::from("some msg"), 1));
+        }
+        {
+            // Room has a message, player has yet to ack it
+            let room = server.get_room(player_id).unwrap();
+            let player = server.get_player(player_id);
+            let messages = server.collect_unacknowledged_messages(room, player);
+            assert_eq!(messages.is_some(), true);
+            assert_eq!(messages.unwrap().len(), 1);
+        }
+
+        {
+            let player = server.get_player_mut(player_id);
+            player.update_chat_seq_num(Some(1));
+        }
+        {
+            // Room has a message, player acked, None
+            let room = server.get_room(player_id).unwrap();
+            let player = server.get_player(player_id);
+            let messages = server.collect_unacknowledged_messages(room, player);
+            assert_eq!(messages, None);
+        }
+    }
+
+    #[test]
+    fn collect_unacknowledged_messages_an_active_room_which_expired_all_messages_returns_none()
+    {
+        let mut server = ServerState::new();
+        let room_name = "some name";
+
+        server.create_new_room(None, String::from(room_name));
+
+        let player_id = {
+            let p: &mut Player = server.add_new_player(String::from("some name"), fake_socket_addr());
+
+            p.player_id
+        };
+        {
+            server.join_room(player_id, String::from(room_name));
+        }
+
+        {
+            // Add a message to the room and then age it so it will expire
+            let room: &mut Room = server.get_room_mut(player_id).unwrap();
+            room.add_message(ServerChatMessage::new(player_id, String::from("some name"), String::from("some msg"), 1));
+
+            let message: &mut ServerChatMessage = room.messages.get_mut(0).unwrap();
+            message.timestamp = Instant::now() - Duration::from_secs(MAX_AGE_CHAT_MESSAGES as u64);
+        }
+        {
+            // Sanity check to ensure player gets the chat message if left unacknowledged
+            let room = server.get_room(player_id).unwrap();
+            let player = server.get_player(player_id);
+            let messages = server.collect_unacknowledged_messages(room, player);
+            assert_eq!(messages.is_some(), true);
+            assert_eq!(messages.unwrap().len(), 1);
+        }
+        {
+            let player = server.get_player_mut(player_id);
+            player.update_chat_seq_num(Some(1));
+        }
+
+        {
+            // Server drains expired messages for the room
+            server.expire_old_messages_in_all_rooms();
+        }
+        {
+            // A room that has no messages, but has player(s) who have acknowledged past messages
+            let room = server.get_room(player_id).unwrap();
+            let player = server.get_player(player_id);
+            let messages = server.collect_unacknowledged_messages(room, player);
+            assert_eq!(messages, None);
+        }
+    }
+
+    #[test]
+    fn handle_chat_message_player_not_in_game()
+    {
+        let mut server = ServerState::new();
+        let room_name = "some name";
+
+        server.create_new_room(None, room_name.to_owned());
+
+        let player_id = {
+            let p: &mut Player = server.add_new_player("some name".to_owned(), fake_socket_addr());
+
+            p.player_id
+        };
+
+        let response = server.handle_chat_message(player_id, "test msg".to_owned());
+        assert_eq!(response, ResponseCode::BadRequest(Some(format!("Player {} has not joined a game.", player_id))));
+    }
+
+    #[test]
+    fn handle_chat_message_player_in_game_one_message()
+    {
+
+        let mut server = ServerState::new();
+        let room_name = "some name";
+
+        server.create_new_room(None, room_name.to_owned());
+
+        let player_id = {
+            let p: &mut Player = server.add_new_player("some player".to_string(), fake_socket_addr());
+
+            p.player_id
+        };
+        {
+            server.join_room(player_id, room_name.to_owned());
+        }
+
+        let response = server.handle_chat_message(player_id, "test msg".to_owned());
+        assert_eq!(response, ResponseCode::OK);
+        let room: &Room = server.get_room(player_id).unwrap();
+        assert_eq!(room.messages.len(), 1);
+        assert_eq!(room.latest_seq_num, 1);
+        assert_eq!(room.get_newest_msg(), room.get_oldest_msg());
+    }
+
+    #[test]
+    fn handle_chat_message_player_in_game_many_messages()
+    {
+
+        let mut server = ServerState::new();
+        let room_name = "some name";
+
+        server.create_new_room(None, room_name.to_owned());
+
+        let player_id = {
+            let p: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+
+            p.player_id
+        };
+        {
+            server.join_room(player_id, room_name.to_owned());
+        }
+
+        let response = server.handle_chat_message(player_id, "test msg first".to_owned());
+        assert_eq!(response, ResponseCode::OK);
+        let response = server.handle_chat_message(player_id, "test msg second".to_owned());
+        assert_eq!(response, ResponseCode::OK);
+
+        let room: &Room = server.get_room(player_id).unwrap();
+        assert_eq!(room.messages.len(), 2);
+        assert_eq!(room.latest_seq_num, 2);
+    }
+
+    #[test]
+    fn create_new_room_good_case()
+    {
+        {
+            let mut server = ServerState::new();
+            let room_name = "some name".to_owned();
+
+            assert_eq!(server.create_new_room(None, room_name), ResponseCode::OK);
+        }
+        // Room name length is within bounds
+        {
+            let mut server = ServerState::new();
+            let room_name = "0123456789ABCDEF".to_owned();
+
+            assert_eq!(server.create_new_room(None, room_name), ResponseCode::OK);
+        }
+    }
+
+    #[test]
+    fn create_new_room_name_is_too_long()
+    {
+        let mut server = ServerState::new();
+        let room_name = "0123456789ABCDEF_#".to_owned();
+
+        assert_eq!(server.create_new_room(None, room_name), ResponseCode::BadRequest(Some("room name too long; max 16 characters".to_owned())));
+    }
+
+    #[test]
+    fn create_new_room_name_taken()
+    {
+        let mut server = ServerState::new();
+        let room_name = "some room".to_owned();
+        assert_eq!(server.create_new_room(None, room_name.clone()), ResponseCode::OK);
+        assert_eq!(server.create_new_room(None, room_name), ResponseCode::BadRequest(Some("room name already in use".to_owned())));
+    }
+
+    #[test]
+    fn create_new_room_player_already_in_room()
+    {
+        let mut server = ServerState::new();
+        let room_name = "some room".to_owned();
+        let other_room_name = "another room".to_owned();
+        assert_eq!(server.create_new_room(None, room_name.clone()), ResponseCode::OK);
+
+        let player_id = {
+            let p: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+
+            p.player_id
+        };
+        {
+            server.join_room(player_id, room_name.to_owned());
+        }
+
+        assert_eq!( server.create_new_room(Some(player_id), other_room_name), ResponseCode::BadRequest(Some("cannot create room because in-game".to_owned())) );
+    }
+
+    #[test]
+    fn create_new_room_join_room_good_case()
+    {
+
+        let mut server = ServerState::new();
+        let room_name = "some room".to_owned();
+        assert_eq!(server.create_new_room(None, room_name.clone()), ResponseCode::OK);
+
+        let player_id = {
+            let p: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+
+            p.player_id
+        };
+        assert_eq!(server.join_room(player_id, room_name.to_owned()), ResponseCode::JoinedRoom("some room".to_owned()));
+    }
+
+    #[test]
+    fn join_room_player_already_in_room()
+    {
+
+        let mut server = ServerState::new();
+        let room_name = "some room".to_owned();
+        assert_eq!(server.create_new_room(None, room_name.clone()), ResponseCode::OK);
+
+        let player_id = {
+            let p: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+
+            p.player_id
+        };
+        assert_eq!(server.join_room(player_id, room_name.clone()), ResponseCode::JoinedRoom("some room".to_owned()));
+        assert_eq!( server.join_room(player_id, room_name), ResponseCode::BadRequest(Some("cannot join game because in-game".to_owned())) );
+    }
+
+    #[test]
+    fn join_room_room_does_not_exist()
+    {
+
+        let mut server = ServerState::new();
+
+        let player_id = {
+            let p: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+
+            p.player_id
+        };
+        assert_eq!(server.join_room(player_id, "some room".to_owned()), ResponseCode::BadRequest(Some("no room named \"some room\"".to_owned())) );
+    }
+
+    #[test]
+    fn leave_room_good_case()
+    {
+        let mut server = ServerState::new();
+        let room_name = "some name";
+
+        server.create_new_room(None, room_name.to_owned());
+
+        let player_id = {
+            let p: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+
+            p.player_id
+        };
+        {
+            server.join_room(player_id, room_name.to_owned());
+        }
+
+        assert_eq!( server.leave_room(player_id), ResponseCode::LeaveRoom );
+
+    }
+
+    #[test]
+    fn leave_room_player_not_in_room()
+    {
+        let mut server = ServerState::new();
+        let room_name = "some room".to_owned();
+        assert_eq!(server.create_new_room(None, room_name.clone()), ResponseCode::OK);
+
+        let player_id = {
+            let p: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+
+            p.player_id
+        };
+
+        assert_eq!( server.leave_room(player_id), ResponseCode::BadRequest(Some("cannot leave game because in lobby".to_owned())) );
+    }
+
+    #[test]
+    fn leave_room_unregistered_player_id()
+    {
+        let mut server = ServerState::new();
+        let room_name = "some room".to_owned();
+        let rand_player_id = PlayerID(0x2457); //RUST
+        assert_eq!(server.create_new_room(None, room_name.clone()), ResponseCode::OK);
+
+        assert_eq!( server.leave_room(rand_player_id), ResponseCode::BadRequest(Some("cannot leave game because in lobby".to_owned())) );
+    }
+
+    #[test]
+    fn add_new_player_player_added_with_initial_sequence_number()
+    {
+        let mut server = ServerState::new();
+        let name = "some player".to_owned();
+
+        let p: &mut Player = server.add_new_player(name.clone(), fake_socket_addr());
+        assert_eq!(p.name, name);
+    }
+
+    #[test]
+    fn is_unique_player_name_yes_and_no_case()
+    {
+        let mut server = ServerState::new();
+        let name = "some player".to_owned();
+        assert_eq!(server.is_unique_player_name("some player"), true);
+
+        {
+            server.add_new_player(name.clone(), fake_socket_addr());
+        }
+        assert_eq!(server.is_unique_player_name("some player"), false);
+    }
+
+    #[test]
+    fn expire_old_messages_in_all_rooms_room_is_empty()
+    {
+        let mut server = ServerState::new();
+        let room_name = "some room";
+
+        server.create_new_room(None, room_name.to_owned().clone());
+        server.expire_old_messages_in_all_rooms();
+
+        for room in server.rooms.values() {
+            assert_eq!(room.messages.len(), 0);
+        }
+    }
+
+
+    #[test]
+    fn expire_old_messages_in_all_rooms_one_room_good_case()
+    {
+        let mut server = ServerState::new();
+        let room_name = "some room";
+
+        server.create_new_room(None, room_name.to_owned().clone());
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            player.player_id
+        };
+
+        server.join_room(player_id, room_name.to_owned());
+
+        server.handle_chat_message(player_id, "Conwayste is such a fun game".to_owned());
+        server.handle_chat_message(player_id, "There are not loot boxes".to_owned());
+        server.handle_chat_message(player_id, "It is free!".to_owned());
+        server.handle_chat_message(player_id, "What's not to love?".to_owned());
+
+        let message_count = {
+            let room: &Room = server.get_room(player_id).unwrap();
+            room.messages.len()
+        };
+        assert_eq!(message_count, 4);
+
+        // Messages are not old enough to be expired
+        server.expire_old_messages_in_all_rooms();
+
+        for room in server.rooms.values() {
+            assert_eq!(room.messages.len(), 4);
+        }
+    }
+
+    #[test]
+    fn expire_old_messages_in_all_rooms_several_rooms_good_case()
+    {
+        let mut server = ServerState::new();
+        let room_name = "some room";
+        let room_name2 = "some room2";
+
+        server.create_new_room(None, room_name.to_owned().clone());
+        server.create_new_room(None, room_name2.to_owned().clone());
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            player.player_id
+        };
+        let player_id2: PlayerID = {
+            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            player.player_id
+        };
+
+        server.join_room(player_id, room_name.to_owned());
+        server.join_room(player_id2, room_name2.to_owned());
+
+        server.handle_chat_message(player_id, "Conwayste is such a fun game".to_owned());
+        server.handle_chat_message(player_id, "There are not loot boxes".to_owned());
+        server.handle_chat_message(player_id2, "It is free!".to_owned());
+        server.handle_chat_message(player_id2, "What's not to love?".to_owned());
+
+        let message_count = {
+            let room: &Room = server.get_room(player_id).unwrap();
+            room.messages.len()
+        };
+        assert_eq!(message_count, 2);
+        let message_count2 = {
+            let room: &Room = server.get_room(player_id2).unwrap();
+            room.messages.len()
+        };
+        assert_eq!(message_count2, 2);
+
+        // Messages are not old enough to be expired
+        server.expire_old_messages_in_all_rooms();
+
+        for room in server.rooms.values() {
+            assert_eq!(room.messages.len(), 2);
+        }
+    }
+
+    #[test]
+    fn expire_old_messages_in_all_rooms_one_room_old_messages_are_wiped()
+    {
+        let mut server = ServerState::new();
+        let room_name = "some room";
+
+        server.create_new_room(None, room_name.to_owned().clone());
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            player.player_id
+        };
+
+        server.join_room(player_id, room_name.to_owned());
+
+        server.handle_chat_message(player_id, "Conwayste is such a fun game".to_owned());
+        server.handle_chat_message(player_id, "There are not loot boxes".to_owned());
+        server.handle_chat_message(player_id, "It is free!".to_owned());
+        server.handle_chat_message(player_id, "What's not to love?".to_owned());
+
+        let current_timestamp = Instant::now();
+        let travel_to_the_past = current_timestamp - Duration::from_secs((MAX_AGE_CHAT_MESSAGES+1) as u64);
+        for ref mut room in server.rooms.values_mut() {
+            println!("Room: {:?}", room.name);
+            for m in room.messages.iter_mut() {
+                println!("{:?}, {:?},       {:?}", m.timestamp, travel_to_the_past, m.timestamp - travel_to_the_past);
+                m.timestamp = travel_to_the_past;
+            }
+        }
+
+        // Messages are not old enough to be expired
+        server.expire_old_messages_in_all_rooms();
+
+        for room in server.rooms.values() {
+            assert_eq!(room.messages.len(), 0);
+        }
+    }
+
+    #[test]
+    fn expire_old_messages_in_all_rooms_several_rooms_old_messages_are_wiped()
+    {
+        let mut server = ServerState::new();
+        let room_name = "some room";
+        let room_name2 = "some room 2";
+
+        server.create_new_room(None, room_name.to_owned().clone());
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            player.player_id
+        };
+        server.create_new_room(None, room_name2.to_owned().clone());
+        let player_id2: PlayerID = {
+            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            player.player_id
+        };
+
+        server.join_room(player_id, room_name.to_owned());
+        server.join_room(player_id2, room_name.to_owned());
+
+        server.handle_chat_message(player_id, "Conwayste is such a fun game".to_owned());
+        server.handle_chat_message(player_id, "There are not loot boxes".to_owned());
+        server.handle_chat_message(player_id2, "It is free!".to_owned());
+        server.handle_chat_message(player_id2, "What's not to love?".to_owned());
+
+        let current_timestamp = Instant::now();
+        let travel_to_the_past = current_timestamp - Duration::from_secs((MAX_AGE_CHAT_MESSAGES+1) as u64);
+        for ref mut room in server.rooms.values_mut() {
+            println!("Room: {:?}", room.name);
+            for m in room.messages.iter_mut() {
+                println!("{:?}, {:?},       {:?}", m.timestamp, travel_to_the_past, m.timestamp - travel_to_the_past);
+                m.timestamp = travel_to_the_past;
+            }
+        }
+
+        // Messages are not old enough to be expired
+        server.expire_old_messages_in_all_rooms();
+
+        for room in server.rooms.values() {
+            assert_eq!(room.messages.len(), 0);
+        }
+    }
+
+    #[test]
+    fn handle_new_connection_good_case() {
+        let mut server = ServerState::new();
+        let player_name = "some name".to_owned();
+        let pkt = server.handle_new_connection(player_name, fake_socket_addr());
+        match pkt {
+            Packet::Response{sequence: _, request_ack: _, code} => {
+                match code {
+                    ResponseCode::LoggedIn(_,_) => {}
+                    _ => panic!("Unexpected ResponseCode: {:?}", code)
+                }
+            }
+            _ => panic!("Unexpected Packet Type: {:?}", pkt)
+        }
+    }
+
+    #[test]
+    fn handle_new_connection_player_name_taken() {
+        let mut server = ServerState::new();
+        let player_name = "some name".to_owned();
+
+        let pkt = server.handle_new_connection(player_name.clone(), fake_socket_addr());
+        match pkt {
+            Packet::Response{sequence: _, request_ack: _, code} => {
+                match code {
+                    ResponseCode::LoggedIn(_,version) => {assert_eq!(version, VERSION.to_owned() )}
+                    _ => panic!("Unexpected ResponseCode: {:?}", code)
+                }
+            }
+            _ => panic!("Unexpected Packet Type: {:?}", pkt)
+        }
+
+        let pkt = server.handle_new_connection(player_name, fake_socket_addr());
+        match pkt {
+            Packet::Response{sequence: _, request_ack: _, code} => {
+                match code {
+                    ResponseCode::Unauthorized(msg) => { assert_eq!(msg, Some("not a unique name".to_owned())); }
+                    _ => panic!("Unexpected ResponseCode: {:?}", code)
+                }
+            }
+            _ => panic!("Unexpected Packet Type: {:?}", pkt)
+        }
+    }
+
+    fn a_request_action_strat() -> BoxedStrategy<RequestAction> {
+        prop_oneof![
+            //Just(RequestAction::Disconnect), // not yet implemented
+            //Just(RequestAction::KeepAlive),  // same
+            Just(RequestAction::LeaveRoom),
+            Just(RequestAction::ListPlayers),
+            Just(RequestAction::ListRooms),
+            Just(RequestAction::None),
+        ].boxed()
+    }
+
+    fn a_request_action_complex_strat() -> BoxedStrategy<RequestAction> {
+        prop_oneof![
+            ("([A-Z]{1,4} [0-9]{1,2}){3}").prop_map(|a| RequestAction::ChatMessage(a)),
+            ("([A-Z]{1,4} [0-9]{1,2}){3}").prop_map(|a| RequestAction::NewRoom(a)),
+            ("([A-Z]{1,4} [0-9]{1,2}){3}").prop_map(|a| RequestAction::JoinRoom(a)),
+            ("([A-Z]{1,4} [0-9]{1,2}){3}", "[0-9].[0-9].[0-9]").prop_map(|(a, b)| RequestAction::Connect{name: a, client_version: b})
+        ].boxed()
+    }
+
+    // These tests are checking that we do not panic on each RequestAction
+    proptest! {
+        #[test]
+        fn process_request_action_simple(ref request in a_request_action_strat()) {
+            let mut server = ServerState::new();
+            server.create_new_room(None, "some room".to_owned().clone());
+            let player_id: PlayerID = {
+                let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+                player.player_id
+            };
+            server.process_request_action(player_id, request.to_owned());
+        }
+
+        #[test]
+        fn process_request_action_complex(ref request in a_request_action_complex_strat()) {
+            let mut server = ServerState::new();
+            server.create_new_room(None, "some room".to_owned().clone());
+            let player_id: PlayerID = {
+                let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+                player.player_id
+            };
+            server.process_request_action(player_id, request.to_owned());
+        }
+    }
+
+    #[test]
+    fn process_request_action_connect_while_connected() {
+        let mut server = ServerState::new();
+        server.create_new_room(None, "some room".to_owned().clone());
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            player.player_id
+        };
+        let result = server.process_request_action(player_id, RequestAction::Connect{name: "some player".to_owned(), client_version: "0.1.0".to_owned()});
+        assert_eq!(result, ResponseCode::BadRequest(Some("already connected".to_owned())));
+    }
+
+    #[test]
+    fn process_request_action_none_is_invalid() {
+        let mut server = ServerState::new();
+        server.create_new_room(None, "some room".to_owned().clone());
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            player.player_id
+        };
+        let result = server.process_request_action(player_id, RequestAction::None);
+        assert_eq!(result, ResponseCode::BadRequest(Some("Invalid request".to_owned())));
+    }
+
+    #[test]
+    fn prepare_response_spot_check_response_packet() {
+        let mut server = ServerState::new();
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            player.request_ack = Some(1);
+            player.player_id
+        };
+        let pkt: Packet = server.prepare_response(player_id, RequestAction::ListRooms).unwrap();
+        match pkt {
+            Packet::Response{code, sequence, request_ack} => {
+                assert_eq!(code, ResponseCode::RoomList(vec![]));
+                assert_eq!(sequence, 1);
+                assert_eq!(request_ack, Some(2));
+            }
+            _ => panic!("Unexpected Packet type on Response path: {:?}", pkt)
+        }
+        let player: &Player = server.get_player(player_id);
+        assert_eq!(player.next_resp_seq, 2);
+    }
+
+    #[test]
+    fn validate_client_version_client_is_up_to_date() {
+        assert_eq!(validate_client_version( env!("CARGO_PKG_VERSION").to_owned()), true);
+    }
+
+    #[test]
+    fn validate_client_version_client_is_very_old() {
+      assert_eq!(validate_client_version("0.0.1".to_owned()), true);
+    }
+
+    #[test]
+    fn validate_client_version_client_is_from_the_future() {
+        assert_eq!(validate_client_version(format!("{}.{}.{}", <i32>::max_value(), <i32>::max_value(), <i32>::max_value()).to_owned()), false);
+    }
+
+    #[test]
+    fn decode_packet_update_reply_good_case() {
+        let mut server = ServerState::new();
+        let cookie: String = {
+            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            player.cookie.clone()
+        };
+
+        let update_reply_packet = Packet::UpdateReply {
+                cookie: cookie,
+                last_chat_seq: Some(0),
+                last_game_update_seq: None,
+                last_gen: None,
+        };
+
+        let result = server.decode_packet(fake_socket_addr(), update_reply_packet);
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
+    }
+
+    #[test]
+    fn decode_packet_update_reply_invalid_cookie() {
+        let mut server = ServerState::new();
+        {
+            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            player.cookie.clone()
+        };
+
+        let cookie = "CookieMonster".to_owned();
+
+        let update_reply_packet = Packet::UpdateReply {
+                cookie: cookie,
+                last_chat_seq: Some(0),
+                last_game_update_seq: None,
+                last_gen: None,
+        };
+
+        let result = server.decode_packet(fake_socket_addr(), update_reply_packet);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn construct_client_updates_no_rooms() {
+        let mut server = ServerState::new();
+        let result = server.construct_client_updates();
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
+    }
+
+    #[test]
+    fn construct_client_updates_empty_rooms() {
+        let mut server = ServerState::new();
+        server.create_new_room(None, "some room".to_owned().clone());
+        let result = server.construct_client_updates();
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
+    }
+
+    #[test]
+    fn construct_client_updates_populated_room_returns_all_messages() {
+        let mut server = ServerState::new();
+        let room_name = "some_room".to_owned();
+        let player_name = "some player".to_owned();
+        let message_text = "Message".to_owned();
+
+        server.create_new_room(None, room_name.clone());
+
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            player.player_id
+        };
+        server.join_room(player_id, room_name);
+        server.handle_chat_message(player_id, message_text.clone());
+        server.handle_chat_message(player_id, message_text.clone());
+        server.handle_chat_message(player_id, message_text.clone());
+        let result = server.construct_client_updates();
+
+        assert!(result.is_ok());
+        let opt_output = result.unwrap();
+        assert!(opt_output.is_some());
+        let mut output: Vec<(SocketAddr, Packet)> = opt_output.unwrap();
+
+        // Vector should contain a single item for this test
+        assert_eq!(output.len(), 1);
+
+        let (addr, pkt) = output.pop().unwrap();
+        assert_eq!(addr, fake_socket_addr());
+
+        match pkt {
+            Packet::Update{chats, game_updates, universe_update} => {
+                assert_eq!(game_updates, None);
+                assert_eq!(universe_update, UniUpdateType::NoChange);
+                assert!(chats.is_some());
+
+                // All client chat sequence numbers start counting at 1
+                let mut i=1;
+
+                for msg in chats.unwrap() {
+                    assert_eq!(msg.player_name, player_name);
+                    assert_eq!(msg.chat_seq, Some(i));
+                    assert_eq!(msg.message, message_text);
+                    i+=1;
+                }
+            }
+            _ => panic!("Unexpected packet in client update construction!")
+        }
+    }
+
+    #[test]
+    fn construct_client_updates_populated_room_returns_updates_after_client_acked() {
+        let mut server = ServerState::new();
+        let room_name = "some_room".to_owned();
+        let player_name = "some player".to_owned();
+        let message_text = "Message".to_owned();
+
+        server.create_new_room(None, room_name.clone());
+
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            player.player_id
+        };
+        server.join_room(player_id, room_name);
+        server.handle_chat_message(player_id, message_text.clone());
+        server.handle_chat_message(player_id, message_text.clone());
+        server.handle_chat_message(player_id, message_text.clone());
+
+        // Assume that the client has acknowledged two chats
+        {
+            let player: &mut Player = server.get_player_mut(player_id);
+            player.update_chat_seq_num(Some(2));
+        }
+
+        // We should then only return the last chat
+        let result = server.construct_client_updates();
+
+        assert!(result.is_ok());
+        let opt_output = result.unwrap();
+        assert!(opt_output.is_some());
+        let mut output: Vec<(SocketAddr, Packet)> = opt_output.unwrap();
+
+        // Vector should contain a single item for this test
+        assert_eq!(output.len(), 1);
+
+        let (addr, pkt) = output.pop().unwrap();
+        assert_eq!(addr, fake_socket_addr());
+
+        match pkt {
+            Packet::Update{chats, game_updates, universe_update} => {
+                assert_eq!(game_updates, None);
+                assert_eq!(universe_update, UniUpdateType::NoChange);
+                assert!(chats.is_some());
+
+                let mut messages = chats.unwrap();
+                assert_eq!(messages.len(), 1);
+                let msg = messages.pop().unwrap();
+
+                assert_eq!(msg.player_name, player_name);
+                assert_eq!(msg.chat_seq, Some(3));
+                assert_eq!(msg.message, message_text);
+            }
+            _ => panic!("Unexpected packet in client update construction!")
+        }
+    }
+
+    #[test]
+    fn broadcast_message_to_two_players_in_room() {
+        let mut server = ServerState::new();
+        let room_name = "some_room".to_owned();
+        let player_name = "some player".to_owned();
+
+        server.create_new_room(None, room_name.clone());
+
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            player.player_id
+        };
+        let player_id2: PlayerID = {
+            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            player.player_id
+        };
+
+        server.join_room(player_id, room_name.clone());
+        {
+            let room: &mut Room = server.get_room_mut(player_id).unwrap();
+            room.broadcast("Silver birch against a Swedish sky".to_owned());
+        }
+        server.join_room(player_id2, room_name.clone());
+        let room: &Room = server.get_room(player_id).unwrap();
+
+        let player = (*server.get_player(player_id)).clone();
+        let msgs = server.collect_unacknowledged_messages(room, &player).unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].message, "Silver birch against a Swedish sky".to_owned());
+
+        let player = (*server.get_player(player_id2)).clone();
+        let msgs = server.collect_unacknowledged_messages(room, &player).unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].message, "Silver birch against a Swedish sky".to_owned());
+    }
+
+    #[test]
+    fn broadcast_message_to_an_empty_room() {
+        let mut server = ServerState::new();
+        let room_name = "some_room".to_owned();
+
+        server.create_new_room(None, room_name.clone());
+        let room_id: &RoomID = server.room_map.get(&room_name.clone()).unwrap();
+
+        {
+            let room: &mut Room = server.rooms.get_mut(&room_id).unwrap();
+            room.broadcast("Silver birch against a Swedish sky".to_owned());
+        }
+        let room: &Room = server.rooms.get(&room_id).unwrap();
+        assert_eq!(room.latest_seq_num, 1);
+        assert_eq!(room.messages.len(), 1);
+        let msgs: &ServerChatMessage = room.messages.get(0).unwrap();
+        assert_eq!(msgs.player_name, "Server".to_owned());
+        assert_eq!(msgs.seq_num, 1);
+        assert_eq!(msgs.player_id, PlayerID(0xFFFFFFFFFFFFFFFF));
+    }
+
+    #[test]
+    #[should_panic]
+    fn disconnect_get_player_by_id_fails() {
+        let mut server = ServerState::new();
+        let player_name = "some player".to_owned();
+
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            player.player_id
+        };
+
+        server.handle_disconnect(player_id);
+        server.get_player(player_id);
+    }
+
+    #[test]
+    fn disconnect_get_player_by_cookie_fails() {
+        let mut server = ServerState::new();
+        let player_name = "some player".to_owned();
+
+        let (player_id, cookie) = {
+            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            (player.player_id, player.cookie.clone())
+        };
+
+        server.handle_disconnect(player_id);
+        assert_eq!(server.get_player_id_by_cookie(cookie.as_str()), None);
+    }
+
+    #[test]
+    fn disconnect_while_in_room_removes_all_traces_of_player() {
+        let mut server = ServerState::new();
+        let room_name = "some_room".to_owned();
+        let player_name = "some player".to_owned();
+
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            player.player_id
+        };
+
+        server.create_new_room(None, room_name.clone());
+        server.join_room(player_id, room_name);
+        let room_id = {
+            let room: &Room = server.get_room(player_id).unwrap();
+            assert_eq!(room.player_ids.contains(&player_id), true);
+            room.room_id
+        };
+        server.handle_disconnect(player_id);
+        // Cannot go through player_id because the player has been removed
+        let room: &Room = server.rooms.get(&room_id).unwrap();
+        assert_eq!(room.player_ids.contains(&player_id), false);
+    }
+
+    #[test]
+    fn test_is_previously_processed_packet() {
+        let mut server = ServerState::new();
+        let player_name = "some player".to_owned();
+
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            player.request_ack = Some(4);
+            player.player_id
+        };
+
+        let player_id2: PlayerID = {
+            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            player.request_ack = None;
+            player.player_id
+        };
+
+        assert_eq!(server.is_previously_processed_packet(player_id2, 0), false);
+
+        assert_eq!(server.is_previously_processed_packet(player_id, 0), true);
+        assert_eq!(server.is_previously_processed_packet(player_id, 4), true);
+        assert_eq!(server.is_previously_processed_packet(player_id, 5), false);
+    }
+
+    #[test]
+    fn test_clear_transmission_queue_on_ack() {
+        let mut server = ServerState::new();
+        let player_name = "some player".to_owned();
+
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            player.request_ack = Some(4);
+            player.player_id
+        };
+
+        for i in 0..5 {
+            let pkt = Packet::Response {
+                sequence: i,
+                request_ack: None,
+                code: ResponseCode::OK
+            };
+
+            let nm: &mut NetworkManager = server.network_map.get_mut(&player_id).unwrap();
+            nm.tx_packets.buffer_item(pkt.clone());
+        }
+
+        server.clear_transmission_queue_on_ack(player_id, None);
+        assert_eq!(server.network_map.get(&player_id).unwrap().tx_packets.len(), 5);
+        server.clear_transmission_queue_on_ack(player_id, Some(0));
+        assert_eq!(server.network_map.get(&player_id).unwrap().tx_packets.len(), 5);
+        server.clear_transmission_queue_on_ack(player_id, Some(1));
+        assert_eq!(server.network_map.get(&player_id).unwrap().tx_packets.len(), 4);
+        server.clear_transmission_queue_on_ack(player_id, Some(5));
+        assert_eq!(server.network_map.get(&player_id).unwrap().tx_packets.len(), 0);
+    }
+
+    #[test]
+    fn test_resend_expired_tx_packets_empty_server() {
+        let mut server = ServerState::new();
+
+        let (udp_tx, _) = mpsc::unbounded();
+        #[cfg(not(should_panic))]
+        server.resend_expired_tx_packets(&udp_tx);
+    }
+
+    #[test]
+    fn test_resend_expired_tx_packets() {
+        let mut server = ServerState::new();
+        let player_name = "some player".to_owned();
+
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            player.request_ack = Some(5);
+            player.player_id
+        };
+
+
+        for i in 0..5 {
+            let pkt = Packet::Response {
+                sequence: i,
+                request_ack: None,
+                code: ResponseCode::OK
+            };
+
+            let nm: &mut NetworkManager = server.network_map.get_mut(&player_id).unwrap();
+            nm.tx_packets.buffer_item(pkt.clone());
+
+            if i < 3 {
+                let attempt: &mut NetAttempt = nm.tx_packets.attempts.back_mut().unwrap();
+                attempt.time = Instant::now() - Duration::from_secs(i+1);
+            }
+        }
+
+        let (udp_tx, _) = mpsc::unbounded();
+        server.resend_expired_tx_packets(&udp_tx);
+
+        for i in 0..5 {
+            let nm: &mut NetworkManager = server.network_map.get_mut(&player_id).unwrap();
+            let packet_retries: &NetAttempt = nm.tx_packets.attempts.get(i).unwrap();
+
+            if i >= 3 {
+                assert_eq!(packet_retries.retries, 0);
+            } else {
+                assert_eq!(packet_retries.retries, 1);
+            }
+        }
+    }
+
+    #[test]
+    fn test_process_queued_rx_packets_first_non_connect_player_packet() {
+        let mut server = ServerState::new();
+        let player_name = "some player".to_owned();
+
+        let (player_id, player_cookie): (PlayerID, String) = {
+            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            player.request_ack = Some(1);   // Player connected and we've confirmed the first transaction
+            (player.player_id, player.cookie.clone())
+        };
+
+        {
+            let pkt = Packet::Request {
+                cookie: Some(player_cookie),
+                sequence: 2,
+                response_ack: None,
+                action: RequestAction::ListPlayers
+            };
+
+            let nm: &mut NetworkManager = server.network_map.get_mut(&player_id).unwrap();
+            nm.rx_packets.buffer_item(pkt.clone());
+
+            assert_eq!(nm.tx_packets.len(), 0);
+        }
+
+        server.process_queued_rx_packets(player_id);
+
+
+        {
+            let nm: &mut NetworkManager = server.network_map.get_mut(&player_id).unwrap();
+            assert_eq!(nm.tx_packets.len(), 1);
+        }
+
+    }
+
+    #[test]
+    fn test_process_queued_rx_packets_contiguous() {
+        let mut server = ServerState::new();
+        let player_name = "some player".to_owned();
+
+        let (player_id, player_cookie): (PlayerID, String) = {
+            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            player.request_ack = Some(1);   // Player connected and we've confirmed the first transaction
+            (player.player_id, player.cookie.clone())
+        };
+
+        for i in 2..10 {
+            let pkt = Packet::Request {
+                cookie: Some(player_cookie.clone()),
+                sequence: i,
+                response_ack: None,
+                action: RequestAction::ListPlayers
+            };
+
+            let nm: &mut NetworkManager = server.network_map.get_mut(&player_id).unwrap();
+            nm.rx_packets.buffer_item(pkt.clone());
+
+            assert_eq!(nm.tx_packets.len(), 0);
+        }
+
+        server.process_queued_rx_packets(player_id);
+
+        {
+            let nm: &mut NetworkManager = server.network_map.get_mut(&player_id).unwrap();
+            assert_eq!(nm.tx_packets.len(), 8);
+        }
+
+    }
+
+    #[test]
+    fn test_process_queued_rx_packets_swiss_cheese_queue() {
+        let mut server = ServerState::new();
+        let player_name = "some player".to_owned();
+
+        let (player_id, player_cookie): (PlayerID, String) = {
+            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            player.request_ack = Some(1);   // Player connected and we've confirmed the first transaction
+            (player.player_id, player.cookie.clone())
+        };
+
+        for i in [2, 3, 4, 6, 8, 9, 10].iter() {
+            let pkt = Packet::Request {
+                cookie: Some(player_cookie.clone()),
+                sequence: *i,
+                response_ack: None,
+                action: RequestAction::ListPlayers
+            };
+
+            let nm: &mut NetworkManager = server.network_map.get_mut(&player_id).unwrap();
+            nm.rx_packets.buffer_item(pkt.clone());
+
+            assert_eq!(nm.tx_packets.len(), 0);
+        }
+
+        server.process_queued_rx_packets(player_id);
+
+        {
+            let nm: &mut NetworkManager = server.network_map.get_mut(&player_id).unwrap();
+            assert_eq!(nm.tx_packets.len(), 3); // only 2, 3, and 4 are processed
+        }
+    }
+}

--- a/netwayste/src/tests.rs
+++ b/netwayste/src/tests.rs
@@ -1,0 +1,2510 @@
+/*  Copyright 2019 the Conwayste Developers.
+ *
+ *  This file is part of netwayste.
+ *
+ *  netwayste is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  netwayste is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with netwayste.  If not, see <http://www.gnu.org/licenses/>. */
+
+use std::{thread, time::{Instant, Duration}};
+use std::net::SocketAddr;
+use crate::net::*;
+use crate::futures::sync::mpsc;
+
+mod netwayste_net_tests {
+    use super::*;
+
+    fn fake_socket_addr() -> SocketAddr {
+        use std::net::{IpAddr, Ipv4Addr};
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 5678)
+    }
+
+
+    // `discord_older_packets()` tests are disabled  until after the necessity of the function is re-evaluated
+    #[test]
+    #[ignore]
+    fn test_discard_older_packets_empty_queue() {
+        let mut nm = NetworkManager::new();
+
+        nm.tx_packets.discard_older_items();
+        nm.rx_packets.discard_older_items();
+        assert_eq!(nm.tx_packets.len(), 0);
+        assert_eq!(nm.rx_packets.len(), 0);
+    }
+
+    #[test]
+    #[ignore]
+    fn test_discard_older_packets_under_limit_keeps_all_messages() {
+        let mut nm = NetworkManager::new();
+        let pkt = Packet::Request {
+            sequence: 0,
+            response_ack: None,
+            cookie: None,
+            action: RequestAction::None
+        };
+
+        nm.tx_packets.push_back(pkt.clone());
+        nm.tx_packets.push_back(pkt.clone());
+        nm.tx_packets.push_back(pkt.clone());
+
+        nm.tx_packets.discard_older_items();
+        assert_eq!(nm.tx_packets.len(), 3);
+
+        nm.rx_packets.push_back(pkt.clone());
+        nm.rx_packets.push_back(pkt.clone());
+        nm.rx_packets.push_back(pkt.clone());
+
+        nm.rx_packets.discard_older_items();
+        assert_eq!(nm.rx_packets.len(), 3);
+    }
+
+    #[test]
+    #[ignore]
+    fn test_discard_older_packets_equal_to_limit() {
+        let mut nm = NetworkManager::new();
+        let pkt = Packet::Request {
+            sequence: 0,
+            response_ack: None,
+            cookie: None,
+            action: RequestAction::None
+        };
+
+        for _ in 0..NETWORK_QUEUE_LENGTH {
+            nm.tx_packets.push_back(pkt.clone());
+        }
+        assert_eq!(nm.tx_packets.len(), NETWORK_QUEUE_LENGTH);
+        nm.tx_packets.discard_older_items();
+        assert_eq!(nm.tx_packets.len(), NETWORK_QUEUE_LENGTH-1);
+
+        for _ in 0..NETWORK_QUEUE_LENGTH {
+            nm.rx_packets.push_back(pkt.clone());
+        }
+        assert_eq!(nm.rx_packets.len(), NETWORK_QUEUE_LENGTH);
+        nm.rx_packets.discard_older_items();
+        assert_eq!(nm.rx_packets.len(), NETWORK_QUEUE_LENGTH);
+    }
+
+    #[test]
+    #[ignore]
+    fn test_discard_older_packets_exceeds_limit_retains_max() {
+        let mut nm = NetworkManager::new();
+        let pkt = Packet::Request {
+            sequence: 0,
+            response_ack: None,
+            cookie: None,
+            action: RequestAction::None
+        };
+
+        for _ in 0..NETWORK_QUEUE_LENGTH+10 {
+            nm.tx_packets.push_back(pkt.clone());
+        }
+        assert_eq!(nm.tx_packets.len(), NETWORK_QUEUE_LENGTH+10);
+        nm.tx_packets.discard_older_items();
+        assert_eq!(nm.tx_packets.len(), NETWORK_QUEUE_LENGTH-1);
+
+        for _ in 0..NETWORK_QUEUE_LENGTH+5 {
+            nm.rx_packets.push_back(pkt.clone());
+        }
+        assert_eq!(nm.rx_packets.len(), NETWORK_QUEUE_LENGTH+5);
+        nm.rx_packets.discard_older_items();
+        assert_eq!(nm.rx_packets.len(), NETWORK_QUEUE_LENGTH);
+    }
+
+    #[test]
+    fn test_buffer_item_queue_is_empty() {
+        let mut nm = NetworkManager::new();
+        let pkt = Packet::Request {
+            sequence: 0,
+            response_ack: None,
+            cookie: None,
+            action: RequestAction::None
+        };
+
+        nm.tx_packets.buffer_item(pkt);
+        assert_eq!(nm.tx_packets.len(), 1);
+    }
+
+    #[test]
+    fn test_buffer_item_sequence_number_reused() {
+        let mut nm = NetworkManager::new();
+        let pkt = Packet::Request {
+            sequence: 0,
+            response_ack: None,
+            cookie: None,
+            action: RequestAction::None
+        };
+
+        nm.tx_packets.buffer_item(pkt);
+        let pkt = Packet::Request {
+            sequence: 0,
+            response_ack: None,
+            cookie: None,
+            action: RequestAction::LeaveRoom
+        };
+
+        nm.tx_packets.buffer_item(pkt);
+        let pkt = nm.tx_packets.queue.back().unwrap();
+        if let Packet::Request { sequence: _, response_ack: _, cookie: _, action } = pkt {
+            assert_eq!(*action, RequestAction::None);
+        }
+    }
+
+    #[test]
+    fn test_buffer_item_basic_sequencing() {
+        let mut nm = NetworkManager::new();
+        let pkt = Packet::Request {
+            sequence: 0,
+            response_ack: None,
+            cookie: None,
+            action: RequestAction::None
+        };
+
+        nm.tx_packets.buffer_item(pkt);
+        let pkt = Packet::Request {
+            sequence: 1,
+            response_ack: None,
+            cookie: None,
+            action: RequestAction::LeaveRoom
+        };
+        nm.tx_packets.buffer_item(pkt);
+        assert_eq!(nm.tx_packets.len(), 2);
+    }
+
+    #[test]
+    fn test_buffer_item_newer_packet_has_smaller_sequence_number() {
+        let mut nm = NetworkManager::new();
+        let pkt = Packet::Request {
+            sequence: 1,
+            response_ack: None,
+            cookie: None,
+            action: RequestAction::None
+        };
+
+        nm.tx_packets.buffer_item(pkt);
+        let pkt = Packet::Request {
+            sequence: 0,
+            response_ack: None,
+            cookie: None,
+            action: RequestAction::LeaveRoom
+        };
+        nm.tx_packets.buffer_item(pkt);
+        assert_eq!(nm.tx_packets.len(), 2);
+
+        let pkt = nm.tx_packets.queue.back().unwrap();
+        if let Packet::Request { sequence, response_ack: _, cookie: _, action:_ } = pkt {
+            assert_eq!(*sequence, 1);
+        }
+    }
+
+
+    // `buffer_item()` test with an enforced hard limit size is disabled until performance is re-examined
+    #[test]
+    #[ignore]
+    fn test_buffer_item_max_queue_limit_maintained() {
+        let mut nm = NetworkManager::new();
+        for index in 0..NETWORK_QUEUE_LENGTH+5 {
+            let pkt = Packet::Request {
+                sequence: index as u64,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.tx_packets.buffer_item(pkt);
+        }
+
+        let mut iter =  nm.tx_packets.queue.iter();
+        for index in 5..NETWORK_QUEUE_LENGTH+5 {
+            let pkt = iter.next().unwrap();
+            if let Packet::Request { sequence, response_ack: _, cookie: _, action:_ } = pkt {
+                assert_eq!(*sequence, index as u64);
+            }
+        }
+    }
+
+    #[test]
+    fn test_buffer_item_basic_contiguous_ascending() {
+        let mut nm = NetworkManager::new();
+        for index in 0..5 {
+            let pkt = Packet::Request {
+                sequence: index as u64,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.rx_packets.buffer_item(pkt);
+        }
+
+        let mut iter = nm.rx_packets.queue.iter();
+        for index in 0..5 {
+            let pkt = iter.next().unwrap();
+            assert_eq!(index, pkt.sequence_number() as usize);
+        }
+    }
+
+    #[test]
+    fn test_buffer_item_basic_contiguous_descending() {
+        let mut nm = NetworkManager::new();
+        for index in (0..5).rev() {
+            let pkt = Packet::Request {
+                sequence: index as u64,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.rx_packets.buffer_item(pkt);
+        }
+
+        let mut iter = nm.rx_packets.queue.iter();
+        for index in 0..5 {
+            let pkt = iter.next().unwrap();
+            assert_eq!(index, pkt.sequence_number() as usize);
+        }
+    }
+
+    #[test]
+    fn test_buffer_item_basic_sequential_gap_ascending() {
+        let mut nm = NetworkManager::new();
+        // TODO Replace with (x,y).step_by(z) once stable
+        for index in [0,2,4,6,8,10].iter() {
+            let pkt = Packet::Request {
+                sequence: *index as u64,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.rx_packets.buffer_item(pkt);
+        }
+
+        let mut iter = nm.rx_packets.queue.iter();
+        for &index in [0,2,4,6,8,10].iter() {
+            let pkt = iter.next().unwrap();
+            assert_eq!(index, pkt.sequence_number() as usize);
+        }
+    }
+
+    #[test]
+    fn test_buffer_item_basic_sequential_gap_descending() {
+        let mut nm = NetworkManager::new();
+        for index in [0,2,4,6,8,10].iter().rev() {
+            let pkt = Packet::Request {
+                sequence: *index as u64,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.rx_packets.buffer_item(pkt);
+        }
+
+        let mut iter = nm.rx_packets.queue.iter();
+        for index in [0,2,4,6,8,10].iter() {
+            let pkt = iter.next().unwrap();
+            assert_eq!(*index, pkt.sequence_number());
+        }
+    }
+
+    #[test]
+    fn test_buffer_item_basic_random() {
+        let mut nm = NetworkManager::new();
+        for index in [5, 2, 9, 1, 0, 8, 6].iter() {
+            let pkt = Packet::Request {
+                sequence: *index as u64,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.rx_packets.buffer_item(pkt);
+        }
+
+        let mut iter = nm.rx_packets.queue.iter();
+        for index in [0, 1, 2, 5, 6, 8, 9].iter() {
+            let pkt = iter.next().unwrap();
+            assert_eq!(*index, pkt.sequence_number() as usize);
+        }
+    }
+
+    #[test]
+    fn test_buffer_item_butterfly_pattern() {
+        let mut nm = NetworkManager::new();
+        // This one is fun because it tests the internal edges of (front_slice and back_slice)
+        for index in [0, 10, 1, 9, 2, 8, 3, 7, 4, 6, 5].iter() {
+            let pkt = Packet::Request {
+                sequence: *index as u64,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.rx_packets.buffer_item(pkt);
+        }
+
+        let mut iter = nm.rx_packets.queue.iter();
+        for index in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10].iter() {
+            let pkt = iter.next().unwrap();
+            assert_eq!(*index, pkt.sequence_number() as usize);
+        }
+    }
+
+    #[test]
+    fn test_buffer_item_basic_repetition() {
+        let mut nm = NetworkManager::new();
+        for index in [0, 0, 0, 0, 1, 2, 2, 2, 5].iter() {
+            let pkt = Packet::Request {
+                sequence: *index as u64,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.rx_packets.buffer_item(pkt);
+        }
+
+        let mut iter = nm.rx_packets.queue.iter();
+        for index in [0, 1, 2, 5].iter() {
+            let pkt = iter.next().unwrap();
+            assert_eq!(*index, pkt.sequence_number() as usize);
+        }
+    }
+
+    #[test]
+    fn test_buffer_item_advanced_sequential_then_pseudorandom_then_sequential() {
+        let mut nm = NetworkManager::new();
+
+        for index in 0..5 {
+            let pkt = Packet::Request {
+                sequence: index as u64,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.rx_packets.buffer_item(pkt);
+        }
+
+        for index in [10, 7, 11, 9, 12, 8, 99, 6].iter() {
+            let pkt = Packet::Request {
+                sequence: *index as u64,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.rx_packets.buffer_item(pkt);
+        }
+
+        for index in 13..20 {
+            let pkt = Packet::Request {
+                sequence: index as u64,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.rx_packets.buffer_item(pkt);
+        }
+
+        let mut iter = nm.rx_packets.queue.iter();
+        let mut range = (0..20).collect::<Vec<usize>>();
+        range.extend([99].iter().cloned()); // Add in 99
+        range.remove(5); // But remove 5 since it was never included
+        for index in range.iter() {
+            let pkt = iter.next().unwrap();
+            assert_eq!(*index, pkt.sequence_number() as usize);
+        }
+    }
+
+    #[test]
+    fn test_buffer_item_advanced_reverse_sequential_then_random_then_reverse_sequential() {
+        let mut nm = NetworkManager::new();
+
+        for index in (0..5).rev() {
+            let pkt = Packet::Request {
+                sequence: index as u64,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.rx_packets.buffer_item(pkt);
+        }
+
+        for index in [10, 7, 11, 9, 12, 8, 99, 6].iter() {
+            let pkt = Packet::Request {
+                sequence: *index as u64,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.rx_packets.buffer_item(pkt);
+        }
+
+        for index in (13..20).rev() {
+            let pkt = Packet::Request {
+                sequence: index as u64,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.rx_packets.buffer_item(pkt);
+        }
+
+        let mut iter = nm.rx_packets.queue.iter();
+        let mut range = (0..20).collect::<Vec<usize>>();
+        range.extend([99].iter().cloned()); // Add in 99
+        range.remove(5); // But remove 5 since it was never included
+        for index in range.iter() {
+            let pkt = iter.next().unwrap();
+            assert_eq!(*index, pkt.sequence_number() as usize);
+        }
+    }
+
+    #[test]
+    fn test_buffer_item_basic_wrapping_case() {
+        let mut nm = NetworkManager::new();
+        let u64_max = <u64>::max_value();
+        let start = u64_max - 5;
+
+        for index in start..(start+5) {
+            let pkt = Packet::Request {
+                sequence: index as u64,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.rx_packets.buffer_item(pkt);
+        }
+
+        {
+            let pkt = Packet::Request {
+                sequence: u64_max,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.rx_packets.buffer_item(pkt);
+        }
+
+        for index in 0..5 {
+            let pkt = Packet::Request {
+                sequence: index as u64,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.rx_packets.buffer_item(pkt);
+        }
+
+        let mut iter = nm.rx_packets.queue.iter();
+        let mut range = (start..u64_max).collect::<Vec<u64>>();
+        range.extend([u64_max, 0, 1, 2, 3, 4].iter().cloned()); // Add in u64 max value plus others
+        for index in range.iter() {
+            let pkt = iter.next().unwrap();
+            assert_eq!(*index, pkt.sequence_number());
+        }
+    }
+
+    #[test]
+    fn test_buffer_item_basic_wrapping_case_then_out_of_order() {
+        let mut nm = NetworkManager::new();
+        let u64_max = <u64>::max_value();
+        let start = u64_max - 5;
+
+        for index in start..(start+5) {
+            let pkt = Packet::Request {
+                sequence: index as u64,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.rx_packets.buffer_item(pkt);
+        }
+
+        {
+            let pkt = Packet::Request {
+                sequence: u64_max,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.rx_packets.buffer_item(pkt);
+        }
+
+        for index in [5, 0, 4, 1, 3, 2].iter() {
+            let pkt = Packet::Request {
+                sequence: *index as u64,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.rx_packets.buffer_item(pkt);
+        }
+
+        let mut iter = nm.rx_packets.queue.iter();
+        let mut range = (start..u64_max).collect::<Vec<u64>>();
+        range.extend([u64_max, 0, 1, 2, 3, 4, 5].iter().cloned()); // Add in u64 max value plus others
+        for index in range.iter() {
+            let pkt = iter.next().unwrap();
+            assert_eq!(*index, pkt.sequence_number());
+        }
+    }
+
+    #[test]
+    fn test_buffer_item_advanced_wrapping_case_everything_out_of_order() {
+        let mut nm = NetworkManager::new();
+        let u64_max = <u64>::max_value();
+        let max_minus_5 = u64_max - 5;
+        let max_minus_4 = u64_max - 4;
+        let max_minus_3 = u64_max - 3;
+        let max_minus_2 = u64_max - 2;
+        let max_minus_1 = u64_max - 1;
+        let zero = 0;
+        let one = 1;
+        let two = 2;
+        let three = 3;
+
+        let input_order = [ max_minus_4,
+                            two,
+                            max_minus_1,
+                            max_minus_5,
+                            u64_max,
+                            three,
+                            max_minus_2,
+                            zero,
+                            max_minus_3,
+                            one ];
+
+        for index in input_order.iter() {
+            let pkt = Packet::Request {
+                sequence: *index as u64,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.rx_packets.buffer_item(pkt);
+        }
+
+        let mut iter = nm.rx_packets.queue.iter();
+        let mut range = vec![];
+        range.extend([max_minus_5, max_minus_4, max_minus_3, max_minus_2, max_minus_1, u64_max, zero, one, two, three]
+                .iter()
+                .cloned()); // Add in u64 max value plus others
+
+        for index in range.iter() {
+            let pkt = iter.next().unwrap();
+            assert_eq!(*index, pkt.sequence_number());
+        }
+    }
+
+    #[test]
+    fn test_buffer_item_advanced_max_sequence_number_arrives_after_a_wrap() {
+        let mut nm = NetworkManager::new();
+        let u64_max = <u64>::max_value();
+        let max_minus_2 = u64_max - 2;
+        let max_minus_1 = u64_max - 1;
+        let two = 2;
+        let three = 3;
+
+        let input_order = [max_minus_1, max_minus_2, three, u64_max, two];
+
+        for index in input_order.iter() {
+            let pkt = Packet::Request {
+                sequence: *index as u64,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.rx_packets.buffer_item(pkt);
+        }
+
+        let mut iter = nm.rx_packets.queue.iter();
+        let mut range = vec![];
+        range.extend([max_minus_2, max_minus_1, u64_max, two, three].iter().cloned()); // Add in u64 max value plus others
+        for index in range.iter() {
+            let pkt = iter.next().unwrap();
+            assert_eq!(*index, pkt.sequence_number());
+        }
+    }
+
+    #[test]
+    fn test_buffer_item_advanced_oldest_sequence_number_arrived_last() {
+        let mut nm = NetworkManager::new();
+        let u64_max = <u64>::max_value();
+        let max_minus_3 = u64_max - 3;
+        let max_minus_2 = u64_max - 2;
+        let max_minus_1 = u64_max - 1;
+        let zero = 0;
+        let one = 1;
+        let two = 2;
+        let three = 3;
+
+        let input_order = [max_minus_1, max_minus_2, three, u64_max, two, one, zero, max_minus_3];
+
+        for index in input_order.iter() {
+            let pkt = Packet::Request {
+                sequence: *index as u64,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.rx_packets.buffer_item(pkt);
+        }
+
+        let mut iter = nm.rx_packets.queue.iter();
+        let mut range = vec![];
+        range.extend([max_minus_3, max_minus_2, max_minus_1, u64_max, zero, one, two, three].iter().cloned());
+
+        for index in range.iter() {
+            let pkt = iter.next().unwrap();
+            assert_eq!(*index, pkt.sequence_number());
+        }
+    }
+
+    #[test]
+    fn test_buffer_item_advanced_wrap_occurs_with_two_item_queue() {
+        let mut nm = NetworkManager::new();
+        let u64_max = <u64>::max_value();
+        let max_minus_3 = u64_max - 3;
+        let max_minus_2 = u64_max - 2;
+        let max_minus_1 = u64_max - 1;
+        let zero = 0;
+        let one = 1;
+        let two = 2;
+        let three = 3;
+
+        // Forward wrap occurs non-contiguously (aka [254, 0, ...] for bytes)
+        let input_order = [max_minus_1, zero, three, u64_max, max_minus_2, one, two, max_minus_3];
+
+        for index in input_order.iter() {
+            let pkt = Packet::Request {
+                sequence: *index as u64,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.rx_packets.buffer_item(pkt);
+        }
+
+        let mut iter = nm.rx_packets.queue.iter();
+        let mut range = vec![];
+        range.extend([max_minus_3, max_minus_2, max_minus_1, u64_max, zero, one, two, three].iter().cloned());
+
+        for index in range.iter() {
+            let pkt = iter.next().unwrap();
+            assert_eq!(*index, pkt.sequence_number());
+        }
+    }
+
+    #[test]
+    fn test_buffer_item_advanced_wrap_occurs_with_two_item_queue_in_reverse() {
+        let mut nm = NetworkManager::new();
+        let u64_max = <u64>::max_value();
+        let max_minus_3 = u64_max - 3;
+        let max_minus_2 = u64_max - 2;
+        let max_minus_1 = u64_max - 1;
+        let zero = 0;
+        let one = 1;
+        let two = 2;
+        let three = 3;
+
+        // Wrap takes place in reverse order ( aka [0, 254, ...] for bytes)
+        let input_order = [zero, max_minus_1, three, u64_max, max_minus_2, one, two, max_minus_3];
+
+        for index in input_order.iter() {
+            let pkt = Packet::Request {
+                sequence: *index as u64,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.rx_packets.buffer_item(pkt);
+        }
+
+        let mut iter = nm.rx_packets.queue.iter();
+        let mut range = vec![];
+        range.extend([max_minus_3, max_minus_2, max_minus_1, u64_max, zero, one, two, three].iter().cloned());
+
+        for index in range.iter() {
+            let pkt = iter.next().unwrap();
+            assert_eq!(*index, pkt.sequence_number());
+        }
+    }
+
+    #[test]
+    fn test_buffer_item_advanced_wrapping_case_max_arrives_first() {
+        let mut nm = NetworkManager::new();
+        let u64_max = <u64>::max_value();
+        let max_minus_5 = u64_max - 5;
+        let max_minus_4 = u64_max - 4;
+        let max_minus_3 = u64_max - 3;
+        let max_minus_2 = u64_max - 2;
+        let max_minus_1 = u64_max - 1;
+        let zero = 0;
+        let one = 1;
+        let two = 2;
+        let three = 3;
+
+        let input_order = [u64_max, max_minus_4, two, max_minus_1, max_minus_5, three, max_minus_2, zero, max_minus_3, one];
+
+        for index in input_order.iter() {
+            let pkt = Packet::Request {
+                sequence: *index as u64,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.rx_packets.buffer_item(pkt);
+        }
+
+        let mut iter = nm.rx_packets.queue.iter();
+        let mut range = vec![];
+        range.extend([max_minus_5, max_minus_4, max_minus_3, max_minus_2, max_minus_1, u64_max, zero, one, two, three].iter().cloned());
+
+        for index in range.iter() {
+            let pkt = iter.next().unwrap();
+            assert_eq!(*index, pkt.sequence_number());
+        }
+    }
+
+    #[test]
+    fn test_buffer_item_advanced_wrapping_case_sequence_number_descending() {
+        let mut nm = NetworkManager::new();
+        let u64_max = <u64>::max_value();
+        let max_minus_5 = u64_max - 5;
+        let max_minus_4 = u64_max - 4;
+        let max_minus_3 = u64_max - 3;
+        let max_minus_2 = u64_max - 2;
+        let max_minus_1 = u64_max - 1;
+        let zero = 0;
+        let one = 1;
+        let two = 2;
+        let three = 3;
+
+        let input_order = [three, two, one, zero, u64_max, max_minus_1, max_minus_2, max_minus_3, max_minus_4, max_minus_5];
+
+        for index in input_order.iter() {
+            let pkt = Packet::Request {
+                sequence: *index as u64,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.rx_packets.buffer_item(pkt);
+        }
+
+        let mut iter = nm.rx_packets.queue.iter();
+        let mut range = vec![];
+        range.extend([max_minus_5, max_minus_4, max_minus_3, max_minus_2, max_minus_1, u64_max, zero, one, two, three]
+                .iter()
+                .cloned());
+
+        for index in range.iter() {
+            let pkt = iter.next().unwrap();
+            assert_eq!(*index, pkt.sequence_number());
+        }
+    }
+
+    #[test]
+    fn test_buffer_item_advanced_wrapping_case_sequence_number_alternating() {
+        let mut nm = NetworkManager::new();
+        let u64_max = <u64>::max_value();
+        let max_minus_5 = u64_max - 5;
+        let max_minus_4 = u64_max - 4;
+        let max_minus_3 = u64_max - 3;
+        let max_minus_2 = u64_max - 2;
+        let max_minus_1 = u64_max - 1;
+        let zero = 0;
+        let one = 1;
+        let two = 2;
+        let three = 3;
+
+        let input_order = [max_minus_5, three, max_minus_4, two, max_minus_3, one, max_minus_2, zero, max_minus_1, u64_max];
+
+        for index in input_order.iter() {
+            let pkt = Packet::Request {
+                sequence: *index as u64,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.rx_packets.buffer_item(pkt);
+        }
+
+        let mut iter = nm.rx_packets.queue.iter();
+        let mut range = vec![];
+        range.extend([max_minus_5, max_minus_4, max_minus_3, max_minus_2, max_minus_1, u64_max, zero, one, two, three]
+                .iter()
+                .cloned()); // Add in u64 max value plus others
+
+        for index in range.iter() {
+            let pkt = iter.next().unwrap();
+            assert_eq!(*index, pkt.sequence_number());
+        }
+    }
+
+    #[test]
+    fn test_reinitialize_all_queues_cleared() {
+        let mut nm = NetworkManager::new();
+        let pkt = Packet::Request {
+            sequence: 0,
+            response_ack: None,
+            cookie: None,
+            action: RequestAction::None
+        };
+
+        for _ in 0..NETWORK_QUEUE_LENGTH {
+            nm.tx_packets.push_back(pkt.clone());
+        }
+        assert_eq!(nm.tx_packets.len(), NETWORK_QUEUE_LENGTH);
+
+        let _chat_msg = BroadcastChatMessage::new(0, "chatchat".to_owned(), "chatchat".to_owned());
+    }
+
+    #[test]
+    fn test_get_contiguous_packets_count() {
+        let mut nm = NetworkManager::new();
+        for index in 0..5 {
+            let pkt = Packet::Request {
+                sequence: index as u64,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.rx_packets.buffer_item(pkt);
+        }
+        for index in 8..10 {
+            let pkt = Packet::Request {
+                sequence: index as u64,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+            nm.rx_packets.buffer_item(pkt);
+        }
+
+        let count = nm.rx_packets.get_contiguous_packets_count(0);
+        assert_eq!(count, 5);
+        let mut iter = nm.rx_packets.as_queue_type().iter();
+        for index in 0..5 {
+            let pkt = iter.next().unwrap();
+            assert_eq!(index, pkt.sequence_number() as usize);
+            // Verify that the packet is not dequeued
+            assert_eq!(index, nm.rx_packets.as_queue_type().get(index).unwrap().sequence_number() as usize);
+        }
+    }
+
+    #[test]
+    fn test_get_retransmit_indices() {
+        let mut nm = NetworkManager::new();
+        for i in 0..5 {
+            let pkt = Packet::Request {
+                sequence: i,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+
+            nm.tx_packets.buffer_item(pkt.clone());
+
+            if i < 3 {
+                let attempt: &mut NetAttempt = nm.tx_packets.attempts.back_mut().unwrap();
+                attempt.time = Instant::now() - Duration::from_secs(i+1);
+            }
+        }
+        assert_eq!(nm.tx_packets.get_retransmit_indices().len(), 3);
+        thread::sleep(Duration::from_millis(2000));
+        assert_eq!(nm.tx_packets.get_retransmit_indices().len(), 5);
+    }
+
+    #[test]
+    fn test_retransmit_expired_tx_packets_no_expirations() {
+        let mut nm = NetworkManager::new();
+
+        for i in 0..5 {
+            let pkt = Packet::Request {
+                sequence: i,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+
+            nm.tx_packets.buffer_item(pkt.clone());
+        }
+
+        let indices = nm.tx_packets.get_retransmit_indices();
+
+        let (udp_tx, _) = mpsc::unbounded();
+        let addr = fake_socket_addr();
+        nm.retransmit_expired_tx_packets(&udp_tx, addr, None, &indices);
+
+        for i in 0..5 {
+            assert_eq!(nm.tx_packets.attempts.get(i).unwrap().retries, 0);
+        }
+    }
+
+    #[test]
+    fn test_retransmit_expired_tx_packets_basic_retries() {
+        let mut nm = NetworkManager::new();
+
+        for i in 0..5 {
+            let pkt = Packet::Request {
+                sequence: i,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+
+            nm.tx_packets.buffer_item(pkt.clone());
+
+           if i < 3 {
+                let attempt: &mut NetAttempt = nm.tx_packets.attempts.back_mut().unwrap();
+                attempt.time = Instant::now() - Duration::from_secs(i+1);
+            }
+        }
+
+        let indices = nm.tx_packets.get_retransmit_indices();
+
+        let (udp_tx, _) = mpsc::unbounded();
+        let addr = fake_socket_addr();
+        nm.retransmit_expired_tx_packets(&udp_tx, addr, None, &indices);
+
+        for i in 0..3 {
+            assert_eq!(nm.tx_packets.attempts.get(i).unwrap().retries, 1);
+        }
+        for i in 3..5 {
+            assert_eq!(nm.tx_packets.attempts.get(i).unwrap().retries, 0);
+        }
+    }
+
+    #[test]
+    fn test_retransmit_expired_tx_packets_aggressive_retries() {
+        let mut nm = NetworkManager::new();
+
+        for i in 0..5 {
+            let pkt = Packet::Request {
+                sequence: i,
+                response_ack: None,
+                cookie: None,
+                action: RequestAction::None
+            };
+
+            nm.tx_packets.buffer_item(pkt.clone());
+
+           if i < 3 {
+                let attempt: &mut NetAttempt = nm.tx_packets.attempts.back_mut().unwrap();
+                attempt.time = Instant::now() - Duration::from_secs(i+1);
+            }
+        }
+
+        // After 2 attempts, aggressive mode should kick in
+        for _ in 0..5 {
+            let indices = nm.tx_packets.get_retransmit_indices();
+
+            println!("{:?}", indices);
+
+            let (udp_tx, _) = mpsc::unbounded();
+            let addr = fake_socket_addr();
+            nm.retransmit_expired_tx_packets(&udp_tx, addr, None, &indices);
+
+            for j in 0..indices.len() {
+                let attempt: &mut NetAttempt = nm.tx_packets.attempts.get_mut(j).unwrap();
+                attempt.time = Instant::now() - Duration::from_secs( 1u64);
+            }
+        }
+
+        for i in 0..3 {
+            // 5 + 2 + 2 + 3
+            assert_eq!(nm.tx_packets.attempts.get(i).unwrap().retries, 11);
+        }
+        for i in 3..5 {
+            assert_eq!(nm.tx_packets.attempts.get(i).unwrap().retries, 0);
+        }
+
+    }
+
+}
+
+/*
+pub mod netwayste_server_tests {
+    use super::*;
+    use crate::proptest::strategy::*;
+    use server;
+
+    fn fake_socket_addr() -> SocketAddr {
+        use std::net::{IpAddr, Ipv4Addr};
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 5678)
+    }
+
+    #[test]
+    fn list_players_player_shows_up_in_player_list() {
+        let mut server = server::ServerState::new();
+        let room_name = "some name";
+        // make a new room
+        server.create_new_room(None, String::from(room_name));
+
+        let (player_id, player_name) = {
+            let p: &mut Player = server.add_new_player(String::from("some name"), fake_socket_addr());
+
+            (p.player_id, p.name.clone())
+        };
+        // make the player join the room
+        {
+            server.join_room(player_id, String::from(room_name));
+        }
+        let resp_code: ResponseCode = server.list_players(player_id);
+        match resp_code {
+            ResponseCode::PlayerList(players) => {
+                assert_eq!(players.len(), 1);
+                assert_eq!(*players.first().unwrap(), player_name);
+            }
+            resp_code @ _ => panic!("Unexpected response code: {:?}", resp_code)
+        }
+    }
+
+    #[test]
+    fn has_chatted_player_did_not_chat_on_join() {
+        let mut server = ServerState::new();
+        let room_name = "some name";
+        // make a new room
+        server.create_new_room(None, String::from(room_name));
+        let player_id = {
+            let p: &mut Player = server.add_new_player(String::from("some name"), fake_socket_addr());
+            p.player_id
+        };
+        // make the player join the room
+        {
+            server.join_room(player_id, String::from(room_name));
+        }
+        let player = server.get_player(player_id);
+        assert_eq!(player.has_chatted(), false);
+    }
+
+    #[test]
+    fn get_confirmed_chat_seq_num_server_tracks_players_chat_updates() {
+        let mut server = ServerState::new();
+        let room_name = "some name";
+        // make a new room
+        server.create_new_room(None, String::from(room_name));
+
+        let (player_id, player_cookie) = {
+            let p: &mut Player = server.add_new_player(String::from("some name"), fake_socket_addr());
+
+            (p.player_id, p.cookie.clone())
+        };
+        // make the player join the room
+        {
+            server.join_room(player_id, String::from(room_name));
+        }
+
+        // A chat-less player now has something to to say
+        server.decode_packet(fake_socket_addr(), Packet::UpdateReply {
+            cookie: player_cookie.clone(),
+            last_chat_seq: Some(1),
+            last_game_update_seq: None,
+            last_gen: None
+        }).unwrap();
+
+        {
+            let player = server.get_player(player_id);
+            assert_eq!(player.get_confirmed_chat_seq_num(), Some(1));
+        }
+
+        // Older messages are ignored
+        server.decode_packet(fake_socket_addr(), Packet::UpdateReply {
+            cookie: player_cookie.clone(),
+            last_chat_seq: Some(0),
+            last_game_update_seq: None,
+            last_gen: None
+        }).unwrap();
+
+        {
+            let player = server.get_player(player_id);
+            assert_eq!(player.get_confirmed_chat_seq_num(), Some(1));
+        }
+
+        // So are absent messages
+        server.decode_packet(fake_socket_addr(), Packet::UpdateReply {
+            cookie: player_cookie,
+            last_chat_seq: None,
+            last_game_update_seq: None,
+            last_gen: None
+        }).unwrap();
+
+        {
+            let player = server.get_player(player_id);
+            assert_eq!(player.get_confirmed_chat_seq_num(), Some(1));
+        }
+    }
+
+    #[test]
+    fn get_message_skip_count_player_acked_messages_are_not_included_in_skip_count() {
+        let mut server = ServerState::new();
+        let room_name = "some name";
+
+        server.create_new_room(None, String::from(room_name));
+
+        let (player_id, _) = {
+            let p: &mut Player = server.add_new_player(String::from("some name"), fake_socket_addr());
+
+            (p.player_id, p.cookie.clone())
+        };
+        // make the player join the room
+        // Give it a single message
+        {
+            server.join_room(player_id, String::from(room_name));
+            server.handle_chat_message(player_id, "ChatMessage".to_owned());
+        }
+
+        {
+            let room: &Room = server.get_room(player_id).unwrap();
+            // The check below does not affect any player acknowledgement as we are not
+            // involving the player yet. This is a simple test to ensure that if a chat
+            // message decoded from a would-be player was less than the latest chat message,
+            // we handle it properly by not skipping any.
+            assert_eq!(room.get_message_skip_count(0), 0);
+        }
+
+        let number_of_messages = 6;
+        for _ in 1..number_of_messages {
+            server.handle_chat_message(player_id, "ChatMessage".to_owned());
+        }
+
+        {
+            //let player = server.get_player_mut(player_id);
+            let player = server.get_player_mut(player_id);
+            // player has not acknowledged any yet
+            #[should_panic]
+            assert_eq!(player.get_confirmed_chat_seq_num(), None);
+        }
+
+        // player acknowledged four of the six
+        let acked_message_count = {
+            let player = server.get_player_mut(player_id);
+            player.update_chat_seq_num(Some(4));
+
+            player.get_confirmed_chat_seq_num().unwrap()
+        };
+        {
+            let room: &Room = server.get_room(player_id).unwrap();
+            assert_eq!(room.get_message_skip_count(acked_message_count), acked_message_count);
+        }
+
+        // player acknowledged all six
+        let acked_message_count = {
+            let player = server.get_player_mut(player_id);
+            player.update_chat_seq_num(Some(6));
+
+            player.get_confirmed_chat_seq_num().unwrap()
+        };
+        {
+            let room: &Room = server.get_room(player_id).unwrap();
+            assert_eq!(room.get_message_skip_count(acked_message_count), acked_message_count);
+        }
+    }
+
+    #[test]
+    // Send fifteen messages, but only leave nine unacknowledged, while wrapping on the sequence number
+    fn get_message_skip_count_player_acked_messages_are_not_included_in_skip_count_wrapped_case() {
+        let mut server = ServerState::new();
+        let room_name = "some name";
+
+        server.create_new_room(None, String::from(room_name));
+
+        let player_id = {
+            let p: &mut Player = server.add_new_player(String::from("some name"), fake_socket_addr());
+
+            p.player_id
+        };
+        {
+            server.join_room(player_id, String::from(room_name));
+        }
+
+        // Picking a value slightly less than max of u64
+        let start_seq_num = u64::max_value() - 6;
+        // First pass, add messages with sequence numbers through the max of u64
+        for seq_num in start_seq_num..u64::max_value() {
+            let room: &mut Room = server.get_room_mut(player_id).unwrap();
+            room.add_message(ServerChatMessage::new(player_id, String::from("some name"), String::from("some msg"), seq_num));
+        }
+        // Second pass, from wrap-point, `0`, eight times
+        for seq_num in 0..8 {
+            let room: &mut Room = server.get_room_mut(player_id).unwrap();
+            room.add_message(ServerChatMessage::new(player_id, String::from("some name"), String::from("some msg"), seq_num));
+        }
+
+        let acked_message_count = {
+            // Ack up until 0xFFFFFFFFFFFFFFFD
+            let player = server.get_player_mut(player_id);
+            player.update_chat_seq_num(Some(start_seq_num + 4));
+
+            player.get_confirmed_chat_seq_num().unwrap()
+        };
+        {
+            let room: &Room = server.get_room(player_id).unwrap();
+            // Fifteen total messages sent.
+            // 2 unacked which are less than u64::max_value()
+            // 8 unacked which are after the numerical wrap
+            let unacked_count = 15 - (8 + 2);
+            assert_eq!(room.get_message_skip_count(acked_message_count), unacked_count);
+        }
+    }
+
+    #[test]
+    fn collect_unacknowledged_messages_a_rooms_unacknowledged_chat_messages_are_collected_for_their_player() {
+        let mut server = ServerState::new();
+        let room_name = "some name";
+
+        server.create_new_room(None, String::from(room_name));
+
+        let player_id = {
+            let p: &mut Player = server.add_new_player(String::from("some name"), fake_socket_addr());
+
+            p.player_id
+        };
+        {
+            server.join_room(player_id, String::from(room_name));
+        }
+
+        {
+            // Room has no messages, None to send to player
+            let room = server.get_room(player_id).unwrap();
+            let player = server.get_player(player_id);
+            let messages = server.collect_unacknowledged_messages(room, player);
+            assert_eq!(messages, None);
+        }
+
+        {
+            let room: &mut Room = server.get_room_mut(player_id).unwrap();
+            room.add_message(ServerChatMessage::new(player_id, String::from("some name"), String::from("some msg"), 1));
+        }
+        {
+            // Room has a message, player has yet to ack it
+            let room = server.get_room(player_id).unwrap();
+            let player = server.get_player(player_id);
+            let messages = server.collect_unacknowledged_messages(room, player);
+            assert_eq!(messages.is_some(), true);
+            assert_eq!(messages.unwrap().len(), 1);
+        }
+
+        {
+            let player = server.get_player_mut(player_id);
+            player.update_chat_seq_num(Some(1));
+        }
+        {
+            // Room has a message, player acked, None
+            let room = server.get_room(player_id).unwrap();
+            let player = server.get_player(player_id);
+            let messages = server.collect_unacknowledged_messages(room, player);
+            assert_eq!(messages, None);
+        }
+    }
+
+    #[test]
+    fn collect_unacknowledged_messages_an_active_room_which_expired_all_messages_returns_none()
+    {
+        let mut server = ServerState::new();
+        let room_name = "some name";
+
+        server.create_new_room(None, String::from(room_name));
+
+        let player_id = {
+            let p: &mut Player = server.add_new_player(String::from("some name"), fake_socket_addr());
+
+            p.player_id
+        };
+        {
+            server.join_room(player_id, String::from(room_name));
+        }
+
+        {
+            // Add a message to the room and then age it so it will expire
+            let room: &mut Room = server.get_room_mut(player_id).unwrap();
+            room.add_message(ServerChatMessage::new(player_id, String::from("some name"), String::from("some msg"), 1));
+
+            let message: &mut ServerChatMessage = room.messages.get_mut(0).unwrap();
+            message.timestamp = Instant::now() - Duration::from_secs(MAX_AGE_CHAT_MESSAGES as u64);
+        }
+        {
+            // Sanity check to ensure player gets the chat message if left unacknowledged
+            let room = server.get_room(player_id).unwrap();
+            let player = server.get_player(player_id);
+            let messages = server.collect_unacknowledged_messages(room, player);
+            assert_eq!(messages.is_some(), true);
+            assert_eq!(messages.unwrap().len(), 1);
+        }
+        {
+            let player = server.get_player_mut(player_id);
+            player.update_chat_seq_num(Some(1));
+        }
+
+        {
+            // Server drains expired messages for the room
+            server.expire_old_messages_in_all_rooms();
+        }
+        {
+            // A room that has no messages, but has player(s) who have acknowledged past messages
+            let room = server.get_room(player_id).unwrap();
+            let player = server.get_player(player_id);
+            let messages = server.collect_unacknowledged_messages(room, player);
+            assert_eq!(messages, None);
+        }
+    }
+
+    #[test]
+    fn handle_chat_message_player_not_in_game()
+    {
+        let mut server = ServerState::new();
+        let room_name = "some name";
+
+        server.create_new_room(None, room_name.to_owned());
+
+        let player_id = {
+            let p: &mut Player = server.add_new_player("some name".to_owned(), fake_socket_addr());
+
+            p.player_id
+        };
+
+        let response = server.handle_chat_message(player_id, "test msg".to_owned());
+        assert_eq!(response, ResponseCode::BadRequest(Some(format!("Player {} has not joined a game.", player_id))));
+    }
+
+    #[test]
+    fn handle_chat_message_player_in_game_one_message()
+    {
+
+        let mut server = ServerState::new();
+        let room_name = "some name";
+
+        server.create_new_room(None, room_name.to_owned());
+
+        let player_id = {
+            let p: &mut Player = server.add_new_player("some player".to_string(), fake_socket_addr());
+
+            p.player_id
+        };
+        {
+            server.join_room(player_id, room_name.to_owned());
+        }
+
+        let response = server.handle_chat_message(player_id, "test msg".to_owned());
+        assert_eq!(response, ResponseCode::OK);
+        let room: &Room = server.get_room(player_id).unwrap();
+        assert_eq!(room.messages.len(), 1);
+        assert_eq!(room.latest_seq_num, 1);
+        assert_eq!(room.get_newest_msg(), room.get_oldest_msg());
+    }
+
+    #[test]
+    fn handle_chat_message_player_in_game_many_messages()
+    {
+
+        let mut server = ServerState::new();
+        let room_name = "some name";
+
+        server.create_new_room(None, room_name.to_owned());
+
+        let player_id = {
+            let p: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+
+            p.player_id
+        };
+        {
+            server.join_room(player_id, room_name.to_owned());
+        }
+
+        let response = server.handle_chat_message(player_id, "test msg first".to_owned());
+        assert_eq!(response, ResponseCode::OK);
+        let response = server.handle_chat_message(player_id, "test msg second".to_owned());
+        assert_eq!(response, ResponseCode::OK);
+
+        let room: &Room = server.get_room(player_id).unwrap();
+        assert_eq!(room.messages.len(), 2);
+        assert_eq!(room.latest_seq_num, 2);
+    }
+
+    #[test]
+    fn create_new_room_good_case()
+    {
+        {
+            let mut server = ServerState::new();
+            let room_name = "some name".to_owned();
+
+            assert_eq!(server.create_new_room(None, room_name), ResponseCode::OK);
+        }
+        // Room name length is within bounds
+        {
+            let mut server = ServerState::new();
+            let room_name = "0123456789ABCDEF".to_owned();
+
+            assert_eq!(server.create_new_room(None, room_name), ResponseCode::OK);
+        }
+    }
+
+    #[test]
+    fn create_new_room_name_is_too_long()
+    {
+        let mut server = ServerState::new();
+        let room_name = "0123456789ABCDEF_#".to_owned();
+
+        assert_eq!(server.create_new_room(None, room_name), ResponseCode::BadRequest(Some("room name too long; max 16 characters".to_owned())));
+    }
+
+    #[test]
+    fn create_new_room_name_taken()
+    {
+        let mut server = ServerState::new();
+        let room_name = "some room".to_owned();
+        assert_eq!(server.create_new_room(None, room_name.clone()), ResponseCode::OK);
+        assert_eq!(server.create_new_room(None, room_name), ResponseCode::BadRequest(Some("room name already in use".to_owned())));
+    }
+
+    #[test]
+    fn create_new_room_player_already_in_room()
+    {
+        let mut server = ServerState::new();
+        let room_name = "some room".to_owned();
+        let other_room_name = "another room".to_owned();
+        assert_eq!(server.create_new_room(None, room_name.clone()), ResponseCode::OK);
+
+        let player_id = {
+            let p: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+
+            p.player_id
+        };
+        {
+            server.join_room(player_id, room_name.to_owned());
+        }
+
+        assert_eq!( server.create_new_room(Some(player_id), other_room_name), ResponseCode::BadRequest(Some("cannot create room because in-game".to_owned())) );
+    }
+
+    #[test]
+    fn create_new_room_join_room_good_case()
+    {
+
+        let mut server = ServerState::new();
+        let room_name = "some room".to_owned();
+        assert_eq!(server.create_new_room(None, room_name.clone()), ResponseCode::OK);
+
+        let player_id = {
+            let p: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+
+            p.player_id
+        };
+        assert_eq!(server.join_room(player_id, room_name.to_owned()), ResponseCode::JoinedRoom("some room".to_owned()));
+    }
+
+    #[test]
+    fn join_room_player_already_in_room()
+    {
+
+        let mut server = ServerState::new();
+        let room_name = "some room".to_owned();
+        assert_eq!(server.create_new_room(None, room_name.clone()), ResponseCode::OK);
+
+        let player_id = {
+            let p: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+
+            p.player_id
+        };
+        assert_eq!(server.join_room(player_id, room_name.clone()), ResponseCode::JoinedRoom("some room".to_owned()));
+        assert_eq!( server.join_room(player_id, room_name), ResponseCode::BadRequest(Some("cannot join game because in-game".to_owned())) );
+    }
+
+    #[test]
+    fn join_room_room_does_not_exist()
+    {
+
+        let mut server = ServerState::new();
+
+        let player_id = {
+            let p: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+
+            p.player_id
+        };
+        assert_eq!(server.join_room(player_id, "some room".to_owned()), ResponseCode::BadRequest(Some("no room named \"some room\"".to_owned())) );
+    }
+
+    #[test]
+    fn leave_room_good_case()
+    {
+        let mut server = ServerState::new();
+        let room_name = "some name";
+
+        server.create_new_room(None, room_name.to_owned());
+
+        let player_id = {
+            let p: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+
+            p.player_id
+        };
+        {
+            server.join_room(player_id, room_name.to_owned());
+        }
+
+        assert_eq!( server.leave_room(player_id), ResponseCode::LeaveRoom );
+
+    }
+
+    #[test]
+    fn leave_room_player_not_in_room()
+    {
+        let mut server = ServerState::new();
+        let room_name = "some room".to_owned();
+        assert_eq!(server.create_new_room(None, room_name.clone()), ResponseCode::OK);
+
+        let player_id = {
+            let p: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+
+            p.player_id
+        };
+
+        assert_eq!( server.leave_room(player_id), ResponseCode::BadRequest(Some("cannot leave game because in lobby".to_owned())) );
+    }
+
+    #[test]
+    fn leave_room_unregistered_player_id()
+    {
+        let mut server = ServerState::new();
+        let room_name = "some room".to_owned();
+        let rand_player_id = PlayerID(0x2457); //RUST
+        assert_eq!(server.create_new_room(None, room_name.clone()), ResponseCode::OK);
+
+        assert_eq!( server.leave_room(rand_player_id), ResponseCode::BadRequest(Some("cannot leave game because in lobby".to_owned())) );
+    }
+
+    #[test]
+    fn add_new_player_player_added_with_initial_sequence_number()
+    {
+        let mut server = ServerState::new();
+        let name = "some player".to_owned();
+
+        let p: &mut Player = server.add_new_player(name.clone(), fake_socket_addr());
+        assert_eq!(p.name, name);
+    }
+
+    #[test]
+    fn is_unique_player_name_yes_and_no_case()
+    {
+        let mut server = ServerState::new();
+        let name = "some player".to_owned();
+        assert_eq!(server.is_unique_player_name("some player"), true);
+
+        {
+            server.add_new_player(name.clone(), fake_socket_addr());
+        }
+        assert_eq!(server.is_unique_player_name("some player"), false);
+    }
+
+    #[test]
+    fn expire_old_messages_in_all_rooms_room_is_empty()
+    {
+        let mut server = ServerState::new();
+        let room_name = "some room";
+
+        server.create_new_room(None, room_name.to_owned().clone());
+        server.expire_old_messages_in_all_rooms();
+
+        for room in server.rooms.values() {
+            assert_eq!(room.messages.len(), 0);
+        }
+    }
+
+
+    #[test]
+    fn expire_old_messages_in_all_rooms_one_room_good_case()
+    {
+        let mut server = ServerState::new();
+        let room_name = "some room";
+
+        server.create_new_room(None, room_name.to_owned().clone());
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            player.player_id
+        };
+
+        server.join_room(player_id, room_name.to_owned());
+
+        server.handle_chat_message(player_id, "Conwayste is such a fun game".to_owned());
+        server.handle_chat_message(player_id, "There are not loot boxes".to_owned());
+        server.handle_chat_message(player_id, "It is free!".to_owned());
+        server.handle_chat_message(player_id, "What's not to love?".to_owned());
+
+        let message_count = {
+            let room: &Room = server.get_room(player_id).unwrap();
+            room.messages.len()
+        };
+        assert_eq!(message_count, 4);
+
+        // Messages are not old enough to be expired
+        server.expire_old_messages_in_all_rooms();
+
+        for room in server.rooms.values() {
+            assert_eq!(room.messages.len(), 4);
+        }
+    }
+
+    #[test]
+    fn expire_old_messages_in_all_rooms_several_rooms_good_case()
+    {
+        let mut server = ServerState::new();
+        let room_name = "some room";
+        let room_name2 = "some room2";
+
+        server.create_new_room(None, room_name.to_owned().clone());
+        server.create_new_room(None, room_name2.to_owned().clone());
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            player.player_id
+        };
+        let player_id2: PlayerID = {
+            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            player.player_id
+        };
+
+        server.join_room(player_id, room_name.to_owned());
+        server.join_room(player_id2, room_name2.to_owned());
+
+        server.handle_chat_message(player_id, "Conwayste is such a fun game".to_owned());
+        server.handle_chat_message(player_id, "There are not loot boxes".to_owned());
+        server.handle_chat_message(player_id2, "It is free!".to_owned());
+        server.handle_chat_message(player_id2, "What's not to love?".to_owned());
+
+        let message_count = {
+            let room: &Room = server.get_room(player_id).unwrap();
+            room.messages.len()
+        };
+        assert_eq!(message_count, 2);
+        let message_count2 = {
+            let room: &Room = server.get_room(player_id2).unwrap();
+            room.messages.len()
+        };
+        assert_eq!(message_count2, 2);
+
+        // Messages are not old enough to be expired
+        server.expire_old_messages_in_all_rooms();
+
+        for room in server.rooms.values() {
+            assert_eq!(room.messages.len(), 2);
+        }
+    }
+
+    #[test]
+    fn expire_old_messages_in_all_rooms_one_room_old_messages_are_wiped()
+    {
+        let mut server = ServerState::new();
+        let room_name = "some room";
+
+        server.create_new_room(None, room_name.to_owned().clone());
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            player.player_id
+        };
+
+        server.join_room(player_id, room_name.to_owned());
+
+        server.handle_chat_message(player_id, "Conwayste is such a fun game".to_owned());
+        server.handle_chat_message(player_id, "There are not loot boxes".to_owned());
+        server.handle_chat_message(player_id, "It is free!".to_owned());
+        server.handle_chat_message(player_id, "What's not to love?".to_owned());
+
+        let current_timestamp = Instant::now();
+        let travel_to_the_past = current_timestamp - Duration::from_secs((MAX_AGE_CHAT_MESSAGES+1) as u64);
+        for ref mut room in server.rooms.values_mut() {
+            println!("Room: {:?}", room.name);
+            for m in room.messages.iter_mut() {
+                println!("{:?}, {:?},       {:?}", m.timestamp, travel_to_the_past, m.timestamp - travel_to_the_past);
+                m.timestamp = travel_to_the_past;
+            }
+        }
+
+        // Messages are not old enough to be expired
+        server.expire_old_messages_in_all_rooms();
+
+        for room in server.rooms.values() {
+            assert_eq!(room.messages.len(), 0);
+        }
+    }
+
+    #[test]
+    fn expire_old_messages_in_all_rooms_several_rooms_old_messages_are_wiped()
+    {
+        let mut server = ServerState::new();
+        let room_name = "some room";
+        let room_name2 = "some room 2";
+
+        server.create_new_room(None, room_name.to_owned().clone());
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            player.player_id
+        };
+        server.create_new_room(None, room_name2.to_owned().clone());
+        let player_id2: PlayerID = {
+            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            player.player_id
+        };
+
+        server.join_room(player_id, room_name.to_owned());
+        server.join_room(player_id2, room_name.to_owned());
+
+        server.handle_chat_message(player_id, "Conwayste is such a fun game".to_owned());
+        server.handle_chat_message(player_id, "There are not loot boxes".to_owned());
+        server.handle_chat_message(player_id2, "It is free!".to_owned());
+        server.handle_chat_message(player_id2, "What's not to love?".to_owned());
+
+        let current_timestamp = Instant::now();
+        let travel_to_the_past = current_timestamp - Duration::from_secs((MAX_AGE_CHAT_MESSAGES+1) as u64);
+        for ref mut room in server.rooms.values_mut() {
+            println!("Room: {:?}", room.name);
+            for m in room.messages.iter_mut() {
+                println!("{:?}, {:?},       {:?}", m.timestamp, travel_to_the_past, m.timestamp - travel_to_the_past);
+                m.timestamp = travel_to_the_past;
+            }
+        }
+
+        // Messages are not old enough to be expired
+        server.expire_old_messages_in_all_rooms();
+
+        for room in server.rooms.values() {
+            assert_eq!(room.messages.len(), 0);
+        }
+    }
+
+    #[test]
+    fn handle_new_connection_good_case() {
+        let mut server = ServerState::new();
+        let player_name = "some name".to_owned();
+        let pkt = server.handle_new_connection(player_name, fake_socket_addr());
+        match pkt {
+            Packet::Response{sequence: _, request_ack: _, code} => {
+                match code {
+                    ResponseCode::LoggedIn(_,_) => {}
+                    _ => panic!("Unexpected ResponseCode: {:?}", code)
+                }
+            }
+            _ => panic!("Unexpected Packet Type: {:?}", pkt)
+        }
+    }
+
+    #[test]
+    fn handle_new_connection_player_name_taken() {
+        let mut server = ServerState::new();
+        let player_name = "some name".to_owned();
+
+        let pkt = server.handle_new_connection(player_name.clone(), fake_socket_addr());
+        match pkt {
+            Packet::Response{sequence: _, request_ack: _, code} => {
+                match code {
+                    ResponseCode::LoggedIn(_,version) => {assert_eq!(version, VERSION.to_owned() )}
+                    _ => panic!("Unexpected ResponseCode: {:?}", code)
+                }
+            }
+            _ => panic!("Unexpected Packet Type: {:?}", pkt)
+        }
+
+        let pkt = server.handle_new_connection(player_name, fake_socket_addr());
+        match pkt {
+            Packet::Response{sequence: _, request_ack: _, code} => {
+                match code {
+                    ResponseCode::Unauthorized(msg) => { assert_eq!(msg, Some("not a unique name".to_owned())); }
+                    _ => panic!("Unexpected ResponseCode: {:?}", code)
+                }
+            }
+            _ => panic!("Unexpected Packet Type: {:?}", pkt)
+        }
+    }
+
+    fn a_request_action_strat() -> BoxedStrategy<RequestAction> {
+        prop_oneof![
+            //Just(RequestAction::Disconnect), // not yet implemented
+            //Just(RequestAction::KeepAlive),  // same
+            Just(RequestAction::LeaveRoom),
+            Just(RequestAction::ListPlayers),
+            Just(RequestAction::ListRooms),
+            Just(RequestAction::None),
+        ].boxed()
+    }
+
+    fn a_request_action_complex_strat() -> BoxedStrategy<RequestAction> {
+        prop_oneof![
+            ("([A-Z]{1,4} [0-9]{1,2}){3}").prop_map(|a| RequestAction::ChatMessage(a)),
+            ("([A-Z]{1,4} [0-9]{1,2}){3}").prop_map(|a| RequestAction::NewRoom(a)),
+            ("([A-Z]{1,4} [0-9]{1,2}){3}").prop_map(|a| RequestAction::JoinRoom(a)),
+            ("([A-Z]{1,4} [0-9]{1,2}){3}", "[0-9].[0-9].[0-9]").prop_map(|(a, b)| RequestAction::Connect{name: a, client_version: b})
+        ].boxed()
+    }
+
+    // These tests are checking that we do not panic on each RequestAction
+    proptest! {
+        #[test]
+        fn process_request_action_simple(ref request in a_request_action_strat()) {
+            let mut server = ServerState::new();
+            server.create_new_room(None, "some room".to_owned().clone());
+            let player_id: PlayerID = {
+                let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+                player.player_id
+            };
+            server.process_request_action(player_id, request.to_owned());
+        }
+
+        #[test]
+        fn process_request_action_complex(ref request in a_request_action_complex_strat()) {
+            let mut server = ServerState::new();
+            server.create_new_room(None, "some room".to_owned().clone());
+            let player_id: PlayerID = {
+                let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+                player.player_id
+            };
+            server.process_request_action(player_id, request.to_owned());
+        }
+    }
+
+    #[test]
+    fn process_request_action_connect_while_connected() {
+        let mut server = ServerState::new();
+        server.create_new_room(None, "some room".to_owned().clone());
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            player.player_id
+        };
+        let result = server.process_request_action(player_id, RequestAction::Connect{name: "some player".to_owned(), client_version: "0.1.0".to_owned()});
+        assert_eq!(result, ResponseCode::BadRequest(Some("already connected".to_owned())));
+    }
+
+    #[test]
+    fn process_request_action_none_is_invalid() {
+        let mut server = ServerState::new();
+        server.create_new_room(None, "some room".to_owned().clone());
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            player.player_id
+        };
+        let result = server.process_request_action(player_id, RequestAction::None);
+        assert_eq!(result, ResponseCode::BadRequest(Some("Invalid request".to_owned())));
+    }
+
+    #[test]
+    fn prepare_response_spot_check_response_packet() {
+        let mut server = ServerState::new();
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            player.request_ack = Some(1);
+            player.player_id
+        };
+        let pkt: Packet = server.prepare_response(player_id, RequestAction::ListRooms).unwrap();
+        match pkt {
+            Packet::Response{code, sequence, request_ack} => {
+                assert_eq!(code, ResponseCode::RoomList(vec![]));
+                assert_eq!(sequence, 1);
+                assert_eq!(request_ack, Some(2));
+            }
+            _ => panic!("Unexpected Packet type on Response path: {:?}", pkt)
+        }
+        let player: &Player = server.get_player(player_id);
+        assert_eq!(player.next_resp_seq, 2);
+    }
+
+    #[test]
+    fn validate_client_version_client_is_up_to_date() {
+        assert_eq!(validate_client_version( env!("CARGO_PKG_VERSION").to_owned()), true);
+    }
+
+    #[test]
+    fn validate_client_version_client_is_very_old() {
+      assert_eq!(validate_client_version("0.0.1".to_owned()), true);
+    }
+
+    #[test]
+    fn validate_client_version_client_is_from_the_future() {
+        assert_eq!(validate_client_version(format!("{}.{}.{}", <i32>::max_value(), <i32>::max_value(), <i32>::max_value()).to_owned()), false);
+    }
+
+    #[test]
+    fn decode_packet_update_reply_good_case() {
+        let mut server = ServerState::new();
+        let cookie: String = {
+            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            player.cookie.clone()
+        };
+
+        let update_reply_packet = Packet::UpdateReply {
+                cookie: cookie,
+                last_chat_seq: Some(0),
+                last_game_update_seq: None,
+                last_gen: None,
+        };
+
+        let result = server.decode_packet(fake_socket_addr(), update_reply_packet);
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
+    }
+
+    #[test]
+    fn decode_packet_update_reply_invalid_cookie() {
+        let mut server = ServerState::new();
+        {
+            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            player.cookie.clone()
+        };
+
+        let cookie = "CookieMonster".to_owned();
+
+        let update_reply_packet = Packet::UpdateReply {
+                cookie: cookie,
+                last_chat_seq: Some(0),
+                last_game_update_seq: None,
+                last_gen: None,
+        };
+
+        let result = server.decode_packet(fake_socket_addr(), update_reply_packet);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn construct_client_updates_no_rooms() {
+        let mut server = ServerState::new();
+        let result = server.construct_client_updates();
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
+    }
+
+    #[test]
+    fn construct_client_updates_empty_rooms() {
+        let mut server = ServerState::new();
+        server.create_new_room(None, "some room".to_owned().clone());
+        let result = server.construct_client_updates();
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
+    }
+
+    #[test]
+    fn construct_client_updates_populated_room_returns_all_messages() {
+        let mut server = ServerState::new();
+        let room_name = "some_room".to_owned();
+        let player_name = "some player".to_owned();
+        let message_text = "Message".to_owned();
+
+        server.create_new_room(None, room_name.clone());
+
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            player.player_id
+        };
+        server.join_room(player_id, room_name);
+        server.handle_chat_message(player_id, message_text.clone());
+        server.handle_chat_message(player_id, message_text.clone());
+        server.handle_chat_message(player_id, message_text.clone());
+        let result = server.construct_client_updates();
+
+        assert!(result.is_ok());
+        let opt_output = result.unwrap();
+        assert!(opt_output.is_some());
+        let mut output: Vec<(SocketAddr, Packet)> = opt_output.unwrap();
+
+        // Vector should contain a single item for this test
+        assert_eq!(output.len(), 1);
+
+        let (addr, pkt) = output.pop().unwrap();
+        assert_eq!(addr, fake_socket_addr());
+
+        match pkt {
+            Packet::Update{chats, game_updates, universe_update} => {
+                assert_eq!(game_updates, None);
+                assert_eq!(universe_update, UniUpdateType::NoChange);
+                assert!(chats.is_some());
+
+                // All client chat sequence numbers start counting at 1
+                let mut i=1;
+
+                for msg in chats.unwrap() {
+                    assert_eq!(msg.player_name, player_name);
+                    assert_eq!(msg.chat_seq, Some(i));
+                    assert_eq!(msg.message, message_text);
+                    i+=1;
+                }
+            }
+            _ => panic!("Unexpected packet in client update construction!")
+        }
+    }
+
+    #[test]
+    fn construct_client_updates_populated_room_returns_updates_after_client_acked() {
+        let mut server = ServerState::new();
+        let room_name = "some_room".to_owned();
+        let player_name = "some player".to_owned();
+        let message_text = "Message".to_owned();
+
+        server.create_new_room(None, room_name.clone());
+
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            player.player_id
+        };
+        server.join_room(player_id, room_name);
+        server.handle_chat_message(player_id, message_text.clone());
+        server.handle_chat_message(player_id, message_text.clone());
+        server.handle_chat_message(player_id, message_text.clone());
+
+        // Assume that the client has acknowledged two chats
+        {
+            let player: &mut Player = server.get_player_mut(player_id);
+            player.update_chat_seq_num(Some(2));
+        }
+
+        // We should then only return the last chat
+        let result = server.construct_client_updates();
+
+        assert!(result.is_ok());
+        let opt_output = result.unwrap();
+        assert!(opt_output.is_some());
+        let mut output: Vec<(SocketAddr, Packet)> = opt_output.unwrap();
+
+        // Vector should contain a single item for this test
+        assert_eq!(output.len(), 1);
+
+        let (addr, pkt) = output.pop().unwrap();
+        assert_eq!(addr, fake_socket_addr());
+
+        match pkt {
+            Packet::Update{chats, game_updates, universe_update} => {
+                assert_eq!(game_updates, None);
+                assert_eq!(universe_update, UniUpdateType::NoChange);
+                assert!(chats.is_some());
+
+                let mut messages = chats.unwrap();
+                assert_eq!(messages.len(), 1);
+                let msg = messages.pop().unwrap();
+
+                assert_eq!(msg.player_name, player_name);
+                assert_eq!(msg.chat_seq, Some(3));
+                assert_eq!(msg.message, message_text);
+            }
+            _ => panic!("Unexpected packet in client update construction!")
+        }
+    }
+
+    #[test]
+    fn broadcast_message_to_two_players_in_room() {
+        let mut server = ServerState::new();
+        let room_name = "some_room".to_owned();
+        let player_name = "some player".to_owned();
+
+        server.create_new_room(None, room_name.clone());
+
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            player.player_id
+        };
+        let player_id2: PlayerID = {
+            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            player.player_id
+        };
+
+        server.join_room(player_id, room_name.clone());
+        {
+            let room: &mut Room = server.get_room_mut(player_id).unwrap();
+            room.broadcast("Silver birch against a Swedish sky".to_owned());
+        }
+        server.join_room(player_id2, room_name.clone());
+        let room: &Room = server.get_room(player_id).unwrap();
+
+        let player = (*server.get_player(player_id)).clone();
+        let msgs = server.collect_unacknowledged_messages(room, &player).unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].message, "Silver birch against a Swedish sky".to_owned());
+
+        let player = (*server.get_player(player_id2)).clone();
+        let msgs = server.collect_unacknowledged_messages(room, &player).unwrap();
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].message, "Silver birch against a Swedish sky".to_owned());
+    }
+
+    #[test]
+    fn broadcast_message_to_an_empty_room() {
+        let mut server = ServerState::new();
+        let room_name = "some_room".to_owned();
+
+        server.create_new_room(None, room_name.clone());
+        let room_id: &RoomID = server.room_map.get(&room_name.clone()).unwrap();
+
+        {
+            let room: &mut Room = server.rooms.get_mut(&room_id).unwrap();
+            room.broadcast("Silver birch against a Swedish sky".to_owned());
+        }
+        let room: &Room = server.rooms.get(&room_id).unwrap();
+        assert_eq!(room.latest_seq_num, 1);
+        assert_eq!(room.messages.len(), 1);
+        let msgs: &ServerChatMessage = room.messages.get(0).unwrap();
+        assert_eq!(msgs.player_name, "Server".to_owned());
+        assert_eq!(msgs.seq_num, 1);
+        assert_eq!(msgs.player_id, PlayerID(0xFFFFFFFFFFFFFFFF));
+    }
+
+    #[test]
+    #[should_panic]
+    fn disconnect_get_player_by_id_fails() {
+        let mut server = ServerState::new();
+        let player_name = "some player".to_owned();
+
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            player.player_id
+        };
+
+        server.handle_disconnect(player_id);
+        server.get_player(player_id);
+    }
+
+    #[test]
+    fn disconnect_get_player_by_cookie_fails() {
+        let mut server = ServerState::new();
+        let player_name = "some player".to_owned();
+
+        let (player_id, cookie) = {
+            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            (player.player_id, player.cookie.clone())
+        };
+
+        server.handle_disconnect(player_id);
+        assert_eq!(server.get_player_id_by_cookie(cookie.as_str()), None);
+    }
+
+    #[test]
+    fn disconnect_while_in_room_removes_all_traces_of_player() {
+        let mut server = ServerState::new();
+        let room_name = "some_room".to_owned();
+        let player_name = "some player".to_owned();
+
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            player.player_id
+        };
+
+        server.create_new_room(None, room_name.clone());
+        server.join_room(player_id, room_name);
+        let room_id = {
+            let room: &Room = server.get_room(player_id).unwrap();
+            assert_eq!(room.player_ids.contains(&player_id), true);
+            room.room_id
+        };
+        server.handle_disconnect(player_id);
+        // Cannot go through player_id because the player has been removed
+        let room: &Room = server.rooms.get(&room_id).unwrap();
+        assert_eq!(room.player_ids.contains(&player_id), false);
+    }
+
+    #[test]
+    fn test_is_previously_processed_packet() {
+        let mut server = ServerState::new();
+        let player_name = "some player".to_owned();
+
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            player.request_ack = Some(4);
+            player.player_id
+        };
+
+        let player_id2: PlayerID = {
+            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            player.request_ack = None;
+            player.player_id
+        };
+
+        assert_eq!(server.is_previously_processed_packet(player_id2, 0), false);
+
+        assert_eq!(server.is_previously_processed_packet(player_id, 0), true);
+        assert_eq!(server.is_previously_processed_packet(player_id, 4), true);
+        assert_eq!(server.is_previously_processed_packet(player_id, 5), false);
+    }
+
+    #[test]
+    fn test_clear_transmission_queue_on_ack() {
+        let mut server = ServerState::new();
+        let player_name = "some player".to_owned();
+
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            player.request_ack = Some(4);
+            player.player_id
+        };
+
+        for i in 0..5 {
+            let pkt = Packet::Response {
+                sequence: i,
+                request_ack: None,
+                code: ResponseCode::OK
+            };
+
+            let nm: &mut NetworkManager = server.network_map.get_mut(&player_id).unwrap();
+            nm.tx_packets.buffer_item(pkt.clone());
+        }
+
+        server.clear_transmission_queue_on_ack(player_id, None);
+        assert_eq!(server.network_map.get(&player_id).unwrap().tx_packets.len(), 5);
+        server.clear_transmission_queue_on_ack(player_id, Some(0));
+        assert_eq!(server.network_map.get(&player_id).unwrap().tx_packets.len(), 5);
+        server.clear_transmission_queue_on_ack(player_id, Some(1));
+        assert_eq!(server.network_map.get(&player_id).unwrap().tx_packets.len(), 4);
+        server.clear_transmission_queue_on_ack(player_id, Some(5));
+        assert_eq!(server.network_map.get(&player_id).unwrap().tx_packets.len(), 0);
+    }
+
+    #[test]
+    fn test_resend_expired_tx_packets_empty_server() {
+        let mut server = ServerState::new();
+
+        let (udp_tx, _) = mpsc::unbounded();
+        #[cfg(not(should_panic))]
+        server.resend_expired_tx_packets(&udp_tx);
+    }
+
+    #[test]
+    fn test_resend_expired_tx_packets() {
+        let mut server = ServerState::new();
+        let player_name = "some player".to_owned();
+
+        let player_id: PlayerID = {
+            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            player.request_ack = Some(5);
+            player.player_id
+        };
+
+
+        for i in 0..5 {
+            let pkt = Packet::Response {
+                sequence: i,
+                request_ack: None,
+                code: ResponseCode::OK
+            };
+
+            let nm: &mut NetworkManager = server.network_map.get_mut(&player_id).unwrap();
+            nm.tx_packets.buffer_item(pkt.clone());
+
+            if i < 3 {
+                let attempt: &mut NetAttempt = nm.tx_packets.attempts.back_mut().unwrap();
+                attempt.time = Instant::now() - Duration::from_secs(i+1);
+            }
+        }
+
+        let (udp_tx, _) = mpsc::unbounded();
+        server.resend_expired_tx_packets(&udp_tx);
+
+        for i in 0..5 {
+            let nm: &mut NetworkManager = server.network_map.get_mut(&player_id).unwrap();
+            let packet_retries: &NetAttempt = nm.tx_packets.attempts.get(i).unwrap();
+
+            if i >= 3 {
+                assert_eq!(packet_retries.retries, 0);
+            } else {
+                assert_eq!(packet_retries.retries, 1);
+            }
+        }
+    }
+
+    #[test]
+    fn test_process_queued_rx_packets_first_non_connect_player_packet() {
+        let mut server = ServerState::new();
+        let player_name = "some player".to_owned();
+
+        let (player_id, player_cookie): (PlayerID, String) = {
+            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            player.request_ack = Some(1);   // Player connected and we've confirmed the first transaction
+            (player.player_id, player.cookie.clone())
+        };
+
+        {
+            let pkt = Packet::Request {
+                cookie: Some(player_cookie),
+                sequence: 2,
+                response_ack: None,
+                action: RequestAction::ListPlayers
+            };
+
+            let nm: &mut NetworkManager = server.network_map.get_mut(&player_id).unwrap();
+            nm.rx_packets.buffer_item(pkt.clone());
+
+            assert_eq!(nm.tx_packets.len(), 0);
+        }
+
+        server.process_queued_rx_packets(player_id);
+
+
+        {
+            let nm: &mut NetworkManager = server.network_map.get_mut(&player_id).unwrap();
+            assert_eq!(nm.tx_packets.len(), 1);
+        }
+
+    }
+
+    #[test]
+    fn test_process_queued_rx_packets_contiguous() {
+        let mut server = ServerState::new();
+        let player_name = "some player".to_owned();
+
+        let (player_id, player_cookie): (PlayerID, String) = {
+            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            player.request_ack = Some(1);   // Player connected and we've confirmed the first transaction
+            (player.player_id, player.cookie.clone())
+        };
+
+        for i in 2..10 {
+            let pkt = Packet::Request {
+                cookie: Some(player_cookie.clone()),
+                sequence: i,
+                response_ack: None,
+                action: RequestAction::ListPlayers
+            };
+
+            let nm: &mut NetworkManager = server.network_map.get_mut(&player_id).unwrap();
+            nm.rx_packets.buffer_item(pkt.clone());
+
+            assert_eq!(nm.tx_packets.len(), 0);
+        }
+
+        server.process_queued_rx_packets(player_id);
+
+        {
+            let nm: &mut NetworkManager = server.network_map.get_mut(&player_id).unwrap();
+            assert_eq!(nm.tx_packets.len(), 8);
+        }
+
+    }
+
+    #[test]
+    fn test_process_queued_rx_packets_swiss_cheese_queue() {
+        let mut server = ServerState::new();
+        let player_name = "some player".to_owned();
+
+        let (player_id, player_cookie): (PlayerID, String) = {
+            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            player.request_ack = Some(1);   // Player connected and we've confirmed the first transaction
+            (player.player_id, player.cookie.clone())
+        };
+
+        for i in [2, 3, 4, 6, 8, 9, 10].iter() {
+            let pkt = Packet::Request {
+                cookie: Some(player_cookie.clone()),
+                sequence: *i,
+                response_ack: None,
+                action: RequestAction::ListPlayers
+            };
+
+            let nm: &mut NetworkManager = server.network_map.get_mut(&player_id).unwrap();
+            nm.rx_packets.buffer_item(pkt.clone());
+
+            assert_eq!(nm.tx_packets.len(), 0);
+        }
+
+        server.process_queued_rx_packets(player_id);
+
+        {
+            let nm: &mut NetworkManager = server.network_map.get_mut(&player_id).unwrap();
+            assert_eq!(nm.tx_packets.len(), 3); // only 2, 3, and 4 are processed
+        }
+    }
+}
+*/
+mod netwayste_client_tests {
+    use super::*;
+    use crate::client::*;
+    use std::sync::mpsc::channel as std_channel;
+
+    fn create_client_net_state() -> ClientNetState {
+        let (nw_server_response, _ggez_server_response) = std_channel::<NetwaysteEvent>();
+        let mut cns = ClientNetState::new(nw_server_response);
+        cns.server_address = Some(fake_socket_addr());
+        cns
+    }
+
+    fn fake_socket_addr() -> SocketAddr {
+        use std::net::{IpAddr, Ipv4Addr};
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 5678)
+    }
+
+    #[test]
+    fn handle_response_ok_no_request_sent() {
+        let mut client_state = create_client_net_state();
+        let result = client_state.handle_response_ok();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn handle_logged_in_verify_connection_cookie() {
+        let mut client_state = create_client_net_state();
+        client_state.name = Some("Dr. Cookie Monster, Esquire".to_owned());
+        assert_eq!(client_state.cookie, None);
+        client_state.handle_logged_in("cookie monster".to_owned(), CLIENT_VERSION.to_owned());
+        assert_eq!(client_state.cookie, Some("cookie monster".to_owned()));
+    }
+
+    #[test]
+    fn handle_incoming_chats_no_new_chat_messages() {
+        let mut client_state = create_client_net_state();
+        assert_eq!(client_state.chat_msg_seq_num, 0);
+
+        client_state.handle_incoming_chats(None);
+        assert_eq!(client_state.chat_msg_seq_num, 0);
+    }
+
+    #[test]
+    fn handle_incoming_chats_new_messages_are_older() {
+        let mut client_state = create_client_net_state();
+        client_state.chat_msg_seq_num = 10;
+
+        let mut incoming_messages = vec![];
+        for x in 0..10 {
+            let new_msg =  BroadcastChatMessage::new(x as u64, "a player".to_owned(), format!("message {}", x));
+            incoming_messages.push(new_msg);
+        }
+
+        client_state.handle_incoming_chats(Some(incoming_messages));
+        assert_eq!(client_state.chat_msg_seq_num, 10);
+    }
+
+    #[test]
+    fn handle_incoming_chats_client_is_up_to_date() {
+        let mut client_state = create_client_net_state();
+        client_state.chat_msg_seq_num = 10;
+
+        let incoming_messages = vec![ BroadcastChatMessage::new(10u64, "a player".to_owned(), format!("message {}", 10))];
+
+        client_state.handle_incoming_chats(Some(incoming_messages));
+        assert_eq!(client_state.chat_msg_seq_num, 10);
+    }
+
+    #[test]
+    #[should_panic]
+    fn handle_incoming_chats_new_messages_player_name_not_set_panics() {
+        let mut client_state = create_client_net_state();
+        client_state.chat_msg_seq_num = 10;
+
+        let incoming_messages = vec![ BroadcastChatMessage::new(11u64, "a player".to_owned(), format!("message {}", 11))];
+
+        client_state.handle_incoming_chats(Some(incoming_messages));
+    }
+
+    #[test]
+    fn handle_incoming_chats_new_messages_are_old_and_new() {
+        let mut client_state = create_client_net_state();
+        let starting_chat_seq_num = 10;
+        client_state.name = Some("client name".to_owned());
+        client_state.chat_msg_seq_num = starting_chat_seq_num;
+
+        let mut incoming_messages = vec![];
+        for x in 0..20 {
+            let new_msg =  BroadcastChatMessage::new(x as u64, "a player".to_owned(), format!("message {}", x));
+            incoming_messages.push(new_msg);
+        }
+
+        client_state.handle_incoming_chats(Some(incoming_messages));
+        assert_eq!(client_state.chat_msg_seq_num, 19);
+
+        let mut seq_num = starting_chat_seq_num+1;
+        let chat_queue = &client_state.network.rx_chat_messages.as_ref().unwrap().queue;
+        for msg in chat_queue {
+            assert_eq!(msg.chat_seq.unwrap(), seq_num);
+            seq_num+=1;
+        }
+    }
+}

--- a/netwayste/testnet.sh
+++ b/netwayste/testnet.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+#
+# Conwayste Developers © 2018
+#
+
+CLIENTLIST=( client )
+
+# $1: client or server
+# $2: command to send
+function send()
+{
+    tmux send-keys -t $1 -l "$2"
+    tmux send-keys -t $1 Enter
+    sleep 0.0001
+}
+
+# Detection lifted from
+# https://unix.stackexchange.com/questions/116539/how-to-detect-the-desktop-environment-in-a-bash-script
+function detect_kde()
+{
+    ps -e | grep -E '^.* kded4$' > /dev/null
+    if [ $? -ne 0 ];
+    then
+        return 0
+    else
+#        VERSION=`kded4 --version | grep -m 1 'KDE' | awk -F ':' '{print $2}' | awk '{print $1}'`
+#        DESKTOP="KDE"
+        return 1
+    fi
+}
+
+function tmuxkill()
+{
+    for i in ${CLIENTLIST[@]}; do
+        tmux kill-session -t $i
+    done
+    tmux kill-session -t server
+    tmux ls
+}
+
+function ConnectToServerDefaultTestRoom()
+{
+    send $1 "/connect Test$1"
+    send $1 "/new TestRoom"
+    send $1 "/join TestRoom"
+}
+
+function IssueInRoomCommands()
+{
+    rand=$((RANDOM % 3))
+    case "$rand" in
+        0)
+            send $1 "Just one really really really really really really really really really long message."
+            ;;
+        1)
+            send $1 "/list"
+            ;;
+        *)
+            send $1 "Rust makes life better."
+            send $1 "Don't you think?."
+            ;;
+    esac
+}
+
+function LeaveRooms()
+{
+    for i in ${CLIENTLIST[@]}; do
+        send $i "/leave"
+    done
+}
+
+function Disconnect()
+{
+    for i in ${CLIENTLIST[@]}; do
+        send $i "/disconnect"
+    done
+}
+
+function PrintStats()
+{
+    echo "Printing Statistics to Clients windows."
+    for i in ${CLIENTLIST[@]}; do
+        send $i "/stats"
+    done
+}
+
+function EnableTrafficControl()
+{
+    # Impose arbitrary latency to outbound UDP
+    #
+    # https://serverfault.com/questions/336089/adding-latency-to-outbound-udp-packets-with-tc
+    # http://luxik.cdi.cz/~devik/qos/htb/manual/userg.htm
+    # https://wiki.linuxfoundation.org/networking/netem?s[]=netem
+    # https://gist.github.com/keturn/541339
+    # http://home.ifi.uio.no/paalh/students/AndersMoe.pdf
+
+    #sudo tc qdisc add dev eth0 root netem delay 200ms 40ms 25% loss 15.3% 25% duplicate 1% corrupt 0.1% reorder 5% 50%
+
+    DEFAULT_PORT=2016
+    sudo tc qdisc add dev lo root handle 1: prio
+    sudo tc qdisc add dev lo parent 1:3 handle 30: netem delay 200ms 40ms 25% loss 15.3% 25% duplicate 1% corrupt 0.1% reorder 5% 50%
+    sudo tc filter add dev lo parent 1:0 protocol ip u32 match ip dport $DEFAULT_PORT 0xffff flowid 1:3
+    sudo tc filter add dev lo parent 1:0 protocol ip u32 match ip sport $DEFAULT_PORT 0xffff flowid 1:3
+    sudo tc qdisc show
+}
+
+function DisableTrafficControl()
+{
+    sudo tc qdisc del dev lo root
+}
+
+function main()
+{
+    DisableTrafficControl # Clean up from a previous session if needed
+    tmuxkill
+    cargo build
+
+    tmux new-session -d -s server "export RUST_BACKTRACE=1; export RUST_LOG=server; ./target/debug/server; read"
+    for i in ${CLIENTLIST[@]}; do
+        printf "Starting cli-client $i"
+        tmux new-session -d -s $i "export RUST_BACKTRACE=1; export RUST_LOG=client; ./target/debug/cli-client; read"
+    done
+
+    echo "Listing sessions..."
+    tmux ls
+
+    echo "Launching Terminal Tmux Windows..."
+    if detect_kde;
+    then
+        for i in ${CLIENTLIST[@]}; do
+            konsole --noclose -e tmux attach-session -t $i &
+        done
+        konsole --noclose -e tmux attach-session -t server &
+    else
+    # For others environments swap in your favorite terminal
+        echo "Your terminal environment isn't specified. Open me up and add support."
+        exit 0
+    fi
+
+    echo "Attached to tmux-sessions."
+    for i in ${CLIENTLIST[@]}; do
+        ConnectToServerDefaultTestRoom $i
+    done
+
+    # Delay to start tmux logging
+    sleep 10
+
+    echo "Enabling Traffic Control..."
+    EnableTrafficControl
+
+    # First basic test... spam 500 /list and chat messages
+    roomCmdCount=500
+
+    echo "Basic test: Spam $roomCmdCount /list and chat messages"
+
+    until [[ $roomCmdCount -eq 0 ]];
+    do
+        for i in ${CLIENTLIST[@]}; do
+            IssueInRoomCommands $i
+        done
+        roomCmdCount=$((roomCmdCount-1))
+    done
+    echo "....Done."
+
+    echo "Wait to disable Traffic Control..."
+    sleep 60
+    echo "Disabling Traffic Control..."
+    DisableTrafficControl
+
+    PrintStats
+    LeaveRooms
+    #Disconnect
+}
+
+main


### PR DESCRIPTION
# Subtree-merging in libconway and netwayste
## Instructions
Move netwayste and libconway outside the repos to some backup dir:
```
mkdir ../old_submods &&
  mv netwayste libconway ../old_submods
```
Delete the submodule metadata in this repo:
```
git submodule deinit --all
```
Move the ex-submodules' `.git` directories back where they belong:
```
# libconway:
rm ../old_submods/libconway/.git &&
  mv .git/modules/libconway ../old_submods/libconway/.git &&
  sed -i'' /worktree/d ../old_submods/libconway/.git/config
# netwayste:
rm ../old_submods/netwayste/.git &&
  mv .git/modules/netwayste ../old_submods/netwayste/.git &&
  sed -i'' /worktree/d ../old_submods/netwayste/.git/config
```
Pull in the subtree-merge changes:
```
git checkout <branch>
git pull
```