### PR TITLE
Move hover check in on_click to caller's scope

### DIFF
--- a/conwayste/src/ui/button.rs
+++ b/conwayste/src/ui/button.rs
@@ -153,7 +153,6 @@ impl Widget for Button {
 
     fn on_click(&mut self, _point: &Point2<f32>) -> Option<(WidgetID, UIAction)>
     {
-        //debug!("Clicked Button, '{:?}'", self.label.textfrag);
         return Some((self.id, self.action));
     }
 

--- a/conwayste/src/ui/button.rs
+++ b/conwayste/src/ui/button.rs
@@ -153,14 +153,8 @@ impl Widget for Button {
 
     fn on_click(&mut self, _point: &Point2<f32>) -> Option<(WidgetID, UIAction)>
     {
-        let hover = self.hover;
-        self.hover = false;
-
-        if hover {
-            debug!("Clicked Button, '{:?}'", self.label.textfrag);
-            return Some((self.id, self.action));
-        }
-        None
+        //debug!("Clicked Button, '{:?}'", self.label.textfrag);
+        return Some((self.id, self.action));
     }
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult<()> {

--- a/conwayste/src/ui/chatbox.rs
+++ b/conwayste/src/ui/chatbox.rs
@@ -244,13 +244,9 @@ impl Widget for Chatbox {
 
     fn on_hover(&mut self, point: &Point2<f32>) {
         self.hover = within_widget(point, &self.dimensions);
-        //if self.hover {
-        //    debug!("Hovering over Chatbox, \"{:?}\"", self.label.dimensions);
-        //}
     }
 
     fn on_click(&mut self, _point: &Point2<f32>) -> Option<(WidgetID, UIAction)> {
-        //debug!("Clicked within Chatbox");
         return Some((self.id, self.action));
     }
 

--- a/conwayste/src/ui/chatbox.rs
+++ b/conwayste/src/ui/chatbox.rs
@@ -250,15 +250,8 @@ impl Widget for Chatbox {
     }
 
     fn on_click(&mut self, _point: &Point2<f32>) -> Option<(WidgetID, UIAction)> {
-        let hover = self.hover;
-        self.hover = false;
-
-        if hover {
-            debug!("Clicked within Chatbox");
-            return Some((self.id, self.action));
-        }
-
-        None
+        //debug!("Clicked within Chatbox");
+        return Some((self.id, self.action));
     }
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult<()> {

--- a/conwayste/src/ui/checkbox.rs
+++ b/conwayste/src/ui/checkbox.rs
@@ -135,14 +135,10 @@ impl Widget for Checkbox {
     fn on_hover(&mut self, point: &Point2<f32>) {
         let label_dimensions = self.label.size();
         self.hover = within_widget(point, &self.dimensions) || within_widget(point, &label_dimensions);
-        if self.hover {
-            //debug!("Hovering over Checkbox, '{:?}'", label_dimensions);
-        }
     }
 
     fn on_click(&mut self, _point: &Point2<f32>) -> Option<(WidgetID, UIAction)>
     {
-        //debug!("Clicked Checkbox, '{}'", self.label.textfrag.text);
         return Some(( self.id, UIAction::Toggle(self.toggle_checkbox()) ));
     }
 

--- a/conwayste/src/ui/checkbox.rs
+++ b/conwayste/src/ui/checkbox.rs
@@ -142,14 +142,8 @@ impl Widget for Checkbox {
 
     fn on_click(&mut self, _point: &Point2<f32>) -> Option<(WidgetID, UIAction)>
     {
-        let hover = self.hover;
-        self.hover = false;
-
-        if hover {
-            //debug!("Clicked Checkbox, '{}'", self.label.textfrag.text);
-            return Some(( self.id, UIAction::Toggle(self.toggle_checkbox()) ));
-        }
-        None
+        //debug!("Clicked Checkbox, '{}'", self.label.textfrag.text);
+        return Some(( self.id, UIAction::Toggle(self.toggle_checkbox()) ));
     }
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult<()> {

--- a/conwayste/src/ui/layer.rs
+++ b/conwayste/src/ui/layer.rs
@@ -21,6 +21,7 @@ use ggez::nalgebra::{Point2, Vector2};
 use ggez::{Context, GameResult};
 
 use super::{
+    common::within_widget,
     widget::Widget,
     Pane,
     TextField,
@@ -146,9 +147,11 @@ impl Widget for Layer {
 
     fn on_click(&mut self, point: &Point2<f32>) -> Option<(WidgetID, UIAction)> {
         for w in self.widgets.iter_mut() {
-            let ui_action = w.on_click(point);
-            if ui_action.is_some() {
-                return ui_action;
+            if within_widget(point, &w.size()) {
+                let ui_action = w.on_click(point);
+                if ui_action.is_some() {
+                    return ui_action;
+                }
             }
         }
         None

--- a/conwayste/src/ui/pane.rs
+++ b/conwayste/src/ui/pane.rs
@@ -137,9 +137,11 @@ impl Widget for Pane {
 
         if hover {
             for w in self.widgets.iter_mut() {
-                let ui_action = w.on_click(point);
-                if ui_action.is_some() {
-                    return ui_action;
+                if within_widget(point, &w.size()) {
+                    let ui_action = w.on_click(point);
+                    if ui_action.is_some() {
+                        return ui_action;
+                    }
                 }
             }
         }

--- a/conwayste/src/ui/textfield.rs
+++ b/conwayste/src/ui/textfield.rs
@@ -263,14 +263,8 @@ impl Widget for TextField {
     }
 
     fn on_click(&mut self, _point: &Point2<f32>) -> Option<(WidgetID, UIAction)> {
-        let hover = self.hover;
-        self.hover = false;
-
-        if hover {
-            self.enter_focus();
-            return Some((self.id, self.action));
-        }
-        None
+        self.enter_focus();
+        return Some((self.id, self.action));
     }
 
     fn update(&mut self, _ctx: &mut Context) -> GameResult<()> {


### PR DESCRIPTION
Implements discussion from  #76 

- [x] Change all `on_click()` usage to remove hover check
- [x] Ensure layer and pane both check the mouse point is within the widget's boundaries before calling `on_click()`
- [x] Unit tests passing
- [x] No new warnings