### PR TITLE
GUI fixes

### DIFF
--- a/conwayste/src/client.rs
+++ b/conwayste/src/client.rs
@@ -300,8 +300,8 @@ fn init_title_screen(s: &mut MainState) -> Result<(), ()> {
 
     let resolution = s.video_settings.get_active_resolution();
     // let resolution = (DEFAULT_SCREEN_WIDTH, DEFAULT_SCREEN_HEIGHT);
-    let win_width  = (resolution.0 / DEFAULT_ZOOM_LEVEL) as isize; // cells
-    let win_height = (resolution.1 / DEFAULT_ZOOM_LEVEL) as isize; // cells
+    let win_width  = (resolution.0 as f32 / DEFAULT_ZOOM_LEVEL) as isize; // cells
+    let win_height = (resolution.1 as f32 / DEFAULT_ZOOM_LEVEL) as isize; // cells
     let player_id = 0;   // hardcoded for this intro
 
     let letter_width = 5;

--- a/conwayste/src/client.rs
+++ b/conwayste/src/client.rs
@@ -610,6 +610,7 @@ impl EventHandler for MainState {
             height,
         );
         if self.uni_draw_params.player_id < 0 {
+            self.intro_viewport.set_dimensions(width, height);
             self.center_intro_viewport(width, height);
         }
         graphics::set_screen_coordinates(ctx, new_rect).unwrap();

--- a/conwayste/src/client.rs
+++ b/conwayste/src/client.rs
@@ -1194,7 +1194,6 @@ fn init_title_screen(s: &mut MainState) -> Result<(), ()> {
     // 2) Determine height and width of the window
     // 3) Center it
     // 4) get offset for row and column to draw at
-    // 5) update universe draw parameters
 
     let resolution = s.video_settings.get_active_resolution();
     let win_width  = (resolution.0 as f32 / DEFAULT_ZOOM_LEVEL) as isize; // cells

--- a/conwayste/src/client.rs
+++ b/conwayste/src/client.rs
@@ -817,7 +817,7 @@ impl MainState {
         });
 
         if let Some(clipped_rect) = utils::Graphics::intersection(full_rect, self.viewport.get_viewport()) {
-            let origin = graphics::DrawParam::new().dest(clipped_rect.point());
+            let origin = graphics::DrawParam::new().dest(Point2::new(0.0, 0.0));
             let rectangle = graphics::Mesh::new_rectangle(ctx, GRID_DRAW_STYLE.to_draw_mode(), clipped_rect, draw_params.fg_color)?;
 
             graphics::draw(ctx, &rectangle, origin)?;

--- a/conwayste/src/client.rs
+++ b/conwayste/src/client.rs
@@ -287,7 +287,7 @@ impl MainState {
 
         // On first-run, use default supported resolution
         let (w, h) = config.get_resolution();
-        vs.set_active_resolution(ctx, w as u32, h as u32)?;
+        vs.set_active_resolution(ctx, video::Resolution{w, h})?;
 
         let is_fullscreen = config.get().video.fullscreen;
         vs.is_fullscreen = is_fullscreen;
@@ -608,13 +608,13 @@ impl EventHandler for MainState {
             height,
         );
         graphics::set_screen_coordinates(ctx, new_rect).unwrap();
-        self.viewport.set_dimensions(width as u32, height as u32);
+        self.viewport.set_dimensions(width, height);
         if self.video_settings.is_fullscreen {
             debug!("not saving resolution to config because is_fullscreen is true");
         } else {
-            self.config.set_resolution(width as u32, height as u32);
+            self.config.set_resolution(width, height);
         }
-        self.video_settings.resolution = (width as u32, height as u32);
+        self.video_settings.resolution = video::Resolution{w: width, h: height};
     }
 
     fn quit_event(&mut self, _ctx: &mut Context) -> bool {
@@ -1196,8 +1196,8 @@ fn init_title_screen(s: &mut MainState) -> Result<(), ()> {
     // 4) get offset for row and column to draw at
 
     let resolution = s.video_settings.get_active_resolution();
-    let win_width  = (resolution.0 as f32 / DEFAULT_ZOOM_LEVEL) as isize; // cells
-    let win_height = (resolution.1 as f32 / DEFAULT_ZOOM_LEVEL) as isize; // cells
+    let win_width  = (resolution.w / DEFAULT_ZOOM_LEVEL) as isize; // cells
+    let win_height = (resolution.h / DEFAULT_ZOOM_LEVEL) as isize; // cells
     let player_id = 0;   // hardcoded for this intro
 
     let letter_width = 5;

--- a/conwayste/src/client.rs
+++ b/conwayste/src/client.rs
@@ -645,8 +645,8 @@ impl EventHandler for MainState {
                           _ctx: &mut Context,
                           x: f32,
                           y: f32,
-                          dx: f32,
-                          dy: f32
+                          _dx: f32,
+                          _dy: f32
                           ) {
         match self.stage {
             Stage::Intro(_) => {}
@@ -719,10 +719,8 @@ impl EventHandler for MainState {
         );
         graphics::set_screen_coordinates(ctx, new_rect).unwrap();
         self.viewport.set_dimensions(width as u32, height as u32);
-        self.config.modify(|settings| {
-            settings.video.resolution_x = width as u32;
-            settings.video.resolution_y = height as u32;
-        });
+        self.config.set_resolution(width as u32, height as u32);
+        self.video_settings.resolution = (width as u32, height as u32);
     }
 
     fn quit_event(&mut self, _ctx: &mut Context) -> bool {
@@ -774,7 +772,7 @@ impl MainState {
             // intro
             &self.intro_viewport
         };
-        let viewport_rect = viewport.get_viewport();
+        let viewport_rect = viewport.get_rect();
 
         // grid background
         let rectangle = graphics::Mesh::new_rectangle(ctx,
@@ -814,7 +812,7 @@ impl MainState {
             }
         });
 
-        if let Some(clipped_rect) = utils::Graphics::intersection(full_rect, self.viewport.get_viewport()) {
+        if let Some(clipped_rect) = utils::Graphics::intersection(full_rect, viewport_rect) {
             let origin = graphics::DrawParam::new().dest(Point2::new(0.0, 0.0));
             let rectangle = graphics::Mesh::new_rectangle(ctx, GRID_DRAW_STYLE.to_draw_mode(), clipped_rect, draw_params.fg_color)?;
 
@@ -989,7 +987,7 @@ impl MainState {
                     input::InputAction::MouseClick(MouseButton::Right, _x, _y) => {}
                     input::InputAction::MouseMovement(_x, _y) => {}
                     input::InputAction::MouseDrag(MouseButton::Left, _x, _y) => {}
-                    input::InputAction::MouseRelease(_) => {}
+                    /*input::InputAction::MouseRelease(_) => {}*/
 
                     input::InputAction::KeyPress(keycode, repeat) => {
                         if !self.menu_sys.get_controls().is_menu_key_pressed() {
@@ -1163,6 +1161,8 @@ impl MainState {
                                 }
                             }
                             menu::MenuItemIdentifier::Resolution => {
+                                // NO-OP; menu item is effectively read-only
+                                /*
                                 if !self.escape_key_pressed {
                                     self.video_settings.advance_to_next_resolution(ctx);
 
@@ -1172,6 +1172,7 @@ impl MainState {
                                     self.config.set_resolution(w, h);
                                     self.viewport.set_dimensions(w, h);
                                 }
+                                */
                             }
                             _ => {}
                         }

--- a/conwayste/src/client.rs
+++ b/conwayste/src/client.rs
@@ -300,8 +300,6 @@ fn init_title_screen(s: &mut MainState) -> Result<(), ()> {
     // 4) get offset for row and column to draw at
 
     let resolution = s.video_settings.get_active_resolution();
-    debug!("init_title_screen: resolution is {:?}", resolution); //XXX
-    // let resolution = (DEFAULT_SCREEN_WIDTH, DEFAULT_SCREEN_HEIGHT);
     let win_width  = (resolution.0 as f32 / DEFAULT_ZOOM_LEVEL) as isize; // cells
     let win_height = (resolution.1 as f32 / DEFAULT_ZOOM_LEVEL) as isize; // cells
     let player_id = 0;   // hardcoded for this intro
@@ -1154,7 +1152,7 @@ impl MainState {
                             menu::MenuItemIdentifier::Fullscreen => {
                                 if !self.escape_key_pressed {
                                     // toggle
-                                    let mut is_fullscreen = !self.video_settings.is_fullscreen;
+                                    let is_fullscreen = !self.video_settings.is_fullscreen;
                                     self.video_settings.is_fullscreen = is_fullscreen;
                                     // actually update screen based on what we toggled
                                     self.video_settings.update_fullscreen(ctx).unwrap(); // TODO: rollback if fail

--- a/conwayste/src/client.rs
+++ b/conwayste/src/client.rs
@@ -94,8 +94,8 @@ struct MainState {
     menu_sys:            menu::MenuSystem,
     video_settings:      video::VideoSettings,
     config:              config::Config,
-    viewport:            viewport::Viewport,
-    intro_viewport:      viewport::Viewport,
+    viewport:            viewport::GridView,
+    intro_viewport:      viewport::GridView,
     input_manager:       input::InputManager,
     net_worker:          Option<network::ConwaysteNetWorker>,
     recvd_first_resize:  bool,       // work around an apparent ggez bug where the first resize event is bogus
@@ -293,12 +293,12 @@ impl MainState {
         vs.is_fullscreen = is_fullscreen;
         vs.update_fullscreen(ctx)?;
 
-        let intro_viewport = viewport::Viewport::new(
+        let intro_viewport = viewport::GridView::new(
             DEFAULT_ZOOM_LEVEL,
             universe_width_in_cells,
             universe_height_in_cells);
 
-        let viewport = viewport::Viewport::new(
+        let viewport = viewport::GridView::new(
             config.get().gameplay.zoom,
             universe_width_in_cells,
             universe_height_in_cells);

--- a/conwayste/src/client.rs
+++ b/conwayste/src/client.rs
@@ -257,149 +257,6 @@ fn init_patterns(s: &mut MainState) -> ConwayResult<()> {
 }
 
 
-enum Orientation {
-    Vertical,
-    Horizontal,
-    Diagonal
-}
-
-// Toggle a horizontal, vertical, or diagonal line, as player with index 0. This is only used for
-// the intro currently. Part or all of the line can be outside of the Universe; if this is the
-// case, only the parts inside the Universe are toggled.
-fn toggle_line(s: &mut MainState, orientation: Orientation, col: isize, row: isize, width: isize, height: isize) {
-    let player_id = 0;   // hardcode player ID, since this is just for the intro
-    match orientation {
-        Orientation::Vertical => {
-            for r in row..(height + row) {
-                if col < 0 || r < 0 { continue }
-                let _ = s.intro_uni.toggle(col as usize, r as usize, player_id);  // `let _ =`, because we don't care about errors
-            }
-        }
-        Orientation::Horizontal => {
-            for c in col..(width + col) {
-                if c < 0 || row < 0 { continue }
-                let _ = s.intro_uni.toggle(c as usize, row as usize, player_id);
-            }
-        }
-        Orientation::Diagonal => {
-            for x in 0..(width - 1) {
-                let c: isize = col+x;
-                let r: isize = row+x;
-                if c < 0 || r < 0 { continue; }
-                let _ = s.intro_uni.toggle(c as usize, r as usize, player_id);
-            }
-        }
-    }
-}
-
-fn init_title_screen(s: &mut MainState) -> Result<(), ()> {
-
-    // 1) Calculate width and height of rectangle which represents the intro logo
-    // 2) Determine height and width of the window
-    // 3) Center it
-    // 4) get offset for row and column to draw at
-
-    let resolution = s.video_settings.get_active_resolution();
-    let win_width  = (resolution.0 as f32 / DEFAULT_ZOOM_LEVEL) as isize; // cells
-    let win_height = (resolution.1 as f32 / DEFAULT_ZOOM_LEVEL) as isize; // cells
-    let player_id = 0;   // hardcoded for this intro
-
-    let letter_width = 5;
-    let letter_height = 6;
-
-    // 9 letters; account for width and spacing
-    let logo_width = 9*5 + 9*5;
-    let logo_height = letter_height;
-
-    let mut offset_col = win_width/2  - logo_width/2;
-    let     offset_row = win_height/2 - logo_height/2;
-
-    let toggle = |s_: &mut MainState, col: isize, row: isize| {
-        if col >= 0 || row >= 0 {
-            let _ = s_.intro_uni.toggle(col as usize, row as usize, player_id); // we don't care if an error is returned
-        }
-    };
-
-    // C
-    toggle_line(s, Orientation::Horizontal, offset_col, offset_row, letter_width,letter_height);
-    toggle_line(s, Orientation::Vertical, offset_col, offset_row+1, letter_width,letter_height);
-    toggle_line(s, Orientation::Horizontal, offset_col+1, offset_row+letter_height, letter_width-1,letter_height);
-
-    offset_col += 2*letter_width;
-
-    // O
-    toggle_line(s, Orientation::Horizontal, offset_col, offset_row, letter_width,letter_height);
-    toggle_line(s, Orientation::Vertical, offset_col, offset_row+1, letter_width,letter_height);
-    toggle_line(s, Orientation::Horizontal, offset_col+1, offset_row+letter_height, letter_width-1,letter_height);
-    toggle_line(s, Orientation::Vertical, offset_col+letter_width-1, offset_row+1, letter_width,letter_height-1);
-
-    offset_col += 2*letter_width;
-
-    // N
-    toggle_line(s, Orientation::Vertical, offset_col, offset_row, letter_width,letter_height+1);
-    toggle_line(s, Orientation::Vertical, offset_col+letter_width, offset_row, letter_width,letter_height+1);
-    toggle_line(s, Orientation::Diagonal, offset_col+1, offset_row+1, letter_width,letter_height);
-
-    offset_col += 2*letter_width;
-
-    // W
-    toggle_line(s, Orientation::Vertical, offset_col, offset_row, letter_width,letter_height);
-    toggle_line(s, Orientation::Vertical, offset_col+letter_width, offset_row, letter_width,letter_height+1);
-    toggle_line(s, Orientation::Horizontal, offset_col, offset_row+letter_height, letter_width,letter_height);
-    toggle(s, offset_col+letter_width/2, offset_row+letter_height-1);
-    toggle(s, offset_col+letter_width/2, offset_row+letter_height-2);
-    toggle(s, offset_col+letter_width/2+1, offset_row+letter_height-1);
-    toggle(s, offset_col+letter_width/2+1, offset_row+letter_height-2);
-
-    offset_col += 2*letter_width;
-
-    // A
-    toggle_line(s, Orientation::Vertical, offset_col, offset_row+1, letter_width,letter_height);
-    toggle_line(s, Orientation::Vertical, offset_col+letter_width, offset_row, letter_width,letter_height+1);
-    toggle_line(s, Orientation::Horizontal, offset_col, offset_row, letter_width,letter_height);
-    toggle_line(s, Orientation::Horizontal, offset_col+1, offset_row+letter_height/2, letter_width-1,letter_height);
-
-    offset_col += 2*letter_width;
-
-    // Y
-    toggle(s, offset_col, offset_row);
-    toggle(s, offset_col, offset_row+1);
-    toggle(s, offset_col, offset_row+2);
-    toggle(s, offset_col+letter_height, offset_row);
-    toggle(s, offset_col+letter_height, offset_row+1);
-    toggle(s, offset_col+letter_height, offset_row+2);
-    toggle_line(s, Orientation::Vertical, offset_col+letter_height/2, offset_row+letter_width/2+2, letter_width,letter_height-3);
-    toggle_line(s, Orientation::Horizontal, offset_col, offset_row+letter_height/2, letter_width+2,letter_height-1);
-
-    offset_col += 2*letter_width;
-
-    // S
-    toggle_line(s, Orientation::Horizontal, offset_col, offset_row, letter_width,letter_height);
-    toggle_line(s, Orientation::Horizontal, offset_col, offset_row+letter_height, letter_width,letter_height);
-    toggle_line(s, Orientation::Horizontal, offset_col, offset_row+letter_height/2, letter_width,letter_height);
-    toggle(s, offset_col, offset_row+1);
-    toggle(s, offset_col, offset_row+2);
-    toggle(s, offset_col+letter_width-1, offset_row+4);
-    toggle(s, offset_col+letter_width-1, offset_row+5);
-
-    offset_col += 2*letter_width;
-
-    // T
-    toggle_line(s, Orientation::Horizontal, offset_col, offset_row, letter_width,letter_height);
-    toggle_line(s, Orientation::Vertical, offset_col+letter_width/2, offset_row+1, letter_width,letter_height);
-
-    offset_col += 2*letter_width;
-
-    // E
-    toggle_line(s, Orientation::Horizontal, offset_col, offset_row, letter_width,letter_height);
-    toggle_line(s, Orientation::Vertical, offset_col, offset_row+1, letter_width,letter_height);
-    toggle_line(s, Orientation::Horizontal, offset_col+1, offset_row+letter_height, letter_width-1,letter_height);
-    toggle_line(s, Orientation::Horizontal, offset_col+1, offset_row+letter_height/2, letter_width-2,letter_height);
-
-    Ok(())
-}
-
-
 // Then we implement the `ggez::game::GameState` trait on it, which
 // requires callbacks for creating the game state, updating it each
 // frame, and drawing it.
@@ -1278,6 +1135,148 @@ impl MainState {
             });
         }
     }
+}
+
+enum Orientation {
+    Vertical,
+    Horizontal,
+    Diagonal
+}
+
+// Toggle a horizontal, vertical, or diagonal line, as player with index 0. This is only used for
+// the intro currently. Part or all of the line can be outside of the Universe; if this is the
+// case, only the parts inside the Universe are toggled.
+fn toggle_line(s: &mut MainState, orientation: Orientation, col: isize, row: isize, width: isize, height: isize) {
+    let player_id = 0;   // hardcode player ID, since this is just for the intro
+    match orientation {
+        Orientation::Vertical => {
+            for r in row..(height + row) {
+                if col < 0 || r < 0 { continue }
+                let _ = s.intro_uni.toggle(col as usize, r as usize, player_id);  // `let _ =`, because we don't care about errors
+            }
+        }
+        Orientation::Horizontal => {
+            for c in col..(width + col) {
+                if c < 0 || row < 0 { continue }
+                let _ = s.intro_uni.toggle(c as usize, row as usize, player_id);
+            }
+        }
+        Orientation::Diagonal => {
+            for x in 0..(width - 1) {
+                let c: isize = col+x;
+                let r: isize = row+x;
+                if c < 0 || r < 0 { continue; }
+                let _ = s.intro_uni.toggle(c as usize, r as usize, player_id);
+            }
+        }
+    }
+}
+
+fn init_title_screen(s: &mut MainState) -> Result<(), ()> {
+
+    // 1) Calculate width and height of rectangle which represents the intro logo
+    // 2) Determine height and width of the window
+    // 3) Center it
+    // 4) get offset for row and column to draw at
+
+    let resolution = s.video_settings.get_active_resolution();
+    let win_width  = (resolution.0 as f32 / DEFAULT_ZOOM_LEVEL) as isize; // cells
+    let win_height = (resolution.1 as f32 / DEFAULT_ZOOM_LEVEL) as isize; // cells
+    let player_id = 0;   // hardcoded for this intro
+
+    let letter_width = 5;
+    let letter_height = 6;
+
+    // 9 letters; account for width and spacing
+    let logo_width = 9*5 + 9*5;
+    let logo_height = letter_height;
+
+    let mut offset_col = win_width/2  - logo_width/2;
+    let     offset_row = win_height/2 - logo_height/2;
+
+    let toggle = |s_: &mut MainState, col: isize, row: isize| {
+        if col >= 0 || row >= 0 {
+            let _ = s_.intro_uni.toggle(col as usize, row as usize, player_id); // we don't care if an error is returned
+        }
+    };
+
+    // C
+    toggle_line(s, Orientation::Horizontal, offset_col, offset_row, letter_width,letter_height);
+    toggle_line(s, Orientation::Vertical, offset_col, offset_row+1, letter_width,letter_height);
+    toggle_line(s, Orientation::Horizontal, offset_col+1, offset_row+letter_height, letter_width-1,letter_height);
+
+    offset_col += 2*letter_width;
+
+    // O
+    toggle_line(s, Orientation::Horizontal, offset_col, offset_row, letter_width,letter_height);
+    toggle_line(s, Orientation::Vertical, offset_col, offset_row+1, letter_width,letter_height);
+    toggle_line(s, Orientation::Horizontal, offset_col+1, offset_row+letter_height, letter_width-1,letter_height);
+    toggle_line(s, Orientation::Vertical, offset_col+letter_width-1, offset_row+1, letter_width,letter_height-1);
+
+    offset_col += 2*letter_width;
+
+    // N
+    toggle_line(s, Orientation::Vertical, offset_col, offset_row, letter_width,letter_height+1);
+    toggle_line(s, Orientation::Vertical, offset_col+letter_width, offset_row, letter_width,letter_height+1);
+    toggle_line(s, Orientation::Diagonal, offset_col+1, offset_row+1, letter_width,letter_height);
+
+    offset_col += 2*letter_width;
+
+    // W
+    toggle_line(s, Orientation::Vertical, offset_col, offset_row, letter_width,letter_height);
+    toggle_line(s, Orientation::Vertical, offset_col+letter_width, offset_row, letter_width,letter_height+1);
+    toggle_line(s, Orientation::Horizontal, offset_col, offset_row+letter_height, letter_width,letter_height);
+    toggle(s, offset_col+letter_width/2, offset_row+letter_height-1);
+    toggle(s, offset_col+letter_width/2, offset_row+letter_height-2);
+    toggle(s, offset_col+letter_width/2+1, offset_row+letter_height-1);
+    toggle(s, offset_col+letter_width/2+1, offset_row+letter_height-2);
+
+    offset_col += 2*letter_width;
+
+    // A
+    toggle_line(s, Orientation::Vertical, offset_col, offset_row+1, letter_width,letter_height);
+    toggle_line(s, Orientation::Vertical, offset_col+letter_width, offset_row, letter_width,letter_height+1);
+    toggle_line(s, Orientation::Horizontal, offset_col, offset_row, letter_width,letter_height);
+    toggle_line(s, Orientation::Horizontal, offset_col+1, offset_row+letter_height/2, letter_width-1,letter_height);
+
+    offset_col += 2*letter_width;
+
+    // Y
+    toggle(s, offset_col, offset_row);
+    toggle(s, offset_col, offset_row+1);
+    toggle(s, offset_col, offset_row+2);
+    toggle(s, offset_col+letter_height, offset_row);
+    toggle(s, offset_col+letter_height, offset_row+1);
+    toggle(s, offset_col+letter_height, offset_row+2);
+    toggle_line(s, Orientation::Vertical, offset_col+letter_height/2, offset_row+letter_width/2+2, letter_width,letter_height-3);
+    toggle_line(s, Orientation::Horizontal, offset_col, offset_row+letter_height/2, letter_width+2,letter_height-1);
+
+    offset_col += 2*letter_width;
+
+    // S
+    toggle_line(s, Orientation::Horizontal, offset_col, offset_row, letter_width,letter_height);
+    toggle_line(s, Orientation::Horizontal, offset_col, offset_row+letter_height, letter_width,letter_height);
+    toggle_line(s, Orientation::Horizontal, offset_col, offset_row+letter_height/2, letter_width,letter_height);
+    toggle(s, offset_col, offset_row+1);
+    toggle(s, offset_col, offset_row+2);
+    toggle(s, offset_col+letter_width-1, offset_row+4);
+    toggle(s, offset_col+letter_width-1, offset_row+5);
+
+    offset_col += 2*letter_width;
+
+    // T
+    toggle_line(s, Orientation::Horizontal, offset_col, offset_row, letter_width,letter_height);
+    toggle_line(s, Orientation::Vertical, offset_col+letter_width/2, offset_row+1, letter_width,letter_height);
+
+    offset_col += 2*letter_width;
+
+    // E
+    toggle_line(s, Orientation::Horizontal, offset_col, offset_row, letter_width,letter_height);
+    toggle_line(s, Orientation::Vertical, offset_col, offset_row+1, letter_width,letter_height);
+    toggle_line(s, Orientation::Horizontal, offset_col+1, offset_row+letter_height, letter_width-1,letter_height);
+    toggle_line(s, Orientation::Horizontal, offset_col+1, offset_row+letter_height/2, letter_width-2,letter_height);
+
+    Ok(())
 }
 
 

--- a/conwayste/src/client.rs
+++ b/conwayste/src/client.rs
@@ -289,7 +289,7 @@ impl MainState {
 
         // On first-run, use default supported resolution
         let (w, h) = config.get_resolution();
-        vs.set_active_resolution(ctx, video::Resolution{w, h})?;
+        vs.set_resolution(ctx, video::Resolution{w, h}, true)?;
 
         let is_fullscreen = config.get().video.fullscreen;
         vs.is_fullscreen = is_fullscreen;
@@ -616,7 +616,7 @@ impl EventHandler for MainState {
         } else {
             self.config.set_resolution(width, height);
         }
-        self.video_settings.resolution = video::Resolution{w: width, h: height};
+        self.video_settings.set_resolution(ctx, video::Resolution{w: width, h: height}, false).unwrap();
     }
 
     fn quit_event(&mut self, _ctx: &mut Context) -> bool {
@@ -1043,7 +1043,7 @@ impl MainState {
 
                                     // Update the configuration file and resize the viewing
                                     // screen
-                                    let (w,h) = self.video_settings.get_active_resolution();
+                                    let (w,h) = self.video_settings.get_resolution();
                                     self.config.set_resolution(w, h);
                                     self.viewport.set_dimensions(w, h);
                                 }
@@ -1198,7 +1198,7 @@ fn init_title_screen(s: &mut MainState) -> Result<(), ()> {
     // 3) Center it
     // 4) get offset for row and column to draw at
 
-    let resolution = s.video_settings.get_active_resolution();
+    let resolution = s.video_settings.get_resolution();
     let win_width  = (resolution.w / DEFAULT_ZOOM_LEVEL) as isize; // cells
     let win_height = (resolution.h / DEFAULT_ZOOM_LEVEL) as isize; // cells
     let player_id = 0;   // hardcoded for this intro

--- a/conwayste/src/client.rs
+++ b/conwayste/src/client.rs
@@ -779,6 +779,7 @@ impl MainState {
         let visibility = if draw_params.player_id >= 0 {
             Some(draw_params.player_id as usize) //XXX, Player One
         } else {
+            // used for random coloring in intro
             Some(0)
         };
 

--- a/conwayste/src/client.rs
+++ b/conwayste/src/client.rs
@@ -584,7 +584,11 @@ impl EventHandler for MainState {
         );
         graphics::set_screen_coordinates(ctx, new_rect).unwrap();
         self.viewport.set_dimensions(width as u32, height as u32);
-        self.config.set_resolution(width as u32, height as u32);
+        if self.video_settings.is_fullscreen {
+            debug!("not saving resolution to config because is_fullscreen is true");
+        } else {
+            self.config.set_resolution(width as u32, height as u32);
+        }
         self.video_settings.resolution = (width as u32, height as u32);
     }
 

--- a/conwayste/src/client.rs
+++ b/conwayste/src/client.rs
@@ -270,6 +270,8 @@ impl MainState {
     fn new(ctx: &mut Context) -> GameResult<MainState> {
         let universe_width_in_cells  = 256;
         let universe_height_in_cells = 120;
+        let intro_universe_width_in_cells  = 256;
+        let intro_universe_height_in_cells = 256;
 
         let mut config = config::Config::new();
         config.load_or_create_default().map_err(|e| {
@@ -295,8 +297,8 @@ impl MainState {
 
         let intro_viewport = viewport::GridView::new(
             DEFAULT_ZOOM_LEVEL,
-            universe_width_in_cells,
-            universe_height_in_cells);
+            intro_universe_width_in_cells,
+            intro_universe_height_in_cells);
 
         let viewport = viewport::GridView::new(
             config.get().gameplay.zoom,
@@ -354,8 +356,8 @@ impl MainState {
         {
             let player = PlayerBuilder::new(Region::new(0, 0, 256, 256));
             BigBang::new()
-                .width(256)
-                .height(256)
+                .width(intro_universe_width_in_cells)
+                .height(intro_universe_height_in_cells)
                 .fog_radius(100)
                 .add_players(vec![player])
                 .birth()
@@ -1188,6 +1190,7 @@ fn toggle_line(s: &mut MainState, orientation: Orientation, col: isize, row: isi
     }
 }
 
+// TODO: this should really have "intro" in its name!
 fn init_title_screen(s: &mut MainState) -> Result<(), ()> {
 
     // 1) Calculate width and height of rectangle which represents the intro logo

--- a/conwayste/src/client.rs
+++ b/conwayste/src/client.rs
@@ -97,6 +97,7 @@ struct MainState {
     intro_viewport:      viewport::Viewport,
     input_manager:       input::InputManager,
     net_worker:          Option<network::ConwaysteNetWorker>,
+    recvd_first_resize:  bool,       // work around an apparent ggez bug where the first resize event is bogus
 
     // Input state
     single_step:         bool,
@@ -378,6 +379,7 @@ impl MainState {
             intro_viewport:      intro_viewport,
             input_manager:       input::InputManager::new(input::InputDeviceType::PRIMARY),
             net_worker:          None,
+            recvd_first_resize:  false,
             single_step:         false,
             arrow_input:         (0, 0),
             drag_draw:           None,
@@ -567,7 +569,13 @@ impl EventHandler for MainState {
     }
 
     fn resize_event(&mut self, ctx: &mut Context, width: f32, height: f32) {
-        debug!("Resized screen to {}, {}", width, height);
+        if !self.recvd_first_resize {
+            // Work around apparent ggez bug -- bogus first resize_event
+            debug!("IGNORING resize_event: {}, {}", width, height);
+            self.recvd_first_resize = true;
+            return;
+        }
+        debug!("resize_event: {}, {}", width, height);
         let new_rect = graphics::Rect::new(
             0.0,
             0.0,

--- a/conwayste/src/client.rs
+++ b/conwayste/src/client.rs
@@ -616,7 +616,7 @@ impl EventHandler for MainState {
                 self.draw_intro(ctx)?;
             }
             Stage::Menu => {
-                self.menu_sys.draw_menu(&self.video_settings, ctx, self.first_gen_was_drawn);
+                self.menu_sys.draw_menu(&self.video_settings, ctx, self.first_gen_was_drawn)?;
             }
             Stage::Run => {
                 self.draw_universe(ctx)?;

--- a/conwayste/src/client.rs
+++ b/conwayste/src/client.rs
@@ -609,6 +609,9 @@ impl EventHandler for MainState {
             width,
             height,
         );
+        if self.uni_draw_params.player_id < 0 {
+            self.center_intro_viewport(width, height);
+        }
         graphics::set_screen_coordinates(ctx, new_rect).unwrap();
         self.viewport.set_dimensions(width, height);
         if self.video_settings.is_fullscreen {
@@ -693,7 +696,7 @@ impl MainState {
                 self.color_settings.get_random_color()
             };
 
-            if let Some(rect) = viewport.get_screen_area(viewport::Cell::new(col, row)) {
+            if let Some(rect) = viewport.window_coords_from_game(viewport::Cell::new(col, row)) {
                 let p = graphics::DrawParam::new()
                     .dest(Point2::new(rect.x, rect.y))
                     .scale(Vector2::new(rect.w, rect.h))
@@ -722,6 +725,14 @@ impl MainState {
         }
 
         Ok(())
+    }
+
+    fn center_intro_viewport(&mut self, win_width: f32, win_height: f32) {
+        let grid_width = self.intro_viewport.grid_width();
+        let grid_height = self.intro_viewport.grid_height();
+        let target_center_x = win_width/2.0 - grid_width/2.0;
+        let target_center_y = win_height/2.0 - grid_height/2.0;
+        self.intro_viewport.set_origin(Point2::new(target_center_x, target_center_y));
     }
 
     fn draw_intro(&mut self, ctx: &mut Context) -> GameResult<()>{
@@ -1198,9 +1209,6 @@ fn init_title_screen(s: &mut MainState) -> Result<(), ()> {
     // 3) Center it
     // 4) get offset for row and column to draw at
 
-    let resolution = s.video_settings.get_resolution();
-    let win_width  = (resolution.w / DEFAULT_ZOOM_LEVEL) as isize; // cells
-    let win_height = (resolution.h / DEFAULT_ZOOM_LEVEL) as isize; // cells
     let player_id = 0;   // hardcoded for this intro
 
     let letter_width = 5;
@@ -1210,8 +1218,11 @@ fn init_title_screen(s: &mut MainState) -> Result<(), ()> {
     let logo_width = 9*5 + 9*5;
     let logo_height = letter_height;
 
-    let mut offset_col = win_width/2  - logo_width/2;
-    let     offset_row = win_height/2 - logo_height/2;
+    let uni_width = s.intro_uni.width() as isize;
+    let uni_height = s.intro_uni.height() as isize;
+
+    let mut offset_col = uni_width/2  - logo_width/2;
+    let     offset_row = uni_height/2 - logo_height/2;
 
     let toggle = |s_: &mut MainState, col: isize, row: isize| {
         if col >= 0 || row >= 0 {

--- a/conwayste/src/config.rs
+++ b/conwayste/src/config.rs
@@ -102,8 +102,8 @@ impl Default for UserNetSettings {
 /// Graphics-related settings like resolution, fullscreen, and more!
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct VideoSettings {
-    pub resolution_x: i32,
-    pub resolution_y: i32,
+    pub resolution_x: u32,
+    pub resolution_y: u32,
     pub fullscreen: bool,
 }
 
@@ -396,7 +396,11 @@ impl Config {
     }
 
     /////////// Convenience Methods ///////////
-    pub fn set_resolution(&mut self, w: i32, h: i32) {
+    pub fn get_resolution(&self) -> (u32, u32) {
+        (self.settings.video.resolution_x, self.settings.video.resolution_y)
+    }
+
+    pub fn set_resolution(&mut self, w: u32, h: u32) {
         self.modify(|settings| {
             settings.video.resolution_x = w;
             settings.video.resolution_y = h;

--- a/conwayste/src/config.rs
+++ b/conwayste/src/config.rs
@@ -102,16 +102,16 @@ impl Default for UserNetSettings {
 /// Graphics-related settings like resolution, fullscreen, and more!
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct VideoSettings {
-    pub resolution_x: u32,
-    pub resolution_y: u32,
+    pub resolution_x: f32,
+    pub resolution_y: f32,
     pub fullscreen: bool,
 }
 
 impl Default for VideoSettings {
     fn default() -> Self {
         VideoSettings {
-            resolution_x: 1024,
-            resolution_y: 768,
+            resolution_x: 1024.0,
+            resolution_y: 768.0,
             fullscreen: false,
         }
     }
@@ -396,11 +396,11 @@ impl Config {
     }
 
     /////////// Convenience Methods ///////////
-    pub fn get_resolution(&self) -> (u32, u32) {
+    pub fn get_resolution(&self) -> (f32, f32) {
         (self.settings.video.resolution_x, self.settings.video.resolution_y)
     }
 
-    pub fn set_resolution(&mut self, w: u32, h: u32) {
+    pub fn set_resolution(&mut self, w: f32, h: f32) {
         self.modify(|settings| {
             settings.video.resolution_x = w;
             settings.video.resolution_y = h;

--- a/conwayste/src/constants.rs
+++ b/conwayste/src/constants.rs
@@ -19,30 +19,38 @@
 use ggez::graphics::{self, Color};
 use std::time::Duration;
 
-
 // game play
-pub const CURRENT_PLAYER_ID         : usize =  1; // TODO:  get the player ID from server rather than hardcoding
-pub const FOG_RADIUS                : usize =  4; // cells
-pub const HISTORY_SIZE              : usize = 16;
+pub const CURRENT_PLAYER_ID: usize = 1; // TODO:  get the player ID from server rather than hardcoding
+pub const FOG_RADIUS: usize = 4; // cells
+pub const HISTORY_SIZE: usize = 16;
 
 // display
-pub const DEFAULT_ACTIVE_COLOR      : Color = Color{r: 0.0,  g: 1.0,  b: 0.0,  a: 1.0}; // menu
-pub const DEFAULT_INACTIVE_COLOR    : Color = Color{r: 0.75, g: 0.75, b: 0.75, a: 1.0}; // menu
-pub const DEFAULT_SCREEN_HEIGHT     : f32   =  800.0; // pixels
-pub const DEFAULT_SCREEN_WIDTH      : f32   = 1200.0; // pixels
-pub const DEFAULT_ZOOM_LEVEL        : f32   =  5.0; // default cell size in pixels
-//pub const FPS                     : u32   = 25;
-pub const GRID_DRAW_STYLE           : DrawStyle = DrawStyle::Fill;
-pub const INTRO_DURATION            : f64   =  8.0; // seconds
-pub const INTRO_PAUSE_DURATION      : f64   =  3.0; // seconds
-pub const MAX_CELL_SIZE             : f32   = 40.0; // pixels
-pub const MIN_CELL_SIZE             : f32   =  5.0; // pixels
-pub const PIXELS_SCROLLED_PER_FRAME : f32   = 50.0; // pixels
+pub const DEFAULT_ACTIVE_COLOR: Color = Color {
+    r: 0.0,
+    g: 1.0,
+    b: 0.0,
+    a: 1.0,
+}; // menu
+pub const DEFAULT_INACTIVE_COLOR: Color = Color {
+    r: 0.75,
+    g: 0.75,
+    b: 0.75,
+    a: 1.0,
+}; // menu
+pub const DEFAULT_SCREEN_HEIGHT: f32     =  800.0; // pixels
+pub const DEFAULT_SCREEN_WIDTH: f32      = 1200.0; // pixels
+pub const DEFAULT_ZOOM_LEVEL: f32        =    5.0; // default cell size in pixels
+//pub const FPS: u32 = 25;
+pub const GRID_DRAW_STYLE: DrawStyle     = DrawStyle::Fill;
+pub const INTRO_DURATION: f64            =  8.0;   // seconds
+pub const INTRO_PAUSE_DURATION: f64      =  3.0;   // seconds
+pub const MAX_CELL_SIZE: f32             = 40.0;   // pixels
+pub const MIN_CELL_SIZE: f32             =  5.0;   // pixels
+pub const PIXELS_SCROLLED_PER_FRAME: f32 = 50.0;   // pixels
 
 // persistent configuration
-pub const CONFIG_FILE_PATH          : &str  = "conwayste.toml";
-pub const MIN_CONFIG_FLUSH_TIME     : Duration = Duration::from_millis(5000);
-
+pub const CONFIG_FILE_PATH: &str = "conwayste.toml";
+pub const MIN_CONFIG_FLUSH_TIME: Duration = Duration::from_millis(5000);
 
 //////////////////////////////////////////////////////////////////////
 

--- a/conwayste/src/constants.rs
+++ b/conwayste/src/constants.rs
@@ -35,7 +35,7 @@ pub const DEFAULT_ZOOM_LEVEL        : f32   =  5.0; // default cell size in pixe
 pub const GRID_DRAW_STYLE           : DrawStyle = DrawStyle::Fill;
 pub const INTRO_DURATION            : f64   =  8.0; // seconds
 pub const INTRO_PAUSE_DURATION      : f64   =  3.0; // seconds
-pub const MAX_CELL_SIZE             : f32   = 20.0; // pixels
+pub const MAX_CELL_SIZE             : f32   = 40.0; // pixels
 pub const MIN_CELL_SIZE             : f32   =  5.0; // pixels
 pub const PIXELS_SCROLLED_PER_FRAME : f32   = 50.0; // pixels
 

--- a/conwayste/src/input.rs
+++ b/conwayste/src/input.rs
@@ -61,10 +61,9 @@ impl InputManager {
     /// Adds an event to the queue.
     /// This will panic if we fill up the queue past `NUM_OF_QUEUED_INPUTS`.
     pub fn add(&mut self, input: InputAction) {
-        // Curious to see if we actually can hit this condition
         if self.events.len() >= NUM_OF_QUEUED_INPUTS {
-            println!("{:?}", self.events);
-            assert!(false);
+            // FIXME
+            panic!("BUG: Input queue is full! Queue contents: {:?}", self.events);
         }
 
         self.events.push_back(input);

--- a/conwayste/src/input.rs
+++ b/conwayste/src/input.rs
@@ -36,7 +36,7 @@ pub enum InputAction {
 
     MouseClick(MouseButton, i32, i32),
     MouseDrag(MouseButton, i32, i32),
-    MouseRelease(MouseButton),
+    //MouseRelease(MouseButton),
     MouseMovement(i32, i32),
 
 //    Gamepad((Button, Axis)),
@@ -67,11 +67,6 @@ impl InputManager {
         }
 
         self.events.push_back(input);
-    }
-
-    /// Pokes at the head of the queue and returns an event if available.
-    pub fn peek(&self) -> Option<&InputAction> {
-        self.events.front()
     }
 
     /// Dequeues can input event.

--- a/conwayste/src/menu.rs
+++ b/conwayste/src/menu.rs
@@ -351,19 +351,6 @@ impl MenuSystem {
                         container.text_width = max_text_width;
                     }
                 }
-
-                /*
-                // Denote Current Selection
-                ////////////////////////////////////////////////////
-                {
-                    let cur_option_str = " >";
-                    let ref container = self.menus.get(&self.menu_state).unwrap();
-                    let coords = container.get_anchor();
-                    let offset = Point2::new(-50.0, (*index) as f32 * 50.0);
-
-                    utils::Graphics::draw_text(_ctx, &self.font, self.active_color, &cur_option_str, &coords, Some(&offset))?;
-                }
-                */
             }
         }
         Ok(())

--- a/conwayste/src/menu.rs
+++ b/conwayste/src/menu.rs
@@ -382,8 +382,8 @@ impl MenuSystem {
                 // Resolution
                 ///////////////////////////////
                 let coords = Point2::new(x, y);
-                let (width, height) = video_settings.get_active_resolution();
-                let cur_res_str = format!("{}x{}", width, height);
+                let res = video_settings.get_active_resolution();
+                let cur_res_str = format!("{}x{}", res.w, res.h);
 
                 // TODO: color
                 utils::Graphics::draw_text(_ctx, &self.font, self.inactive_color, &cur_res_str,

--- a/conwayste/src/menu.rs
+++ b/conwayste/src/menu.rs
@@ -17,8 +17,7 @@
  *  <http://www.gnu.org/licenses/>. */
 
 use ggez::{Context, GameResult};
-use ggez::graphics;
-use ggez::graphics::Color;
+use ggez::graphics::{self, Color};
 use ggez::nalgebra::Point2;
 use std::collections::HashMap;
 
@@ -86,6 +85,8 @@ pub struct MenuControls {
 #[derive(Debug, Clone)]
 pub struct MenuContainer {
     anchor:     Point2<f32>,
+    width:      f32,
+    height:     f32,
     text_width: f32,            // maximum width in pixels of any option
     menu_items: Vec<MenuItem>,
     metadata:   MenuMetaData,
@@ -94,9 +95,11 @@ pub struct MenuContainer {
 }
 
 impl MenuContainer {
-    pub fn new(x: f32, y: f32) -> MenuContainer {
+    pub fn new(width: f32, height: f32) -> MenuContainer {
         MenuContainer {
-            anchor: Point2::new(x, y),
+            anchor: Point2::new(0.0, 0.0),   // uninitialized; see adjust_anchors()
+            width,
+            height,
             text_width: 0.0,
             menu_items: Vec::<MenuItem>::new(),
             metadata: MenuMetaData::new(0, 0),
@@ -222,11 +225,14 @@ impl MenuSystem {
             active_color:   DEFAULT_ACTIVE_COLOR,
         };
 
-        menu_sys.menus.insert(MenuState::MainMenu, MenuContainer::new(400.0, 300.0));
-        menu_sys.menus.insert(MenuState::Options,  MenuContainer::new(400.0, 300.0));
-        menu_sys.menus.insert(MenuState::Video,    MenuContainer::new(200.0, 100.0));
-        menu_sys.menus.insert(MenuState::Audio,    MenuContainer::new(200.0, 100.0));
-        menu_sys.menus.insert(MenuState::Gameplay, MenuContainer::new(200.0, 100.0));
+        // FIXME: Hardcoded width and height. This is very hacky, but I expect this code to be
+        // replaced soon.  Note also that there is nothing stopping the contents from overflowing
+        // this container if they are larger.
+        menu_sys.menus.insert(MenuState::MainMenu, MenuContainer::new(159.0, 120.0));
+        menu_sys.menus.insert(MenuState::Options,  MenuContainer::new( 87.0, 120.0));
+        menu_sys.menus.insert(MenuState::Video,    MenuContainer::new(192.0,  50.0));
+        menu_sys.menus.insert(MenuState::Audio,    MenuContainer::new( 44.0,  30.0));
+        menu_sys.menus.insert(MenuState::Gameplay, MenuContainer::new( 44.0,  30.0));
 
         let start_game  = MenuItem::new(MenuItemIdentifier::StartGame,            String ::from("Start Game"), false, MenuItemValue::ValNone());
         let connect     = MenuItem::new(MenuItemIdentifier::Connect,              String ::from("Connect to Server"), false, MenuItemValue::ValNone());
@@ -315,6 +321,17 @@ impl MenuSystem {
         &mut self.controls
     }
 
+    /// Per-frame adjustment of anchors based on screen dims and width and height of MenuContainers
+    fn adjust_anchors(&mut self, ctx: &mut Context) -> GameResult<()> {
+        // get screen dims
+        let window_rect = graphics::window(ctx).get_inner_size().unwrap();
+        for menu in self.menus.values_mut() {
+            menu.anchor.x = (window_rect.width as f32 - menu.width) as f32 / 2.0;
+            menu.anchor.y = (window_rect.height as f32 - menu.height) as f32 / 2.0;
+        }
+        Ok(())
+    }
+
     fn draw_general_menu_view(&mut self, _ctx: &mut Context, has_game_started: bool) -> GameResult<()> {
         let index = self.get_menu_container().get_menu_item_index(); // current position in this menu
         // Menu Navigation
@@ -341,11 +358,11 @@ impl MenuSystem {
                         let color = if index == i { self.active_color } else { self.inactive_color };
                         let (w, h) = utils::Graphics::draw_text(_ctx, &self.font, color, &menu_option_str,
                                                                  &coords, Some(&offset))?;
-                        if max_text_width < w as f32 {
-                            max_text_width = w as f32;
+                        if max_text_width < w {
+                            max_text_width = w;
                         }
 
-                        offset = utils::Graphics::point_offset(offset, 0.0, h as f32 + 10.0);
+                        offset = utils::Graphics::point_offset(offset, 0.0, h + 10.0);
                     }
                     if container.text_width < max_text_width {
                         container.text_width = max_text_width;
@@ -376,7 +393,7 @@ impl MenuSystem {
                 // TODO: color
                 let (_w, h) = utils::Graphics::draw_text(_ctx, &self.font, self.inactive_color,
                                                          &is_fullscreen_str, &coords, None)?;
-                y += h as f32 + 10.0;
+                y += h + 10.0;
 
                 ////////////////////////////////
                 // Resolution
@@ -394,9 +411,10 @@ impl MenuSystem {
         Ok(())
     }
 
-    pub fn draw_menu(&mut self, video_settings: &video::VideoSettings, _ctx: &mut Context, has_game_started: bool) -> GameResult<()> {
-        self.draw_general_menu_view(_ctx, has_game_started)?;
-        self.draw_specific_menu_view(video_settings, _ctx)?;
+    pub fn draw_menu(&mut self, video_settings: &video::VideoSettings, ctx: &mut Context, has_game_started: bool) -> GameResult<()> {
+        self.adjust_anchors(ctx)?;
+        self.draw_general_menu_view(ctx, has_game_started)?;
+        self.draw_specific_menu_view(video_settings, ctx)?;
         Ok(())
     }
 

--- a/conwayste/src/menu.rs
+++ b/conwayste/src/menu.rs
@@ -382,7 +382,7 @@ impl MenuSystem {
                 // Resolution
                 ///////////////////////////////
                 let coords = Point2::new(x, y);
-                let res = video_settings.get_active_resolution();
+                let res = video_settings.get_resolution();
                 let cur_res_str = format!("{}x{}", res.w, res.h);
 
                 // TODO: color

--- a/conwayste/src/utils.rs
+++ b/conwayste/src/utils.rs
@@ -34,14 +34,14 @@ impl Graphics {
     /// On success, an `Ok((text_width, text_height))` tuple is returned, indicating the width
     /// and height of the text in pixels.
     pub fn draw_text(ctx: &mut Context, font: &Font, color: Color, text: &str,
-                     coords: &Point2<f32>, adjustment: Option<&Point2<f32>>) -> GameResult<(u32, u32)> {
+                     coords: &Point2<f32>, adjustment: Option<&Point2<f32>>) -> GameResult<(f32, f32)> {
         let text_fragment = TextFragment::new(text)
             .scale(Scale::uniform(20.0))              // TODO needs refactoring so size is specified in signature, fix in UI branch
             .color(color)
             .font(*font);
 
         let mut graphics_text = Text::new(text_fragment);
-        let (text_width, text_height) = (graphics_text.width(ctx), graphics_text.height(ctx));
+        let (text_width, text_height) = (graphics_text.width(ctx) as f32, graphics_text.height(ctx) as f32);
         let dst;
 
         if let Some(offset) = adjustment {

--- a/conwayste/src/utils.rs
+++ b/conwayste/src/utils.rs
@@ -27,8 +27,15 @@ impl Graphics {
     /// Helper function to draw text onto the screen.
     /// Given the string `str`, it will be drawn at the point coordinates specified by `coords`.
     /// An offset can be specified by an optional `adjustment` point.
-    pub fn draw_text(_ctx: &mut Context, font: &Font, color: Color, text: &str, coords: &Point2, adjustment: Option<&Point2>) -> GameResult<()> {
+    ///
+    /// # Return value
+    ///
+    /// On success, an `Ok((text_width, text_height))` tuple is returned, indicating the width
+    /// and height of the text in pixels.
+    pub fn draw_text(_ctx: &mut Context, font: &Font, color: Color, text: &str, coords: &Point2,
+                     adjustment: Option<&Point2>) -> GameResult<(u32, u32)> {
         let mut graphics_text = Text::new(_ctx, text, font)?;
+        let (text_width, text_height) = (graphics_text.width(), graphics_text.height());
         let dst;
 
         if let Some(offset) = adjustment {
@@ -44,7 +51,7 @@ impl Graphics {
         graphics::set_color(_ctx, color)?;                   // text foreground
         graphics::draw(_ctx, &mut graphics_text, dst, 0.0)?; // actually draw the text!
         graphics::set_color(_ctx, previous_color)?;          // restore previous color
-        Ok(())
+        Ok((text_width, text_height))
     }
 
     /// Determines if two rectangles overlap, and if so, 

--- a/conwayste/src/video.rs
+++ b/conwayste/src/video.rs
@@ -121,11 +121,11 @@ impl VideoSettings {
     /// Makes us fullscreen or not based on the `is_fullscreen` field.
     pub fn update_fullscreen(&mut self, ctx: &mut Context) -> GameResult<()> {
         let fs_type = if self.is_fullscreen {
-            FullscreenType::Windowed
-        } else {
             FullscreenType::Desktop
+        } else {
+            FullscreenType::Windowed
         };
-        let _ = graphics::set_fullscreen(ctx, fs_type)?;
+        graphics::set_fullscreen(ctx, fs_type)?;
         Ok(())
     }
 }

--- a/conwayste/src/video.rs
+++ b/conwayste/src/video.rs
@@ -17,12 +17,11 @@
  *  <http://www.gnu.org/licenses/>. */
 
 use ggez::{Context, graphics, GameResult, conf::FullscreenType};
-use std::num::Wrapping;
 
-#[derive(Debug, Clone, PartialEq, Copy)]
-struct Resolution {
-    w: u32,
-    h: u32,
+#[derive(Debug, Clone, PartialEq, Copy, Default)]
+pub struct Resolution {
+    pub w: f32,
+    pub h: f32,
 }
 
 /*
@@ -35,85 +34,36 @@ const DISPLAY_MODES: [Resolution; 5]  = [
 ];
 */
 
-/// This manages the supported resolutions.
-#[derive(Debug, Clone)]
-struct DisplayModeManager {
-    index: Wrapping<usize>,
-    modes: Vec<Resolution>,
-    opt_refresh_rate: Option<i32>,
-}
-
-impl DisplayModeManager {
-    pub fn new() -> DisplayModeManager {
-        DisplayModeManager {
-            index: Wrapping(usize::max_value()),
-            modes: Vec::new(),
-            opt_refresh_rate: None,
-        }
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct VideoSettings {
-    pub resolution    : (u32, u32),
-    pub is_fullscreen :       bool,
-    res_manager       : DisplayModeManager,
-
+    pub resolution:    Resolution,
+    pub is_fullscreen: bool,
 }
 
 impl VideoSettings {
     pub fn new() -> VideoSettings {
         VideoSettings {
-            resolution: (0, 0),
+            resolution: Resolution::default(),
             is_fullscreen: false,
-            res_manager: DisplayModeManager::new(),
         }
     }
-
-    /*
-     * TODO: delete this once we are sure resizable windows are OK.
-    /// We query graphics library to see what resolutions are supported.
-    /// This intersected with the `DISPLAY_MODES` list.
-    pub fn gather_display_modes(&mut self, ctx: &Context) -> GameResult<()>  {
-        let sdl_context =  &ctx.gfx_context;
-        let sdl_video = sdl_context.video()?;
-
-        let num_of_display_modes = sdl_video.num_display_modes(0)?;
-
-        for x in  0..num_of_display_modes {
-            let display_mode = sdl_video.display_mode(0, x)?;
-            let resolution = Resolution {
-                w: display_mode.w as u32,
-                h: display_mode.h as u32,
-            };
-
-            self.res_manager.add_mode(resolution);
-
-            if self.res_manager.opt_refresh_rate.is_none() {
-                self.res_manager.set_refresh_rate(display_mode.refresh_rate);
-            }
-        }
-
-        Ok(())
-    }
-    */
 
     /// Gets the current active resolution.
-    pub fn get_active_resolution(&self) -> (u32, u32) {
+    pub fn get_active_resolution(&self) -> Resolution {
         self.resolution
     }
 
     /// Sets the current active resolution and updates the SDL context.
-    pub fn set_active_resolution(&mut self, ctx: &mut Context, w: u32, h: u32) -> GameResult<()> {
-        self.resolution = (w,h);
-        self.refresh_game_resolution(ctx, w, h)?;
+    pub fn set_active_resolution(&mut self, ctx: &mut Context, res: Resolution) -> GameResult<()> {
+        self.resolution = res;
+        self.refresh_game_resolution(ctx, res.w, res.h)?;
         Ok(())
     }
 
     /// Updates the SDL video context to the supplied resolution.
-    fn refresh_game_resolution(&mut self, ctx: &mut Context, w: u32, h: u32) -> GameResult<()> {
-        if w != 0 && h != 0 {
-            graphics::set_drawable_size(ctx, w as f32, h as f32)?;
+    fn refresh_game_resolution(&mut self, ctx: &mut Context, w: f32, h: f32) -> GameResult<()> {
+        if w != 0.0 && h != 0.0 {
+            graphics::set_drawable_size(ctx, w, h)?;
         }
         Ok(())
     }

--- a/conwayste/src/video.rs
+++ b/conwayste/src/video.rs
@@ -25,7 +25,7 @@ struct Resolution {
     h: u32,
 }
 
-/// For now, conwayste supports a `16:9` aspect ratio only.
+/*
 const DISPLAY_MODES: [Resolution; 5]  = [
     Resolution {w: 1280, h: 720},
     Resolution {w: 1366, h: 768},
@@ -33,6 +33,7 @@ const DISPLAY_MODES: [Resolution; 5]  = [
     Resolution {w: 1920, h: 1080},
     Resolution {w: 2560, h: 1440},
 ];
+*/
 
 /// This manages the supported resolutions.
 #[derive(Debug, Clone)]
@@ -49,37 +50,6 @@ impl DisplayModeManager {
             modes: Vec::new(),
             opt_refresh_rate: None,
         }
-    }
-
-    /// Adds a new display mode and removes duplicates.
-    pub fn add_mode(&mut self, new_mode: Resolution) {
-        for mode in DISPLAY_MODES.iter() {
-            if mode == &new_mode {
-                self.modes.push(new_mode);
-            }
-        }
-        self.modes.dedup();
-    }
-
-    /// Sets the game refresh rate. Right now this does not do anything.
-    pub fn set_refresh_rate(&mut self, refresh_rate: i32) {
-        self.opt_refresh_rate = Some(refresh_rate);
-    }
-
-    /// Prints the supported display modes in debug mode.
-    pub fn print_supported_modes(&self) {
-        println!("Supported Resolutions Determined:");
-
-        for mode in self.modes.iter() {
-            println!("Width: {}, Height: {}", mode.w, mode.h);
-        }
-    }
-
-    /// Advances to the next resolution.
-    pub fn set_next_supported_resolution(&mut self) -> (u32, u32) {
-        self.index = (self.index + Wrapping(1usize)) % Wrapping(self.modes.len());
-        let display_mode = self.modes.get(self.index.0).unwrap();
-        (display_mode.w, display_mode.h)
     }
 }
 
@@ -129,11 +99,6 @@ impl VideoSettings {
     }
     */
 
-    /// For debug, we have the option to print the supported resolutions.
-    pub fn print_resolutions(&self) {
-        self.res_manager.print_supported_modes();
-    }
-
     /// Gets the current active resolution.
     pub fn get_active_resolution(&self) -> (u32, u32) {
         self.resolution
@@ -143,15 +108,6 @@ impl VideoSettings {
     pub fn set_active_resolution(&mut self, ctx: &mut Context, w: u32, h: u32) -> GameResult<()> {
         self.resolution = (w,h);
         self.refresh_game_resolution(ctx, w, h)?;
-        Ok(())
-    }
-
-    /// Advances to the next supported game resolution, in-order.
-    pub fn advance_to_next_resolution(&mut self, ctx: &mut Context) -> GameResult<()> {
-        let (width, height) = self.res_manager.set_next_supported_resolution();
-        self.set_active_resolution(ctx, width, height)?;
-
-        info!("{:?}", (width, height));
         Ok(())
     }
 

--- a/conwayste/src/video.rs
+++ b/conwayste/src/video.rs
@@ -75,7 +75,8 @@ impl VideoSettings {
         Ok(())
     }
 
-    /// Makes us fullscreen or not based on the `is_fullscreen` field.
+    /// Makes us fullscreen or not based on the `is_fullscreen` field. If we are fullscreen, also
+    /// updates the `resolution` field based on the actual screen resolution.
     pub fn update_fullscreen(&mut self, ctx: &mut Context) -> GameResult<()> {
         let fs_type = if self.is_fullscreen {
             FullscreenType::Desktop
@@ -83,6 +84,14 @@ impl VideoSettings {
             FullscreenType::Windowed
         };
         graphics::set_fullscreen(ctx, fs_type)?;
+
+        // Also update `resolution`
+        if self.is_fullscreen {
+            self.resolution = graphics::drawable_size(ctx).into();
+        } else {
+            // Don't update here because ggez 0.5.1 gives us the wrong resolution!
+        }
+
         Ok(())
     }
 }

--- a/conwayste/src/video.rs
+++ b/conwayste/src/video.rs
@@ -64,7 +64,6 @@ pub struct VideoSettings {
 impl VideoSettings {
     pub fn new() -> VideoSettings {
         VideoSettings {
-            // TODO: ensure this is set on startup
             resolution: (0, 0),
             is_fullscreen: false,
             res_manager: DisplayModeManager::new(),

--- a/conwayste/src/video.rs
+++ b/conwayste/src/video.rs
@@ -21,17 +21,17 @@ use std::num::Wrapping;
 
 #[derive(Debug, Clone, PartialEq, Copy)]
 struct Resolution {
-    w: f32,
-    h: f32
+    w: u32,
+    h: u32,
 }
 
 /// For now, conwayste supports a `16:9` aspect ratio only.
 const DISPLAY_MODES: [Resolution; 5]  = [
-    Resolution {w: 1280.0, h: 720.0},
-    Resolution {w: 1366.0, h: 768.0},
-    Resolution {w: 1600.0, h: 900.0},
-    Resolution {w: 1920.0, h: 1080.0},
-    Resolution {w: 2560.0, h: 1440.0},
+    Resolution {w: 1280, h: 720},
+    Resolution {w: 1366, h: 768},
+    Resolution {w: 1600, h: 900},
+    Resolution {w: 1920, h: 1080},
+    Resolution {w: 2560, h: 1440},
 ];
 
 /// This manages the supported resolutions.
@@ -76,7 +76,7 @@ impl DisplayModeManager {
     }
 
     /// Advances to the next resolution.
-    pub fn set_next_supported_resolution(&mut self) -> (f32, f32) {
+    pub fn set_next_supported_resolution(&mut self) -> (u32, u32) {
         self.index = (self.index + Wrapping(1usize)) % Wrapping(self.modes.len());
         let display_mode = self.modes.get(self.index.0).unwrap();
         (display_mode.w, display_mode.h)
@@ -85,7 +85,7 @@ impl DisplayModeManager {
 
 #[derive(Debug, Clone)]
 pub struct VideoSettings {
-    pub resolution    : (f32, f32),
+    pub resolution    : (u32, u32),
     pub is_fullscreen :       bool,
     res_manager       : DisplayModeManager,
 
@@ -94,7 +94,8 @@ pub struct VideoSettings {
 impl VideoSettings {
     pub fn new() -> VideoSettings {
         VideoSettings {
-            resolution: (0.0, 0.0),
+            // TODO: ensure this is set on startup
+            resolution: (0, 0),
             is_fullscreen: false,
             res_manager: DisplayModeManager::new(),
         }
@@ -111,8 +112,8 @@ impl VideoSettings {
         for x in  0..num_of_display_modes {
             let display_mode = sdl_video.display_mode(0, x)?;
             let resolution = Resolution {
-                w: display_mode.w as f32,
-                h: display_mode.h as f32
+                w: display_mode.w as u32,
+                h: display_mode.h as u32,
             };
 
             self.res_manager.add_mode(resolution);
@@ -131,14 +132,14 @@ impl VideoSettings {
     }
 
     /// Gets the current active resolution.
-    pub fn get_active_resolution(&self) -> (f32, f32) {
+    pub fn get_active_resolution(&self) -> (u32, u32) {
         self.resolution
     }
 
     /// Sets the current active resolution and updates the SDL context.
-    pub fn set_active_resolution(&mut self, _ctx: &mut Context, w: f32, h: f32) {
+    pub fn set_active_resolution(&mut self, _ctx: &mut Context, w: u32, h: u32) {
         self.resolution = (w,h);
-        self.refresh_game_resolution(_ctx, w as i32, h as i32);
+        self.refresh_game_resolution(_ctx, w, h);
     }
 
     /// Advances to the next supported game resolution, in-order.
@@ -150,9 +151,9 @@ impl VideoSettings {
     }
 
     /// Updates the SDL video context to the supplied resolution.
-    fn refresh_game_resolution(&mut self, ctx: &mut Context, w: i32, h: i32) {
+    fn refresh_game_resolution(&mut self, ctx: &mut Context, w: u32, h: u32) {
         if w != 0 && h != 0 {
-            let _ = graphics::set_resolution(ctx, w as u32, h as u32);
+            let _ = graphics::set_resolution(ctx, w, h);
         }
     }
 

--- a/conwayste/src/video.rs
+++ b/conwayste/src/video.rs
@@ -24,6 +24,12 @@ pub struct Resolution {
     pub h: f32,
 }
 
+impl From<(f32, f32)> for Resolution {
+    fn from(src: (f32, f32)) -> Resolution {
+        Resolution{ w: src.0, h: src.1 }
+    }
+}
+
 /*
 const DISPLAY_MODES: [Resolution; 5]  = [
     Resolution {w: 1280, h: 720},
@@ -36,7 +42,7 @@ const DISPLAY_MODES: [Resolution; 5]  = [
 
 #[derive(Debug, Clone)]
 pub struct VideoSettings {
-    pub resolution:    Resolution,
+    resolution:        Resolution,
     pub is_fullscreen: bool,
 }
 
@@ -49,22 +55,23 @@ impl VideoSettings {
     }
 
     /// Gets the current active resolution.
-    pub fn get_active_resolution(&self) -> Resolution {
+    pub fn get_resolution(&self) -> Resolution {
         self.resolution
     }
 
-    /// Sets the current active resolution and updates the SDL context.
-    pub fn set_active_resolution(&mut self, ctx: &mut Context, res: Resolution) -> GameResult<()> {
+    /// Sets the `resolution` field.
+    /// If `refresh` is true, calls `update_resolution` to actually resize the window.
+    pub fn set_resolution(&mut self, ctx: &mut Context, res: Resolution, refresh: bool) -> GameResult<()> {
         self.resolution = res;
-        self.refresh_game_resolution(ctx, res.w, res.h)?;
+        if refresh {
+            self.update_resolution(ctx, res.w, res.h)?;
+        }
         Ok(())
     }
 
-    /// Updates the SDL video context to the supplied resolution.
-    fn refresh_game_resolution(&mut self, ctx: &mut Context, w: f32, h: f32) -> GameResult<()> {
-        if w != 0.0 && h != 0.0 {
-            graphics::set_drawable_size(ctx, w, h)?;
-        }
+    /// Resizes the window based on the `resolution` field.
+    fn update_resolution(&mut self, ctx: &mut Context, w: f32, h: f32) -> GameResult<()> {
+        graphics::set_drawable_size(ctx, w, h)?;
         Ok(())
     }
 

--- a/conwayste/src/video.rs
+++ b/conwayste/src/video.rs
@@ -101,11 +101,9 @@ impl VideoSettings {
         }
     }
 
-/*
- * FIXME
- * as of ggez 0.5.1, there wasn't an obvious way to query the supported display modes.
- * Likely have to dig into wininit to find the answer
-    /// We query Wininit (?) to see what resolutions are supported.
+    /*
+     * TODO: delete this once we are sure resizable windows are OK.
+    /// We query graphics library to see what resolutions are supported.
     /// This intersected with the `DISPLAY_MODES` list.
     pub fn gather_display_modes(&mut self, ctx: &Context) -> GameResult<()>  {
         let sdl_context =  &ctx.gfx_context;
@@ -129,7 +127,7 @@ impl VideoSettings {
 
         Ok(())
     }
-*/
+    */
 
     /// For debug, we have the option to print the supported resolutions.
     pub fn print_resolutions(&self) {
@@ -165,24 +163,14 @@ impl VideoSettings {
         Ok(())
     }
 
-/*
- * FIXME
- * as of ggez 0.5.1, there wasn't an obvious way to query whether the window is fullscreen or not.
- * Likely have to dig into wininit to find the answer.
- * */
-    /// Toggles fullscreen mode within the SDL video context
-    pub fn toggle_fullscreen(&mut self, ctx: &mut Context) {
+    /// Makes us fullscreen or not based on the `is_fullscreen` field.
+    pub fn update_fullscreen(&mut self, ctx: &mut Context) -> GameResult<()> {
         let fs_type = if self.is_fullscreen {
             FullscreenType::Windowed
         } else {
-            FullscreenType::True
+            FullscreenType::Desktop
         };
-        let _ = graphics::set_fullscreen(ctx, fs_type);
-    }
-
-
-    /// Queries if we are fullscreen or otherwise.
-    pub fn is_fullscreen(&self) -> bool {
-        self.is_fullscreen
+        let _ = graphics::set_fullscreen(ctx, fs_type)?;
+        Ok(())
     }
 }

--- a/conwayste/src/viewport.rs
+++ b/conwayste/src/viewport.rs
@@ -245,22 +245,23 @@ impl Viewport {
         self.grid_view.set_height(h as f32);
     }
 
-    /// Given a point, find the nearest Cell specified by a row and column.
+    /// Given a point, find the nearest Cell (game coordinates) specified by a point in window
+    /// coordinates.
     pub fn get_cell(&self, point: Point2<f32>) -> Option<Cell> {
         self.grid_view.game_coords_from_window(point)
     }
 
-    /// Get the cell size, which directly correlates to the zoom level.
+    /// Gets the cell size in pixels.
     pub fn get_cell_size(&self) -> f32 {
         self.grid_view.cell_size
     }
 
-    /// Gets a rectangle representing the grid.
-    pub fn get_viewport(&self) -> Rect {
+    /// Gets a rectangle representing the grid in game coordinates.
+    pub fn get_rect(&self) -> Rect {
         self.grid_view.rect
     }
 
-    /// Returns the origin of the grid.
+    /// Returns the origin of the grid in window coordinates.
     pub fn get_origin(&self) -> Point2<f32> {
         self.grid_view.grid_origin
     }

--- a/conwayste/src/viewport.rs
+++ b/conwayste/src/viewport.rs
@@ -119,10 +119,8 @@ impl GridView {
 
                 self.cell_size = next_cell_size;
 
-                let columns = self.columns as u32;
-
-                let phi = columns as i32 * old_cell_size as i32;
-                let alpha = self.rect.w as i32;
+                let phi = self.columns as f32 * old_cell_size as f32;
+                let alpha = self.rect.w;
 
                 if phi > alpha {
                     self.grid_origin = utils::Graphics::point_offset(self.grid_origin,
@@ -150,7 +148,7 @@ impl GridView {
     /// This is compared against the size of the screen, `α`, `alpha`, to see if we can
     /// adjust the grid origin.
     fn adjust_panning(&mut self, recenter_after_zoom: bool, arrow_input: (isize, isize)) {
-        let (columns, rows) = (self.columns as u32, self.rows as u32);
+        let (columns, rows) = (self.columns, self.rows);
 
         //debug!("\n\nP A N N I N G:");
         //debug!("Columns, Rows = {:?}", (columns, rows));
@@ -254,9 +252,9 @@ impl GridView {
 
     /// Set dimensions of the grid in window coordinates (pixels). This may cause unintended
     /// consequences if modified while a game is running.  Be mindful of the window size.
-    pub fn set_dimensions(&mut self, w: u32, h: u32) {
-        self.set_width(w as f32);
-        self.set_height(h as f32);
+    pub fn set_dimensions(&mut self, w: f32, h: f32) {
+        self.set_width(w);
+        self.set_height(h);
     }
 
     /// Given a point, find the nearest Cell (game coordinates) specified by a point in window
@@ -281,13 +279,13 @@ impl GridView {
     }
 
     /// Returns the width of the grid in pixels.
-    pub fn grid_width(&self) -> u32 {
-        self.columns as u32 * self.cell_size as u32
+    pub fn grid_width(&self) -> f32 {
+        self.columns as f32 * self.cell_size
     }
 
     /// Returns the height of the grid in pixels.
-    pub fn grid_height(&self) -> u32 {
-        self.rows as u32 * self.cell_size as u32
+    pub fn grid_height(&self) -> f32 {
+        self.rows as f32 * self.cell_size
     }
 
     pub fn get_rect_from_origin(&self) -> Rect {

--- a/conwayste/src/viewport.rs
+++ b/conwayste/src/viewport.rs
@@ -101,11 +101,13 @@ impl Viewport {
             let window_center = Point2::new(self.grid_view.rect.w/2.0, self.grid_view.rect.h/2.0);
 
             if let Some(cell) = self.grid_view.game_coords_from_window(window_center) {
-                let (old_cell_count_for_x, old_cell_count_for_y) = (cell.row, cell.col);
-                let delta_x = cell_size_delta * (old_cell_count_for_x as f32 * next_cell_size as f32 - old_cell_count_for_x as f32 * old_cell_size as f32);
-                let delta_y = cell_size_delta * (old_cell_count_for_y as f32 * next_cell_size as f32 - old_cell_count_for_y as f32 * old_cell_size as f32);
+                let (old_cell_center_x, old_cell_center_y) = (cell.row, cell.col);
+                let delta_x = cell_size_delta * (old_cell_center_x as f32 * next_cell_size as f32 -
+                                                 old_cell_center_x as f32 * old_cell_size as f32);
+                let delta_y = cell_size_delta * (old_cell_center_y as f32 * next_cell_size as f32 -
+                                                 old_cell_center_y as f32 * old_cell_size as f32);
 
-                //debug!("current cell count: {}, {}", old_cell_count_for_x, old_cell_count_for_x);
+                //debug!("current cell count: {}, {}", old_cell_center_x, old_cell_center_x);
                 //debug!("delta in win coords: {}, {}", delta_x, delta_y);
 
                 self.grid_view.cell_size = next_cell_size;

--- a/conwayste/src/viewport.rs
+++ b/conwayste/src/viewport.rs
@@ -30,13 +30,13 @@ use crate::constants::{
     PIXELS_SCROLLED_PER_FRAME,
 };
 
-const NO_INPUT                  : (isize, isize) = (0, 0);
-const PAN_LEFT                  : isize          = -1;
-const PAN_RIGHT                 : isize          =  1;
-const PAN_UP                    : isize          = -1;
-const PAN_DOWN                  : isize          =  1;
-const ZOOM_IN                   : f32            =  1.0;
-const ZOOM_OUT                  : f32            = -1.0;
+const NO_INPUT:  (isize, isize) = (0, 0);
+const PAN_LEFT:  isize          = -1;
+const PAN_RIGHT: isize          =  1;
+const PAN_UP:    isize          = -1;
+const PAN_DOWN:  isize          =  1;
+const ZOOM_IN:   f32            =  1.0;
+const ZOOM_OUT:  f32            = -1.0;
 
 #[derive(Debug, PartialEq)]
 pub struct Cell {
@@ -53,10 +53,6 @@ impl Cell {
     }
 }
 
-pub struct Viewport {
-    grid_view:           GridView,
-}
-
 #[derive(PartialEq)]
 /// Whether the user is zooming in our out.
 pub enum ZoomDirection {
@@ -64,13 +60,31 @@ pub enum ZoomDirection {
     ZoomIn
 }
 
-impl Viewport {
+/// Controls the mapping between window and game coordinates.
+/// This should always be sized with respect to the window, otherwise we'll
+/// get black bars.
+pub struct GridView {
+    rect:        Rect,  // the area the game grid takes up on screen
+    cell_size:   f32,   // zoom level in window coordinates
+    columns:     usize, // width in game coords (should match bitmap/universe width)
+    rows:        usize, // height in game coords (should match bitmap/universe height)
+    // The grid origin point tells us where the top-left of the universe is with respect to the
+    // window.
+    grid_origin: Point2<f32>, // top-left corner of grid in window coords. (may be outside rect)
+}
 
-    /// Creates a new Viewport which manages how the how things
-    /// are displayed within the Window.
-    pub fn new(cell_size: f32, length: usize, width: usize) -> Viewport {
-        Viewport {
-            grid_view : GridView::new(cell_size, length, width),
+
+impl GridView {
+
+    /// Creates a new Gridview which maintains control over how the conwayste universe is positioned with
+    /// respect to the window.
+    pub fn new(cell_size: f32, uni_width: usize, uni_height: usize) -> GridView {
+        GridView {
+            rect:        Rect::new(0.0, 0.0, DEFAULT_SCREEN_WIDTH, DEFAULT_SCREEN_HEIGHT),
+            cell_size:   cell_size,
+            columns:     uni_width,
+            rows:        uni_height,
+            grid_origin: Point2::new(0.0, 0.0),
         }
     }
 
@@ -82,36 +96,36 @@ impl Viewport {
     /// 2) The offset needs to be repositioned so that the center of the screen
     ///   holds after the cell size change.
     pub fn adjust_zoom_level(&mut self, direction : ZoomDirection) {
-        if (direction == ZoomDirection::ZoomIn && self.grid_view.cell_size < MAX_CELL_SIZE) ||
-           (direction == ZoomDirection::ZoomOut && self.grid_view.cell_size > MIN_CELL_SIZE) {
+        if (direction == ZoomDirection::ZoomIn && self.cell_size < MAX_CELL_SIZE) ||
+           (direction == ZoomDirection::ZoomOut && self.cell_size > MIN_CELL_SIZE) {
 
             let zoom_dir: f32 = match direction {
                 ZoomDirection::ZoomIn => ZOOM_IN,
                 ZoomDirection::ZoomOut => ZOOM_OUT,
             };
 
-            let next_cell_size = self.grid_view.cell_size + zoom_dir;
-            let old_cell_size = self.grid_view.cell_size;
+            let next_cell_size = self.cell_size + zoom_dir;
+            let old_cell_size = self.cell_size;
             let cell_size_delta = next_cell_size - old_cell_size;
 
-            let window_center = Point2::new(self.grid_view.rect.w/2.0, self.grid_view.rect.h/2.0);
+            let window_center = Point2::new(self.rect.w/2.0, self.rect.h/2.0);
 
-            if let Some(cell) = self.grid_view.game_coords_from_window(window_center) {
+            if let Some(cell) = self.game_coords_from_window(window_center) {
                 let (old_cell_center_x, old_cell_center_y) = (cell.row, cell.col);
                 let delta_x = cell_size_delta * (old_cell_center_x as f32 * next_cell_size as f32 -
                                                  old_cell_center_x as f32 * old_cell_size as f32);
                 let delta_y = cell_size_delta * (old_cell_center_y as f32 * next_cell_size as f32 -
                                                  old_cell_center_y as f32 * old_cell_size as f32);
 
-                self.grid_view.cell_size = next_cell_size;
+                self.cell_size = next_cell_size;
 
-                let columns = self.grid_view.columns as u32;
+                let columns = self.columns as u32;
 
                 let phi = columns as i32 * old_cell_size as i32;
-                let alpha = self.grid_view.rect.w as i32;
+                let alpha = self.rect.w as i32;
 
                 if phi > alpha {
-                    self.grid_view.grid_origin = utils::Graphics::point_offset(self.grid_view.grid_origin,
+                    self.grid_origin = utils::Graphics::point_offset(self.grid_origin,
                                                                          -cell_size_delta * delta_x,
                                                                          -cell_size_delta * delta_y
                                                                          );
@@ -136,7 +150,7 @@ impl Viewport {
     /// This is compared against the size of the screen, `α`, `alpha`, to see if we can
     /// adjust the grid origin.
     fn adjust_panning(&mut self, recenter_after_zoom: bool, arrow_input: (isize, isize)) {
-        let (columns, rows) = (self.grid_view.columns as u32, self.grid_view.rows as u32);
+        let (columns, rows) = (self.columns as u32, self.rows as u32);
 
         //debug!("\n\nP A N N I N G:");
         //debug!("Columns, Rows = {:?}", (columns, rows));
@@ -145,21 +159,21 @@ impl Viewport {
         let dx_in_pixels = -(dx as f32) * PIXELS_SCROLLED_PER_FRAME;
         let dy_in_pixels = -(dy as f32) * PIXELS_SCROLLED_PER_FRAME;
 
-        let cur_origin_x = self.grid_view.grid_origin.x;
-        let cur_origin_y = self.grid_view.grid_origin.y;
+        let cur_origin_x = self.grid_origin.x;
+        let cur_origin_y = self.grid_origin.y;
 
         let new_origin_x = cur_origin_x + dx_in_pixels;
         let new_origin_y = cur_origin_y + dy_in_pixels;
 
-        let cell_size = self.grid_view.cell_size;
+        let cell_size = self.cell_size;
         let border_in_cells = 10.0;
         let border_in_px = border_in_cells * cell_size;
 
         //debug!("Cell Size: {:?}", (cell_size));
 
         let mut pan = true;
-        let mut limit_x = self.grid_view.grid_origin.x;
-        let mut limit_y = self.grid_view.grid_origin.y;
+        let mut limit_x = self.grid_origin.x;
+        let mut limit_y = self.grid_origin.y;
         // Here we check if we're at our limits. In all other cases, we'll fallthrough to the
         // bottom grid_origin offsetting.
 
@@ -187,7 +201,7 @@ impl Viewport {
         //
         if dx == PAN_RIGHT || recenter_after_zoom {
             let phi = (border_in_cells + columns as f32)*(cell_size);
-            let alpha = self.grid_view.rect.w;
+            let alpha = self.rect.w;
 
             if phi > alpha && f32::abs(new_origin_x) >= phi - alpha {
                 pan = false;
@@ -210,7 +224,7 @@ impl Viewport {
         // Panning down
         if dy == PAN_DOWN || recenter_after_zoom {
             let phi = (border_in_cells + rows as f32)*(cell_size);
-            let alpha = self.grid_view.rect.h;
+            let alpha = self.rect.h;
 
             if phi > alpha && f32::abs(new_origin_y) >= phi - alpha {
                 pan = false;
@@ -223,16 +237,16 @@ impl Viewport {
         }
 
         if pan {
-            self.grid_view.grid_origin = utils::Graphics::point_offset(self.grid_view.grid_origin, dx_in_pixels, dy_in_pixels);
+            self.grid_origin = utils::Graphics::point_offset(self.grid_origin, dx_in_pixels, dy_in_pixels);
         }
         else {
             // We cannot pan as we are out of bounds, but let us ensure we maintain a border
-            self.grid_view.grid_origin = Point2::new(limit_x as f32, limit_y as f32);
+            self.grid_origin = Point2::new(limit_x as f32, limit_y as f32);
         }
 
     }
 
-    /// Parent viewport handler update. Currently we update the following, in-order:
+    /// Parent GridView handler update. Currently we update the following, in-order:
     /// # Pan around the grid view.
     pub fn update(&mut self, direction: (isize, isize)) {
         self.adjust_panning(false, direction);
@@ -241,39 +255,39 @@ impl Viewport {
     /// Set dimensions of the grid in window coordinates (pixels). This may cause unintended
     /// consequences if modified while a game is running.  Be mindful of the window size.
     pub fn set_dimensions(&mut self, w: u32, h: u32) {
-        self.grid_view.set_width(w as f32);
-        self.grid_view.set_height(h as f32);
+        self.set_width(w as f32);
+        self.set_height(h as f32);
     }
 
     /// Given a point, find the nearest Cell (game coordinates) specified by a point in window
     /// coordinates.
     pub fn get_cell(&self, point: Point2<f32>) -> Option<Cell> {
-        self.grid_view.game_coords_from_window(point)
+        self.game_coords_from_window(point)
     }
 
     /// Gets the cell size in pixels.
     pub fn get_cell_size(&self) -> f32 {
-        self.grid_view.cell_size
+        self.cell_size
     }
 
     /// Gets a rectangle representing the grid in game coordinates.
     pub fn get_rect(&self) -> Rect {
-        self.grid_view.rect
+        self.rect
     }
 
     /// Returns the origin of the grid in window coordinates.
     pub fn get_origin(&self) -> Point2<f32> {
-        self.grid_view.grid_origin
+        self.grid_origin
     }
 
     /// Returns the width of the grid in pixels.
     pub fn grid_width(&self) -> u32 {
-        self.grid_view.columns as u32 * self.grid_view.cell_size as u32
+        self.columns as u32 * self.cell_size as u32
     }
 
     /// Returns the height of the grid in pixels.
     pub fn grid_height(&self) -> u32 {
-        self.grid_view.rows as u32 * self.grid_view.cell_size as u32
+        self.rows as u32 * self.cell_size as u32
     }
 
     pub fn get_rect_from_origin(&self) -> Rect {
@@ -285,36 +299,7 @@ impl Viewport {
     }
 
     pub fn get_screen_area(&self, cell: Cell) -> Option<Rect> {
-        self.grid_view.window_coords_from_game(cell)
-    }
-}
-
-/// Controls the mapping between window and game coordinates.
-/// This should always be sized with respect to the window, otherwise we'll
-/// get black bars.
-struct GridView {
-    rect:        Rect,  // the area the game grid takes up on screen
-    cell_size:   f32,   // zoom level in window coordinates
-    columns:     usize, // width in game coords (should match bitmap/universe width)
-    rows:        usize, // height in game coords (should match bitmap/universe height)
-    // The grid origin point tells us where the top-left of the universe is with respect to the
-    // window.
-    grid_origin: Point2<f32>, // top-left corner of grid in window coords. (may be outside rect)
-}
-
-
-impl GridView {
-
-    /// Creates a new Gridview which maintains control over how the conwayste universe is positioned with
-    /// respect to the window.
-    pub fn new(cell_size: f32, universe_width_in_cells: usize, universe_height_in_cells: usize) -> GridView {
-        GridView {
-            rect:        Rect::new(0.0, 0.0, DEFAULT_SCREEN_WIDTH, DEFAULT_SCREEN_HEIGHT),
-            cell_size:   cell_size,
-            columns:     universe_width_in_cells,
-            rows:        universe_height_in_cells,
-            grid_origin: Point2::new(0.0, 0.0),
-        }
+        self.window_coords_from_game(cell)
     }
 
     /// Attempt to return a tuple of cell coordinates within the game space.
@@ -365,12 +350,12 @@ impl GridView {
         return None;
     }
 
-    /// Sets the width of the viewport in window coordinates (pixels).
+    /// Sets the width of the GridView in window coordinates (pixels).
     pub fn set_width(&mut self, width: f32) {
         self.rect.w = width;
     }
 
-    /// Sets the height of the viewport in window coordinates (pixels).
+    /// Sets the height of the GridView in window coordinates (pixels).
     pub fn set_height(&mut self, height: f32) {
         self.rect.h = height;
     }

--- a/conwayste/src/viewport.rs
+++ b/conwayste/src/viewport.rs
@@ -364,7 +364,7 @@ impl GridView {
     }
 
     /// The column and row supplied lies is `None` outside of the grid.
-    // Otherwise we'll translate a row/column pair into its representative rectangle.
+    /// Otherwise we'll translate a row/column pair into its representative rectangle.
     fn window_coords_from_game(&self, cell: Cell) -> Option<Rect> {
         if cell.row < self.rows && cell.col < self.columns {
             return self.window_coords_from_game_unchecked( cell.col as isize, cell.row as isize);

--- a/conwayste/src/viewport.rs
+++ b/conwayste/src/viewport.rs
@@ -90,10 +90,6 @@ impl Viewport {
                 ZoomDirection::ZoomOut => ZOOM_OUT,
             };
 
-            //debug!("Window Size: ({}, {})", self.grid_view.rect.w, self.grid_view.rect.h);
-            //debug!("Origin Before: ({},{})", self.grid_view.grid_origin.x, self.grid_view.grid_origin.y);
-            //debug!("Cell Size Before: {},", self.grid_view.cell_size);
-
             let next_cell_size = self.grid_view.cell_size + zoom_dir;
             let old_cell_size = self.grid_view.cell_size;
             let cell_size_delta = next_cell_size - old_cell_size;
@@ -106,9 +102,6 @@ impl Viewport {
                                                  old_cell_center_x as f32 * old_cell_size as f32);
                 let delta_y = cell_size_delta * (old_cell_center_y as f32 * next_cell_size as f32 -
                                                  old_cell_center_y as f32 * old_cell_size as f32);
-
-                //debug!("current cell count: {}, {}", old_cell_center_x, old_cell_center_x);
-                //debug!("delta in win coords: {}, {}", delta_x, delta_y);
 
                 self.grid_view.cell_size = next_cell_size;
 
@@ -126,8 +119,6 @@ impl Viewport {
 
                 self.adjust_panning(true, NO_INPUT);
 
-                //debug!("Origin After: ({},{})\n", self.grid_view.grid_origin.x, self.grid_view.grid_origin.y);
-                //debug!("Cell Size After: {},", self.grid_view.cell_size);
             }
         }
     }
@@ -332,7 +323,7 @@ impl GridView {
         let col: isize = ((point.x - self.grid_origin.x) / self.cell_size) as isize;
         let row: isize = ((point.y - self.grid_origin.y) / self.cell_size) as isize;
 
-        (col , row)
+        (col, row)
     }
 
     /// Given a window point in pixels, we'll determine the nearest intersecting

--- a/conwayste/src/viewport.rs
+++ b/conwayste/src/viewport.rs
@@ -297,7 +297,7 @@ impl Viewport {
 }
 
 /// Controls the mapping between window and game coordinates.
-/// This should always  be sized with respect to the window, otherwise we'll
+/// This should always be sized with respect to the window, otherwise we'll
 /// get black bars.
 struct GridView {
     rect:        Rect,  // the area the game grid takes up on screen
@@ -312,7 +312,7 @@ struct GridView {
 
 impl GridView {
 
-    /// Creates a new Gridview which maintains control over how the conwayste universe is positioned within
+    /// Creates a new Gridview which maintains control over how the conwayste universe is positioned with
     /// respect to the window.
     pub fn new(cell_size: f32, universe_width_in_cells: usize, universe_height_in_cells: usize) -> GridView {
         GridView {

--- a/conwayste/src/viewport.rs
+++ b/conwayste/src/viewport.rs
@@ -244,13 +244,11 @@ impl Viewport {
         self.adjust_panning(false, direction);
     }
 
-    /// Set dimensions of the grid. This may cause unintended consequences if modified during run-time. 
-    /// Be mindful of the window size.
-    pub fn set_dimensions(&mut self, w: f32, h: f32) {
-        self.grid_view.set_width(w);
-        self.grid_view.set_height(h);
-        self.grid_view.rect.w = w;
-        self.grid_view.rect.h = h;
+    /// Set dimensions of the grid in window coordinates (pixels). This may cause unintended
+    /// consequences if modified while a game is running.  Be mindful of the window size.
+    pub fn set_dimensions(&mut self, w: u32, h: u32) {
+        self.grid_view.set_width(w as f32);
+        self.grid_view.set_height(h as f32);
     }
 
     /// Given a point, find the nearest Cell specified by a row and column.
@@ -372,12 +370,12 @@ impl GridView {
         return None;
     }
 
-    /// Sets the width of the viewport.
+    /// Sets the width of the viewport in window coordinates (pixels).
     pub fn set_width(&mut self, width: f32) {
         self.rect.w = width;
     }
 
-    /// Sets the height of the viewport.
+    /// Sets the height of the viewport in window coordinates (pixels).
     pub fn set_height(&mut self, height: f32) {
         self.rect.h = height;
     }

--- a/conwayste/src/viewport.rs
+++ b/conwayste/src/viewport.rs
@@ -278,6 +278,11 @@ impl GridView {
         self.grid_origin
     }
 
+    /// Sets the origin of the grid in window coordinates.
+    pub fn set_origin(&mut self, point: Point2<f32>) {
+        self.grid_origin = point;
+    }
+
     /// Returns the width of the grid in pixels.
     pub fn grid_width(&self) -> f32 {
         self.columns as f32 * self.cell_size
@@ -294,10 +299,6 @@ impl GridView {
         let full_height = self.grid_height() as f32;
 
         Rect::new(origin.x, origin.y, full_width, full_height)
-    }
-
-    pub fn get_screen_area(&self, cell: Cell) -> Option<Rect> {
-        self.window_coords_from_game(cell)
     }
 
     /// Attempt to return a tuple of cell coordinates within the game space.
@@ -325,7 +326,7 @@ impl GridView {
     /// Attempt to return a rectangle for the on-screen area of the specified cell.
     /// If partially in view, will be clipped by the bounding rectangle.
     /// Caller must ensure that column and row are within bounds.
-    fn window_coords_from_game_unchecked(&self, col: isize, row: isize) -> Option<Rect> {
+    pub fn window_coords_from_game_unchecked(&self, col: isize, row: isize) -> Option<Rect> {
         let left   = self.grid_origin.x + (col as f32)     * self.cell_size;
         let right  = self.grid_origin.x + (col + 1) as f32 * self.cell_size - 1.0;
         let top    = self.grid_origin.y + (row as f32)     * self.cell_size;
@@ -341,7 +342,7 @@ impl GridView {
 
     /// The column and row supplied lies is `None` outside of the grid.
     /// Otherwise we'll translate a row/column pair into its representative rectangle.
-    fn window_coords_from_game(&self, cell: Cell) -> Option<Rect> {
+    pub fn window_coords_from_game(&self, cell: Cell) -> Option<Rect> {
         if cell.row < self.rows && cell.col < self.columns {
             return self.window_coords_from_game_unchecked( cell.col as isize, cell.row as isize);
         }

--- a/conwayste/src/viewport.rs
+++ b/conwayste/src/viewport.rs
@@ -84,11 +84,10 @@ impl Viewport {
         if (direction == ZoomDirection::ZoomIn && self.grid_view.cell_size < MAX_CELL_SIZE) ||
            (direction == ZoomDirection::ZoomOut && self.grid_view.cell_size > MIN_CELL_SIZE) {
 
-            let zoom_dir: f32;
-            match direction {
-                ZoomDirection::ZoomIn => zoom_dir = ZOOM_IN,
-                ZoomDirection::ZoomOut => zoom_dir = ZOOM_OUT,
-            }
+            let zoom_dir: f32 = match direction {
+                ZoomDirection::ZoomIn => ZOOM_IN,
+                ZoomDirection::ZoomOut => ZOOM_OUT,
+            };
 
             //debug!("Window Size: ({}, {})", self.grid_view.rect.w, self.grid_view.rect.h);
             //debug!("Origin Before: ({},{})", self.grid_view.grid_origin.x, self.grid_view.grid_origin.y);
@@ -96,13 +95,14 @@ impl Viewport {
 
             let next_cell_size = self.grid_view.cell_size + zoom_dir;
             let old_cell_size = self.grid_view.cell_size;
+            let cell_size_delta = next_cell_size - old_cell_size;
 
             let window_center = Point2::new(self.grid_view.rect.w/2.0, self.grid_view.rect.h/2.0);
 
             if let Some(cell) = self.grid_view.game_coords_from_window(window_center) {
                 let (old_cell_count_for_x, old_cell_count_for_y) = (cell.row, cell.col);
-                let delta_x = zoom_dir * (old_cell_count_for_x as f32 * next_cell_size as f32 - old_cell_count_for_x as f32 * old_cell_size as f32);
-                let delta_y = zoom_dir * (old_cell_count_for_y as f32 * next_cell_size as f32 - old_cell_count_for_y as f32 * old_cell_size as f32);
+                let delta_x = cell_size_delta * (old_cell_count_for_x as f32 * next_cell_size as f32 - old_cell_count_for_x as f32 * old_cell_size as f32);
+                let delta_y = cell_size_delta * (old_cell_count_for_y as f32 * next_cell_size as f32 - old_cell_count_for_y as f32 * old_cell_size as f32);
 
                 //debug!("current cell count: {}, {}", old_cell_count_for_x, old_cell_count_for_x);
                 //debug!("delta in win coords: {}, {}", delta_x, delta_y);
@@ -116,8 +116,8 @@ impl Viewport {
 
                 if phi > alpha {
                     self.grid_view.grid_origin = utils::Graphics::point_offset(self.grid_view.grid_origin,
-                                                                         -zoom_dir * delta_x,
-                                                                         -zoom_dir * delta_y
+                                                                         -cell_size_delta * delta_x,
+                                                                         -cell_size_delta * delta_y
                                                                          );
                 }
 


### PR DESCRIPTION
Fixes:
* fix intro centering
* fix video options alignment
* change some datatypes

Merge checklist:
- [x] **fix the issue with offset drawing when the gray area outside the grid is visible**
- [x] clean up `GridView` and `Viewport` in viewport.rs
- [x] clean up `VideoSettings` and `DisplayModeManager` in video.rs
- [x] ensure that if `fullscreen = true` in config on startup, that the logic is not reversed and it actually starts in fullscreen mode.
- [x] fix `draw_universe` TODO
- [x] use `f32` for window coordinates to match ggez
- [x] center intro even when fullscreen
- [x] center the menu
- [x] no warnings
