### PR TITLE
Insert patterns with 2-9 and 0; reset with 1

### DIFF
--- a/conwayste/src/client.rs
+++ b/conwayste/src/client.rs
@@ -1519,23 +1519,17 @@ impl MainState {
     ///
     /// This will return an error if the selected RLE pattern is invalid.
     fn bit_pattern_from_char(&self, keycode: KeyCode) -> Result<(BitGrid, usize, usize), Box<dyn Error>> {
-        // TODO: make this configurable
+        let gameplay = &self.config.get().gameplay;
         let rle_str = match keycode {
-            KeyCode::Key2 => "bob$2bo$3o!",  // SE glider
-            KeyCode::Key3 => "o$obo$2o!",    // SW glider
-            KeyCode::Key4 => "3o$o$bo!",     // NW glider
-            KeyCode::Key5 => "b2o$obo$2bo!", // NE glider
-
-            KeyCode::Key6 => "4bo$5bo$o4bo$b5o!",         // E LWSS
-            KeyCode::Key7 => "bo$o$o$o$o2bo$3o!",         // S LWSS
-            KeyCode::Key8 => "5o$o4bo$o$bo!",             // W LWSS
-            KeyCode::Key9 => "b3o$o2bo$3bo$3bo$3bo$2bo!", // N LWSS
-
-            // https://www.conwaylife.com/wiki/Period-22_glider_gun
-            KeyCode::Key0 => concat!("18b2o25b$19bo7bo17b$19bobo14b2o7b$20b2o12b2o2bo6b$24b3o7b2ob2o6b$24b2o",
-                                     "b2o7b3o6b$24bo2b2o12b2o2b$25b2o14bobob$35bo7bob$43b2o2$2o23bo19b$bo21b",
-                                     "obo19b$bobo13b3o4b2o19b$2b2o3bo8bo3bo24b$6bob2o6bo4bo23b$5bo4bo6b2obo",
-                                     "9bo14b$6bo3bo8bo3b2o6bo13b$7b3o13bobo3b3o13b$25bo19b$25b2o!"),
+            KeyCode::Key2 => &gameplay.pattern2,
+            KeyCode::Key3 => &gameplay.pattern3,
+            KeyCode::Key4 => &gameplay.pattern4,
+            KeyCode::Key5 => &gameplay.pattern5,
+            KeyCode::Key6 => &gameplay.pattern6,
+            KeyCode::Key7 => &gameplay.pattern7,
+            KeyCode::Key8 => &gameplay.pattern8,
+            KeyCode::Key9 => &gameplay.pattern9,
+            KeyCode::Key0 => &gameplay.pattern0,
             _ => "", // unexpected
         };
         let pat = Pattern(rle_str.to_owned());

--- a/conwayste/src/client.rs
+++ b/conwayste/src/client.rs
@@ -626,43 +626,23 @@ impl EventHandler for MainState {
 
         let current_screen = self.get_current_screen();
 
+        let mut do_return = false; // we need to abort if one of the draw_* methods fail
         match current_screen {
             Screen::Intro => {
-                let result = self.draw_intro(ctx);
-                let mut out_result: GameResult<()> = Ok(());
-                let mut do_return = false;
-                handle_error!(result,
-                    GameError => |e| {
-                        out_result = Err(e);
-                    },
-                    else => |e| {
-                        error!("Error from draw_intro: {}", e);
-                        do_return = true;
-                    }
-                ).unwrap();
-                if do_return {
-                    return out_result;
-                }
+                self.draw_intro(ctx).unwrap_or_else(|e| {
+                    error!("Error from draw_intro: {}", e);
+                    do_return = true;
+                });
             }
             Screen::Menu => {
                 self.menu_sys.draw_menu(&self.video_settings, ctx, self.first_gen_was_drawn)?;
             }
             Screen::Run => {
-                let result = self.draw_universe(ctx);
-                let mut out_result: GameResult<()> = Ok(());
                 let mut do_return = false;
-                handle_error!(result,
-                    GameError => |e| {
-                        out_result = Err(e);
-                    },
-                    else => |e| {
-                        error!("Error from draw_universe: {}", e);
-                        do_return = true;
-                    }
-                ).unwrap();
-                if do_return {
-                    return out_result;
-                }
+                self.draw_universe(ctx).unwrap_or_else(|e| {
+                    error!("Error from draw_universe: {}", e);
+                    do_return = true;
+                });
             }
             Screen::InRoom => {
                 ui::draw_text(ctx, self.system_font.clone(), *MENU_TEXT_COLOR, String::from("In Room"), &Point2::new(100.0, 100.0))?;
@@ -673,6 +653,11 @@ impl EventHandler for MainState {
                 // TODO
              },
             Screen::Exit => {}
+        }
+
+        if do_return {
+            // error in above match -- can't pass on error because it's a GameResult (no enum for this!)
+            return Ok(());
         }
 
         if let Some(ref mut layers) = LayoutManager::get_screen_layers(&mut self.ui_layout, current_screen) {

--- a/conwayste/src/client.rs
+++ b/conwayste/src/client.rs
@@ -49,6 +49,7 @@ use conway::grids::{CharGrid, BitGrid};
 use conway::rle::Pattern;
 use conway::ConwayResult;
 use conway::error::ConwayError;
+use conway::Rotation;
 
 use netwayste::net::NetwaysteEvent;
 
@@ -576,7 +577,21 @@ impl EventHandler for MainState {
                         }
                     }
                 } else if is_shift && self.arrow_input != (0, 0) {
-                    if let Some((ref _grid, _width, _height)) = self.insert_mode {
+                    if let Some((ref mut grid, width, height)) = self.insert_mode {
+                        let rotation = match self.arrow_input {
+                            (-1, 0) => Some(Rotation::CCW),
+                            ( 1, 0) => Some(Rotation::CW),
+                            (0, 0) => unreachable!(),
+                            _ => None,   // do nothing in this case
+                        };
+                        if let Some(rotation) = rotation {
+                            let center = (width/2, height/2);
+                            grid.rotate(rotation, center).unwrap_or_else(|e| {
+                                error!("Failed to rotate pattern {:?} around {:?}: {:?}", rotation, center, e);
+                            });
+                        } else {
+                            info!("Ignoring Shift-<Up/Down>");
+                        }
                     }
                 }
 

--- a/conwayste/src/client.rs
+++ b/conwayste/src/client.rs
@@ -577,7 +577,7 @@ impl EventHandler for MainState {
                         }
                     }
                 } else if is_shift && self.arrow_input != (0, 0) {
-                    if let Some((ref mut grid, width, height)) = self.insert_mode {
+                    if let Some((ref mut grid, ref mut width, ref mut height)) = self.insert_mode {
                         let rotation = match self.arrow_input {
                             (-1, 0) => Some(Rotation::CCW),
                             ( 1, 0) => Some(Rotation::CW),
@@ -585,10 +585,13 @@ impl EventHandler for MainState {
                             _ => None,   // do nothing in this case
                         };
                         if let Some(rotation) = rotation {
-                            let center = (width/2, height/2);
-                            grid.rotate(rotation, center).unwrap_or_else(|e| {
-                                error!("Failed to rotate pattern {:?} around {:?}: {:?}", rotation, center, e);
+                            grid.rotate(*width, *height, rotation).unwrap_or_else(|e| {
+                                error!("Failed to rotate pattern {:?}: {:?}", rotation, e);
                             });
+                            // reverse the stored width and height
+                            let (new_width, new_height) = (*height, *width);
+                            *width = new_width;
+                            *height = new_height;
                         } else {
                             info!("Ignoring Shift-<Up/Down>");
                         }

--- a/conwayste/src/client.rs
+++ b/conwayste/src/client.rs
@@ -631,7 +631,7 @@ impl EventHandler for MainState {
                 let result = self.draw_intro(ctx);
                 let mut out_result: GameResult<()> = Ok(());
                 let mut do_return = false;
-                handle_error!{result,
+                handle_error!(result,
                     GameError => |e| {
                         out_result = Err(e);
                     },
@@ -639,7 +639,7 @@ impl EventHandler for MainState {
                         error!("Error from draw_intro: {}", e);
                         do_return = true;
                     }
-                };
+                ).unwrap();
                 if do_return {
                     return out_result;
                 }
@@ -651,7 +651,7 @@ impl EventHandler for MainState {
                 let result = self.draw_universe(ctx);
                 let mut out_result: GameResult<()> = Ok(());
                 let mut do_return = false;
-                handle_error!{result,
+                handle_error!(result,
                     GameError => |e| {
                         out_result = Err(e);
                     },
@@ -659,7 +659,7 @@ impl EventHandler for MainState {
                         error!("Error from draw_universe: {}", e);
                         do_return = true;
                     }
-                };
+                ).unwrap();
                 if do_return {
                     return out_result;
                 }

--- a/conwayste/src/client.rs
+++ b/conwayste/src/client.rs
@@ -947,8 +947,7 @@ impl MainState {
                 return Err(format!("Unexpected player ID {}", self.uni_draw_params.player_id).into());
             }
             let player_cell_state = CellState::Alive(Some(self.uni_draw_params.player_id as usize));
-            let mut player_color = self.color_settings.get_color(Some(player_cell_state));
-            player_color.a = 0.5;  // semi-transparent since this is an overlay
+            let player_color = self.color_settings.get_color(Some(player_cell_state));
             if let Some(cursor_cell) = viewport.game_coords_from_window(self.inputs.mouse_info.position) {
                 let (cursor_col, cursor_row) = (cursor_cell.col, cursor_cell.row);
                 grid.each_set(|grid_col, grid_row| {
@@ -970,6 +969,7 @@ impl MainState {
                                 return;
                             }
                         }
+                        color.a = 0.5;  // semi-transparent since this is an overlay
                         let p = graphics::DrawParam::new()
                             .dest(Point2::new(rect.x, rect.y))
                             .scale(Vector2::new(rect.w, rect.h))

--- a/conwayste/src/client.rs
+++ b/conwayste/src/client.rs
@@ -626,22 +626,18 @@ impl EventHandler for MainState {
 
         let current_screen = self.get_current_screen();
 
-        let mut do_return = false; // we need to abort if one of the draw_* methods fail
         match current_screen {
             Screen::Intro => {
                 self.draw_intro(ctx).unwrap_or_else(|e| {
                     error!("Error from draw_intro: {}", e);
-                    do_return = true;
                 });
             }
             Screen::Menu => {
                 self.menu_sys.draw_menu(&self.video_settings, ctx, self.first_gen_was_drawn)?;
             }
             Screen::Run => {
-                let mut do_return = false;
                 self.draw_universe(ctx).unwrap_or_else(|e| {
                     error!("Error from draw_universe: {}", e);
-                    do_return = true;
                 });
             }
             Screen::InRoom => {
@@ -653,11 +649,6 @@ impl EventHandler for MainState {
                 // TODO
              },
             Screen::Exit => {}
-        }
-
-        if do_return {
-            // error in above match -- can't pass on error because it's a GameResult (no enum for this!)
-            return Ok(());
         }
 
         if let Some(ref mut layers) = LayoutManager::get_screen_layers(&mut self.ui_layout, current_screen) {

--- a/conwayste/src/config.rs
+++ b/conwayste/src/config.rs
@@ -152,16 +152,28 @@ impl Default for GamePlaySettings {
     fn default() -> Self {
         GamePlaySettings {
             zoom: DEFAULT_ZOOM_LEVEL,
-            pattern2: "bob$2bo$3o!".to_owned(),  // SE glider
-            pattern3: "o$obo$2o!".to_owned(),    // SW glider
-            pattern4: "3o$o$bo!".to_owned(),     // NW glider
-            pattern5: "b2o$obo$2bo!".to_owned(), // NE glider
-            pattern6: "4bo$5bo$o4bo$b5o!".to_owned(),         // E LWSS
-            pattern7: "bo$o$o$o$o2bo$3o!".to_owned(),         // S LWSS
-            pattern8: "5o$o4bo$o$bo!".to_owned(),             // W LWSS
-            pattern9: "b3o$o2bo$3bo$3bo$3bo$2bo!".to_owned(), // N LWSS
+            pattern2: "bob$2bo$3o!".to_owned(),                     // SE glider
+            pattern3: "4bo$5bo$o4bo$b5o!".to_owned(),               // E LWSS
+            pattern4: "2o2b$obob$2bob$2b2o!".to_owned(),            // NW eater
+            pattern5: "2o$2o!".to_owned(),                          // block
+            pattern6: "b2o$2ob$bo!".to_owned(),                     // R-pentomino
+            pattern7: "10o!".to_owned(),                            // flashy thingy idk the name
 
-            // https://www.conwaylife.com/wiki/Period-22_glider_gun
+            // First-ever P23 oscillator "David Hilbert", discovered 2019-11-23.
+            // https://www.conwaylife.com/wiki/David_Hilbert
+            // https://www.conwaylife.com/forums/viewtopic.php?t=&p=85719#p85719
+            pattern8: concat!("16b2o$16bo$17bo$14b4o$5b2o7bo$5bo11b3o$2b2obo11bo2bob2o$o2bob2o3bo3bo",
+                               "4b2obo2bo$2obo5b2o2bobo6bob2o$3bo5bo5bo6bo$3b2o7b3o6b2o$7b3o3$9bobo$9b",
+                               "2o3b3o$14b3o$9b2o$9b2o3$11bo$3b2o5b2o9b2o$3bo5b2obo9bo$2obo6bobo9bob2o",
+                               "$o2bob2o4b2o6b2obo2bo$2b2obo11bo2bob2o$5bo11b3o$5b2o7bo$14b4o$17bo$16b",
+                               "o$16b2o!").to_owned(),
+
+            // N cottonmouth ship. https://www.conwaylife.com/wiki/Cottonmouth
+            pattern9: concat!("2b2o2b2o$4b2o$4b2o$bobo2bobo$bo6bo2$bo6bo$2b2o2b2o$3b4o2$3o4b3o2$2o6b",
+                              "2o$2o6b2o2$bo6bo$bobo2bobo2$2b2o2b2o$bo6bo2$4b2o$3bo2bo$3bo2bo$2bo4bo$",
+                              "2bo4bo$3b4o$2b2o2b2o$2bo4bo$2bo4bo3$3b4o$4b2o!").to_owned(),
+
+            // NW P22 glider gun. https://www.conwaylife.com/wiki/Period-22_glider_gun
             pattern0: concat!("18b2o25b$19bo7bo17b$19bobo14b2o7b$20b2o12b2o2bo6b$24b3o7b2ob2o6b$24b2o",
                               "b2o7b3o6b$24bo2b2o12b2o2b$25b2o14bobob$35bo7bob$43b2o2$2o23bo19b$bo21b",
                               "obo19b$bobo13b3o4b2o19b$2b2o3bo8bo3bo24b$6bob2o6bo4bo23b$5bo4bo6b2obo",

--- a/conwayste/src/config.rs
+++ b/conwayste/src/config.rs
@@ -137,12 +137,35 @@ impl Default for AudioSettings {
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct GamePlaySettings {
     pub zoom: f32,
+    pub pattern2: String,
+    pub pattern3: String,
+    pub pattern4: String,
+    pub pattern5: String,
+    pub pattern6: String,
+    pub pattern7: String,
+    pub pattern8: String,
+    pub pattern9: String,
+    pub pattern0: String,
 }
 
 impl Default for GamePlaySettings {
     fn default() -> Self {
         GamePlaySettings {
             zoom: DEFAULT_ZOOM_LEVEL,
+            pattern2: "bob$2bo$3o!".to_owned(),  // SE glider
+            pattern3: "o$obo$2o!".to_owned(),    // SW glider
+            pattern4: "3o$o$bo!".to_owned(),     // NW glider
+            pattern5: "b2o$obo$2bo!".to_owned(), // NE glider
+            pattern6: "4bo$5bo$o4bo$b5o!".to_owned(),         // E LWSS
+            pattern7: "bo$o$o$o$o2bo$3o!".to_owned(),         // S LWSS
+            pattern8: "5o$o4bo$o$bo!".to_owned(),             // W LWSS
+            pattern9: "b3o$o2bo$3bo$3bo$3bo$2bo!".to_owned(), // N LWSS
+
+            // https://www.conwaylife.com/wiki/Period-22_glider_gun
+            pattern0: concat!("18b2o25b$19bo7bo17b$19bobo14b2o7b$20b2o12b2o2bo6b$24b3o7b2ob2o6b$24b2o",
+                              "b2o7b3o6b$24bo2b2o12b2o2b$25b2o14bobob$35bo7bob$43b2o2$2o23bo19b$bo21b",
+                              "obo19b$bobo13b3o4b2o19b$2b2o3bo8bo3bo24b$6bob2o6bo4bo23b$5bo4bo6b2obo",
+                              "9bo14b$6bo3bo8bo3b2o6bo13b$7b3o13bobo3b3o13b$25bo19b$25b2o!").to_owned(),
         }
     }
 }

--- a/conwayste/src/constants.rs
+++ b/conwayste/src/constants.rs
@@ -55,6 +55,7 @@ pub mod colors {
         pub static ref GEN_COUNTER_COLOR: Color = Color::from(css::RED);
         pub static ref UNIVERSE_BG_COLOR: Color = Color::new( 0.25,  0.25,  0.25, 1.0);
         pub static ref LAYER_TRANSPARENCY_BG_COLOR: Color = color_with_alpha(css::HONEYDEW, 0.4);
+        pub static ref INSERT_PATTERN_UNWRITABLE: Color = Color::from(css::RED);
     }
 }
 

--- a/conwayste/src/error.rs
+++ b/conwayste/src/error.rs
@@ -94,6 +94,10 @@
 /// ).unwrap(); // this unwrap will never panic because of the else block
 /// ```
 ///
+/// NOTE: when using `.unwrap()`, be sure to use parentheses for the macro call (e.g.,
+/// `handle_error!(...)`) and not curly braces, otherwise you will get a confusing `expected
+/// expression` error.
+///
 
 #[macro_export]
 macro_rules! handle_error {
@@ -104,7 +108,9 @@ macro_rules! handle_error {
                 boxed_error.downcast::<$matcher>()
                     .and_then(|$var: Box<$matcher>| {
                         let $var = *$var; // unbox
+                        #[allow(unused_variables)]
                         let val = $result;
+                        #[allow(unreachable_code)]
                         Ok(val)
                     })
             })
@@ -119,7 +125,9 @@ macro_rules! handle_error {
        )
         .or_else(|boxed_error| -> Result<$type, Box<dyn Error>> {
             let $default_var = boxed_error;
+            #[allow(unused_variables)]
             let val = $default_result;
+            #[allow(unreachable_code)]
             Ok(val)
         })
    };

--- a/conwayste/src/error.rs
+++ b/conwayste/src/error.rs
@@ -104,7 +104,7 @@ macro_rules! handle_error {
    ($input:ident -> $type:ty $(, $matcher:ty => |$var:ident| $result:expr)*) => {
        $input
         $(
-            .or_else(|boxed_error| -> Result<$type, Box<dyn Error>> {
+            .or_else(|boxed_error: Box<dyn Error>| -> Result<$type, Box<dyn Error>> {
                 boxed_error.downcast::<$matcher>()
                     .and_then(|$var: Box<$matcher>| {
                         let $var = *$var; // unbox
@@ -123,7 +123,7 @@ macro_rules! handle_error {
                 , $matcher => |$var| $result
             )*
        )
-        .or_else(|boxed_error| -> Result<$type, Box<dyn Error>> {
+        .or_else(|boxed_error: Box<dyn Error>| -> Result<$type, Box<dyn Error>> {
             let $default_var = boxed_error;
             #[allow(unused_variables)]
             let val = $default_result;

--- a/conwayste/src/input.rs
+++ b/conwayste/src/input.rs
@@ -73,7 +73,7 @@ impl MouseInfo {
 pub struct KeyInfo {
     pub key: Option<KeyCode>,
     pub repeating: bool,
-    pub modifier: Option<KeyMods>,
+    pub modifier: KeyMods,
     pub debug_print: bool,
 }
 
@@ -82,7 +82,7 @@ impl KeyInfo {
         KeyInfo {
             key: None,
             repeating: false,
-            modifier: None,
+            modifier: KeyMods::NONE,
             debug_print: false,
         }
     }

--- a/conwayste/src/viewport.rs
+++ b/conwayste/src/viewport.rs
@@ -313,7 +313,7 @@ impl GridView {
     /// Given a window point in pixels, we'll determine the nearest intersecting
     /// row, column pair.
     // Given a Point2<f32>(x,y), we determine a col/row tuple in cell units
-    fn game_coords_from_window(&self, point: Point2<f32>) -> Option<Cell> {
+    pub fn game_coords_from_window(&self, point: Point2<f32>) -> Option<Cell> {
         let (col, row) = self.game_coords_from_window_unchecked(point);
 
         if col < 0 || col >= self.columns as isize || row < 0 || row >= self.rows as isize {

--- a/libconway/src/grids.rs
+++ b/libconway/src/grids.rs
@@ -15,6 +15,7 @@
  *  You should have received a copy of the GNU General Public License
  *  along with libconway.  If not, see <http://www.gnu.org/licenses/>. */
 
+use std::error::Error;
 use std::ops::{Index, IndexMut};
 use std::cmp;
 use crate::universe::Region;
@@ -26,6 +27,13 @@ pub enum BitOperation {
     Clear,
     Set,
     Toggle
+}
+
+/// Defines a rotation.
+#[derive(Eq, PartialEq, Debug, Clone, Copy)]
+pub enum Rotation {
+    CW,  // clockwise
+    CCW, // counter-clockwise
 }
 
 
@@ -214,6 +222,17 @@ impl BitGrid {
                 }
             }
         }
+    }
+
+    /// Rotates pattern in the specified direction around the specified center point.
+    ///
+    /// # Errors
+    ///
+    pub fn rotate(&mut self, rotation: Rotation, (center_col, center_row): (usize, usize)) -> Result<(), Box<dyn Error>> {
+        let new_width_in_words = (self.height() - 1)/64 + 1;   // number of words needed for this many cells
+        let new_height = self.width();
+        let mut new = BitGrid::new(new_width_in_words, new_height);
+        Ok(())
     }
 }
 

--- a/libconway/src/grids.rs
+++ b/libconway/src/grids.rs
@@ -199,6 +199,22 @@ impl BitGrid {
             }
         }
     }
+
+    /// Calls callback on each bit that is set (1). Callback receives (col, row).
+    pub fn each_set<F: FnMut(usize, usize)>(&self, mut callback: F) {
+        for row in 0 .. self.height() {
+            let mut col = 0;
+            for col_idx in 0 .. self.width_in_words() {
+                for shift in (0..64).rev() {
+                    let word = self.0[row][col_idx];
+                    if (word>>shift)&1 == 1 {
+                        callback(col, row);
+                    }
+                    col += 1;
+                }
+            }
+        }
+    }
 }
 
 

--- a/libconway/src/lib.rs
+++ b/libconway/src/lib.rs
@@ -26,5 +26,7 @@ pub mod error;
 
 pub use error::{ConwayError, ConwayResult};
 
+pub use grids::Rotation;
+
 #[cfg(test)]
 pub mod tests;

--- a/libconway/src/rle.rs
+++ b/libconway/src/rle.rs
@@ -192,7 +192,9 @@ impl CharGrid for PatternSize {
     /// Height in cells
     fn height(&self) -> usize { self.row + 1 }
 
-    fn get_run(&self, _col: usize, _row: usize, _visibility: Option<usize>) -> (usize, char) { unimplemented!("PatternSize is write-only"); }
+    fn get_run(&self, _col: usize, _row: usize, _visibility: Option<usize>) -> (usize, char) {
+        unimplemented!("PatternSize is write-only");
+    }
 }
 
 

--- a/libconway/src/tests.rs
+++ b/libconway/src/tests.rs
@@ -977,6 +977,19 @@ mod grid_tests {
         let pat_r = grid.to_pattern(None);
         assert_eq!(pat_r, Pattern("o$obo$2o!".to_owned()));
     }
+
+    #[test]
+    fn bit_grid_each_set1() {
+        let pat = Pattern("bo$2bo$3o!".to_owned());
+        let grid = pat.to_new_bit_grid(3, 3).unwrap();
+        let expected = vec![(1, 0), (2, 1), (0, 2), (1, 2), (2, 2)];
+        let mut i = 0;
+        grid.each_set(|c,r| {
+            assert_eq!((c, r), expected[i]);
+            i += 1;
+        });
+        assert_eq!(i, expected.len());
+    }
 }
 
 

--- a/libconway/src/universe.rs
+++ b/libconway/src/universe.rs
@@ -1320,7 +1320,7 @@ impl Universe {
     /// 
     /// Does numerous consistency checks on the bitmaps, and panics if inconsistencies are found.
     //XXX non_dead_cells_in_region
-    pub fn each_non_dead(&self, region: Region, visibility: Option<usize>, callback: &mut FnMut(usize, usize, CellState)) {
+    pub fn each_non_dead(&self, region: Region, visibility: Option<usize>, callback: &mut dyn FnMut(usize, usize, CellState)) {
         let cells = &self.gen_states[self.state_index].cells;
         let wall  = &self.gen_states[self.state_index].wall_cells;
         let known = &self.gen_states[self.state_index].known;
@@ -1415,7 +1415,7 @@ impl Universe {
     /// Iterate over every non-dead cell in the universe for the current generation.
     /// `visibility` is an optional player_id, allowing filtering based on fog.
     /// Callback receives (col, row, cell_state).
-    pub fn each_non_dead_full(&self, visibility: Option<usize>, callback: &mut FnMut(usize, usize, CellState)) {
+    pub fn each_non_dead_full(&self, visibility: Option<usize>, callback: &mut dyn FnMut(usize, usize, CellState)) {
         self.each_non_dead(self.region(), visibility, callback);
     }
 

--- a/libconway/src/universe.rs
+++ b/libconway/src/universe.rs
@@ -849,7 +849,17 @@ impl Universe {
         if player_id >= self.player_writable.len() {
             return Err(ConwayError::InvalidData{reason: format!("Unexpected player_id {}", player_id)});
         }
-        Ok(self.player_writable[player_id].contains(col as isize, row as isize))
+        let in_writable_region = self.player_writable[player_id].contains(col as isize, row as isize);
+        if !in_writable_region {
+            return Ok(false);
+        }
+
+        let wall  = &self.gen_states[self.state_index].wall_cells;
+        let word_col = col/64;
+        let shift = 63 - (col & (64 - 1));
+        let on_wall_cell = (wall[row][word_col] >> shift) & 1 == 1;
+
+        Ok(!on_wall_cell)
     }
 
 


### PR DESCRIPTION
Change your insert mode with number keys! Works when paused or running.
- [x] insert patterns
- [x] fix bug causing regular cell toggle to not work
- [x] center inserts under cursor
- [x] visible indicator of what will be inserted (0.5 alpha).
- [x] truncate overlay where not writable
- [x] patterns configurable in conwayste.toml
- [x] rotate with Shift-Arrow
- [x] add unit tests for what I changed/added in libconway