### PR TITLE
Use id_tree-generated NodeId's instead of statically defined WidgetID's

### DIFF
--- a/conwayste/src/client.rs
+++ b/conwayste/src/client.rs
@@ -485,8 +485,8 @@ impl EventHandler for MainState {
                     }
 
                     if left_mouse_click {
-                        if let Some( (ui_id, ui_action) ) = layer.on_click(&mouse_point) {
-                            self.handle_ui_action(ctx, ui_id, ui_action).or_else(|e| -> UIResult<()> {
+                        if let Some( ui_action ) = layer.on_click(&mouse_point) {
+                            self.handle_ui_action(ctx, ui_action).or_else(|e| -> UIResult<()> {
                                 error!("Failed to handle UI action: {}", e);
                                 Ok(())
                             }).unwrap();
@@ -500,7 +500,8 @@ impl EventHandler for MainState {
                 // TODO Disable FSP limit until we decide if we need it
                 // while timer::check_update_time(ctx, FPS) {
                 let mut textfield_under_focus = false;
-                match TextField::widget_from_screen_and_id(&mut self.ui_layout, Screen::Run, INGAME_PANE1_CHATBOXTEXTFIELD) {
+                let id = self.ui_layout.chatbox_tf_id.clone();
+                match TextField::widget_from_screen_and_id(&mut self.ui_layout, Screen::Run, &id) {
                     Ok(tf) => {
                         match tf.input_state {
                             Some(TextInputState::TextInputComplete) =>  {
@@ -1068,11 +1069,12 @@ impl MainState {
                 return Ok(());
             }
             KeyCode::Return => {
-                match TextField::widget_from_screen_and_id(&mut self.ui_layout, Screen::Run, INGAME_PANE1_CHATBOXTEXTFIELD) {
+                let id = self.ui_layout.chatbox_tf_id.clone();
+                match TextField::widget_from_screen_and_id(&mut self.ui_layout, Screen::Run, &id) {
                     Ok(tf) => {
                         if tf.input_state.is_none() {
                             if let Some(layer) = LayoutManager::get_screen_layering(&mut self.ui_layout, Screen::Run) {
-                                layer.enter_focus(INGAME_PANE1_CHATBOXTEXTFIELD)?;
+                                layer.enter_focus(&id)?;
                             }
                         }
                     }
@@ -1390,8 +1392,9 @@ impl MainState {
             }
         }
 
+        let id = self.ui_layout.chatbox_tf_id.clone();
         for msg in incoming_messages {
-            match Chatbox::widget_from_screen_and_id(&mut self.ui_layout, Screen::Run, INGAME_PANE1_CHATBOX) {
+            match Chatbox::widget_from_screen_and_id(&mut self.ui_layout, Screen::Run, &id) {
                 Ok(cb) => cb.add_message(msg),
                 Err(e) => error!("Could not add mesasge to Chatbox on network message receive: {:?}", e)
             }

--- a/conwayste/src/client.rs
+++ b/conwayste/src/client.rs
@@ -804,8 +804,6 @@ impl EventHandler for MainState {
             return;
         }
 
-        // PR_GATE: Ameen to look at why it doesn't print the error after a TF loses focus
-        // and then remove the er ror message once fixed, and this misspelled comment
         let screen = self.get_current_screen();
         match LayoutManager::focused_textfield_mut(&mut self.ui_layout, screen) {
             Ok(tf) => tf.on_char(character),

--- a/conwayste/src/constants.rs
+++ b/conwayste/src/constants.rs
@@ -1,4 +1,4 @@
-/*  Copyright 2018 the Conwayste Developers.
+/*  Copyright 2018-2020 the Conwayste Developers.
  *
  *  This file is part of conwayste.
  *

--- a/conwayste/src/constants.rs
+++ b/conwayste/src/constants.rs
@@ -90,23 +90,6 @@ pub const CHATBOX_LINE_SPACING: f32 = 2.0;
 pub const CHATBOX_HISTORY: usize = 20;
 pub const CHAT_TEXTFIELD_HEIGHT: f32 = (25.0);
 
-pub mod widget_ids {
-    use crate::ui::WidgetID;
-    pub const MAINMENU_LAYER1: WidgetID = WidgetID(0);
-    pub const MAINMENU_TESTBUTTON: WidgetID = WidgetID(1);
-    pub const MAINMENU_TESTBUTTONLABEL: WidgetID = WidgetID(2);
-    pub const MAINMENU_TESTCHECKBOX: WidgetID = WidgetID(3);
-    pub const MAINMENU_PANE1: WidgetID = WidgetID(4);
-    pub const MAINMENU_PANE1_BUTTONYES: WidgetID = WidgetID(5);
-    pub const MAINMENU_PANE1_BUTTONYESLABEL: WidgetID = WidgetID(6);
-    pub const MAINMENU_PANE1_BUTTONNO: WidgetID = WidgetID(7);
-    pub const MAINMENU_PANE1_BUTTONNOLABEL: WidgetID = WidgetID(8);
-    pub const INGAME_LAYER1: WidgetID = WidgetID(9);
-    pub const INGAME_PANE1: WidgetID = WidgetID(10);
-    pub const INGAME_PANE1_CHATBOX: WidgetID = WidgetID(11);
-    pub const INGAME_PANE1_CHATBOXTEXTFIELD: WidgetID = WidgetID(12);
-}
-
 // Layering's tree data structure capacities. Arbitrarily chosen.
 pub const LAYERING_NODE_CAPACITY: usize = 100;
 pub const LAYERING_SWAP_CAPACITY: usize = 10;

--- a/conwayste/src/ui/button.rs
+++ b/conwayste/src/ui/button.rs
@@ -23,17 +23,18 @@ use ggez::graphics::{self, Rect, Color, DrawMode, DrawParam};
 use ggez::nalgebra::{Point2, Vector2};
 use ggez::{Context, GameResult};
 
+use id_tree::NodeId;
+
 use super::{
     label::Label,
     widget::Widget,
     common::{within_widget, color_with_alpha, center, FontInfo},
     UIAction,
     UIError, UIResult,
-    WidgetID
 };
 
 pub struct Button {
-    id: WidgetID,
+    id: Option<NodeId>,
     z_index: usize,
     pub label: Label,
     pub button_color: Color,
@@ -62,9 +63,7 @@ impl Button {
     ///
     /// # Arguments
     /// * `ctx` - GGEZ context
-    /// * `widget_id` - Unique widget identifier
     /// * `action` - Unique action identifer
-    /// * `label_id` - Unique widget identifier for the associated label representing the button's text
     /// * `font_info` - font descriptor to be used when drawing the text
     /// * `button_text` - Text to be displayed
     ///
@@ -77,9 +76,8 @@ impl Button {
     /// let font = Font::Default;
     /// let font_info = common::FontInfo::new(ctx, font, Some(20.0));
     /// let b = Button::new(
-    ///     ctx, ui::TestButton1,
+    ///     ctx,
     ///     UIAction::PrintHelloWorld,
-    ///     ui::TestButton1Label,
     ///     font_info,
     ///     "TestButton"
     /// );
@@ -89,9 +87,7 @@ impl Button {
     ///
     pub fn new(
         ctx: &mut Context,
-        widget_id: WidgetID,
         action: UIAction,
-        label_id: WidgetID,
         font_info: FontInfo,
         button_text: String,
     ) -> Self {
@@ -99,7 +95,6 @@ impl Button {
         let label_position = Point2::new(0.0, 0.0);
         let label = Label::new(
             ctx,
-            label_id,
             font_info,
             button_text,
             color_with_alpha(css::WHITE, 0.1),
@@ -115,7 +110,7 @@ impl Button {
         );
 
         let mut b = Button {
-            id: widget_id,
+            id: None,
             z_index: std::usize::MAX,
             label: label,
             button_color: color_with_alpha(css::DARKCYAN, 0.8),
@@ -144,8 +139,12 @@ impl Button {
 }
 
 impl Widget for Button {
-    fn id(&self) -> WidgetID {
-        self.id
+    fn id(&self) -> Option<&NodeId> {
+        self.id.as_ref()
+    }
+
+    fn set_id(&mut self, new_id: NodeId) {
+        self.id = Some(new_id);
     }
 
     fn z_index(&self) -> usize {
@@ -160,9 +159,9 @@ impl Widget for Button {
         self.hover = within_widget(point, &self.dimensions);
     }
 
-    fn on_click(&mut self, _point: &Point2<f32>) -> Option<(WidgetID, UIAction)>
+    fn on_click(&mut self, _point: &Point2<f32>) -> Option<UIAction>
     {
-        return Some((self.id, self.action));
+        return Some(self.action);
     }
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult<()> {

--- a/conwayste/src/ui/button.rs
+++ b/conwayste/src/ui/button.rs
@@ -1,4 +1,4 @@
-/*  Copyright 2019 the Conwayste Developers.
+/*  Copyright 2019-2020 the Conwayste Developers.
  *
  *  This file is part of conwayste.
  *

--- a/conwayste/src/ui/checkbox.rs
+++ b/conwayste/src/ui/checkbox.rs
@@ -23,19 +23,20 @@ use ggez::graphics::{self, Rect, DrawMode, DrawParam};
 use ggez::nalgebra::{Point2, Vector2};
 use ggez::{Context, GameResult};
 
+use id_tree::NodeId;
+
 use super::{
     label::Label,
     widget::Widget,
     common::{within_widget, FontInfo},
     UIAction,
     UIError, UIResult,
-    WidgetID,
 };
 
 use crate::constants::colors::*;
 
 pub struct Checkbox {
-    id: WidgetID,
+    id: Option<NodeId>,
     z_index: usize,
     pub label: Label,
     pub enabled: bool,
@@ -60,7 +61,6 @@ impl Checkbox {
     ///
     /// # Arguments
     /// * `ctx` - GGEZ context
-    /// * `widget_id` - Unique widget identifier
     /// * `enabled` - initial to checked or unchecked
     /// * `font_info` - font descriptor to be used when drawing the text
     /// * `text` - Label text
@@ -76,7 +76,6 @@ impl Checkbox {
     /// let font_info = common::FontInfo::new(ctx, font, Some(20.0));
     /// let checkbox = Checkbox::new(
     ///     ctx,
-    ///     ui::TestCheckbox,
     ///     false,
     ///     font_info,
     ///     "Toggle Me",
@@ -87,7 +86,6 @@ impl Checkbox {
     ///
     pub fn new(
         ctx: &mut Context,
-        widget_id: WidgetID,
         enabled: bool,
         font_info: FontInfo,
         text: String,
@@ -99,9 +97,9 @@ impl Checkbox {
         );
 
         Checkbox {
-            id: widget_id,
+            id: None,
             z_index: std::usize::MAX,
-            label: Label::new(ctx, widget_id, font_info, text, *CHECKBOX_TEXT_COLOR, label_origin),
+            label: Label::new(ctx, font_info, text, *CHECKBOX_TEXT_COLOR, label_origin),
             enabled: enabled,
             dimensions: dimensions,
             hover: false,
@@ -118,8 +116,12 @@ impl Checkbox {
 
 
 impl Widget for Checkbox {
-    fn id(&self) -> WidgetID {
-        self.id
+    fn id(&self) -> Option<&NodeId> {
+        self.id.as_ref()
+    }
+
+    fn set_id(&mut self, new_id: NodeId) {
+        self.id = Some(new_id);
     }
 
     fn z_index(&self) -> usize {
@@ -182,10 +184,10 @@ impl Widget for Checkbox {
         self.hover = within_widget(point, &self.dimensions) || within_widget(point, &label_dimensions);
     }
 
-    fn on_click(&mut self, _point: &Point2<f32>) -> Option<(WidgetID, UIAction)>
+    fn on_click(&mut self, _point: &Point2<f32>) -> Option<UIAction>
     {
         // TODO: Check child label for an on_click event once it's refactored out
-        return Some(( self.id, UIAction::Toggle(self.toggle_checkbox()) ));
+        return Some(UIAction::Toggle(self.toggle_checkbox()));
     }
 
     fn draw(&mut self, ctx: &mut Context) -> GameResult<()> {

--- a/conwayste/src/ui/checkbox.rs
+++ b/conwayste/src/ui/checkbox.rs
@@ -1,5 +1,5 @@
 
-/*  Copyright 2019 the Conwayste Developers.
+/*  Copyright 2019-2020 the Conwayste Developers.
  *
  *  This file is part of conwayste.
  *

--- a/conwayste/src/ui/common.rs
+++ b/conwayste/src/ui/common.rs
@@ -28,7 +28,7 @@ macro_rules! widget_from_id {
         use super::layer::Layering;
 
         impl $type {
-            pub fn widget_from_id(layer: &mut Layering, id: WidgetID) -> UIResult<&mut $type>
+            pub fn widget_from_id<'a, 'b>(layer: &'b mut Layering, id: &'a NodeId) -> UIResult<&'b mut $type>
             {
                 let widget_result = layer.get_widget_mut(id);
                 match widget_result {
@@ -67,7 +67,7 @@ macro_rules! widget_from_id {
 ///
 /// # Examples
 /// ```rust
-/// let widget = layer.get_widget_mut(WidgetID(0));
+/// let widget = layer.get_widget_mut(a_node_id);
 /// let textfield = downcast_widget_mut!(widget, TextField);
 /// textfield.enter_focus()
 /// ```

--- a/conwayste/src/ui/common.rs
+++ b/conwayste/src/ui/common.rs
@@ -1,4 +1,4 @@
-/*  Copyright 2019 the Conwayste Developers.
+/*  Copyright 2019-2020 the Conwayste Developers.
  *
  *  This file is part of conwayste.
  *

--- a/conwayste/src/ui/label.rs
+++ b/conwayste/src/ui/label.rs
@@ -24,15 +24,16 @@ use ggez::nalgebra::{Point2, Vector2};
 #[cfg(test)]
 use ggez::graphics::Font;
 
+use id_tree::NodeId;
+
 use super::{
     common::FontInfo,
     widget::Widget,
     UIError, UIResult,
-    WidgetID
 };
 
 pub struct Label {
-    id: WidgetID,
+    id: Option<NodeId>,
     z_index: usize,
     pub textfrag: TextFragment,
     pub dimensions: Rect,
@@ -50,7 +51,6 @@ impl Label {
     ///
     /// # Arguments
     /// * `ctx` - GGEZ context
-    /// * `widget_id` - Unique widget identifier
     /// * `font` - font to be used when drawing the text
     /// * `string` - Label text
     /// * `color` - Text color
@@ -66,7 +66,6 @@ impl Label {
     /// let font_info = FontInfo::new(font, Some(20.0));
     /// let label = Label::new(
     ///     ctx,
-    ///     ui::TestLabel,
     ///     font_info,
     ///     "TestButton",
     ///     Color::from(css::DARKCYAN),
@@ -78,7 +77,6 @@ impl Label {
     ///
     pub fn new(
         ctx: &mut Context,
-        widget_id: WidgetID,
         font_info: FontInfo,
         string: String,
         color: Color,
@@ -106,7 +104,7 @@ impl Label {
         dimensions.move_to(dest);
 
         Label {
-            id: widget_id,
+            id: None,
             z_index: std::usize::MAX,
             textfrag: text_fragment,
             dimensions: dimensions
@@ -116,8 +114,12 @@ impl Label {
 
 impl Widget for Label {
     /// Retrieves the widget's unique identifer
-    fn id(&self) -> WidgetID {
-        self.id
+    fn id(&self) -> Option<&NodeId> {
+        self.id.as_ref()
+    }
+
+    fn set_id(&mut self, new_id: NodeId) {
+        self.id = Some(new_id);
     }
 
     fn z_index(&self) -> usize {

--- a/conwayste/src/ui/label.rs
+++ b/conwayste/src/ui/label.rs
@@ -1,4 +1,4 @@
-/*  Copyright 2019 the Conwayste Developers.
+/*  Copyright 2019-2020 the Conwayste Developers.
  *
  *  This file is part of conwayste.
  *

--- a/conwayste/src/ui/layer.rs
+++ b/conwayste/src/ui/layer.rs
@@ -169,7 +169,7 @@ impl Layering {
     /// Add a widget to the layering, where the z-order is specified by the insert modifier.
     /// Widgets can be inserted at the current layer, at the next layer (one order higher), or nested
     /// to a widget-container (like a Pane). The widget's z-index is overridden by the destination
-    /// layer's z-order.
+    /// layer's z-order. `set_id` is called on the widget after insertion to update the widget's id.
     ///
     /// # Return
     /// Returns a unique node identifier assigned to the successfully inserted widget.
@@ -186,11 +186,9 @@ impl Layering {
     ) -> UIResult<NodeId> {
         // Check that we aren't inserting a widget into the tree that already exists
          if let Some(id) = widget.id() {
-            if self.widget_exists(id) {
-                return Err(Box::new(UIError::NodeIDCollision {
-                    reason: format!("Widget with ID {:?} exists in layer's widget tree.", id),
-                }));
-            }
+            return Err(Box::new(UIError::NodeIDCollision {
+                reason: format!("Widget with ID {:?} exists was assigned an ID already.", id),
+            }));
         }
 
         // Unwrap safe because our tree will always have a dummy root node

--- a/conwayste/src/ui/layer.rs
+++ b/conwayste/src/ui/layer.rs
@@ -133,7 +133,7 @@ impl Layering {
         let mut s = String::new();
         let _ = self.widget_tree.write_formatted(&mut s);
         debug!("{}", s);
-        self.widget_tree.traverse_level_order(id).is_ok()
+        self.widget_tree.get(id).is_ok()
     }
 
     /// Collect all nodes in the tree belonging to the corresponding z_order

--- a/conwayste/src/ui/layer.rs
+++ b/conwayste/src/ui/layer.rs
@@ -265,7 +265,7 @@ impl Layering {
         node.data_mut().set_id(inserted_node_id.clone());
 
         // Note the behavior if id_tree (somehow) reused an ID
-        if !self.removed_node_ids.contains(&inserted_node_id) {
+        if self.removed_node_ids.contains(&inserted_node_id) {
             warn!("NodeId {:?} found in removed-hashset during widget insertion. Possible reusage!", inserted_node_id);
         }
 
@@ -292,7 +292,6 @@ impl Layering {
         // Insert the node's children ids to the removed hash-set
         if let Ok(children_ids ) = self.widget_tree.children_ids(&id) {
             // collect nodes to bypass issue with double borrow on ChildrenIds iterator
-            let children_ids: Vec<&NodeId> = children_ids.collect();
             for node_id_ref in children_ids {
                 self.removed_node_ids.insert((*node_id_ref).clone());
             }
@@ -301,7 +300,6 @@ impl Layering {
         // Finally check the node itself
         // clone is okay because the HashSet is intended to keep track of all removed widget ids
         // result not checked as this is reported during widget insertion
-        #[allow(unused)]
         self.removed_node_ids.insert(id.clone());
 
         // clone is okay because it is required
@@ -310,12 +308,12 @@ impl Layering {
                 // clone is okay for error reporting
                 reason: format!("NodeIDError occurred during removal of {:?}: {:?}", id.clone(), e)
             }));
-        });
+        })?;
 
         // Determine if the highest z-order changes due to the widget removal by checking no other
         // widgets are present at that z_order
-        while (self.highest_z_order != 0 &&
-            self.collect_node_ids(self.highest_z_order).is_empty()) {
+        while self.highest_z_order != 0 &&
+            self.collect_node_ids(self.highest_z_order).is_empty() {
             self.highest_z_order -= 1;
         }
 

--- a/conwayste/src/ui/mod.rs
+++ b/conwayste/src/ui/mod.rs
@@ -59,6 +59,3 @@ pub enum UIAction {
     Toggle(bool),
     EnterText, // TODO: see if we still need this "gunk residue"
 }
-
-#[derive(PartialOrd, PartialEq, Eq, Debug, Copy, Clone, Hash)]
-pub struct WidgetID(pub usize);

--- a/conwayste/src/ui/mod.rs
+++ b/conwayste/src/ui/mod.rs
@@ -1,4 +1,4 @@
-/*  Copyright 2019 the Conwayste Developers.
+/*  Copyright 2019-2020 the Conwayste Developers.
  *
  *  This file is part of conwayste.
  *

--- a/conwayste/src/ui/pane.rs
+++ b/conwayste/src/ui/pane.rs
@@ -22,18 +22,18 @@ use ggez::graphics::{self, Color, Rect, DrawMode, DrawParam};
 use ggez::nalgebra::{Point2, Vector2};
 use ggez::{Context, GameResult};
 
+use id_tree::NodeId;
+
 use super::{
     widget::Widget,
     common::{within_widget},
-    UIAction,
     UIError, UIResult,
-    WidgetID
 };
 
 use crate::constants::colors::*;
 
 pub struct Pane {
-    id: WidgetID,
+    id: Option<NodeId>,
     z_index: usize,
     pub dimensions: Rect,
     pub hover: bool,
@@ -54,10 +54,10 @@ impl fmt::Debug for Pane {
 
 /// A container of one or more widgets
 impl Pane {
-    /// Specify the unique widget identifer for the pane, and its dimensional bounds
-    pub fn new(widget_id: WidgetID, dimensions: Rect) -> Self {
+    /// Specify the dimensional bounds of the Pane container
+    pub fn new(dimensions: Rect) -> Self {
         Pane {
-            id: widget_id,
+            id: None,
             z_index: std::usize::MAX,
             dimensions: dimensions,
             hover: false,
@@ -80,8 +80,12 @@ impl Pane {
 }
 
 impl Widget for Pane {
-    fn id(&self) -> WidgetID {
-        self.id
+    fn id(&self) -> Option<&NodeId> {
+        self.id.as_ref()
+    }
+
+    fn set_id(&mut self, new_id: NodeId) {
+        self.id = Some(new_id);
     }
 
     fn z_index(&self) -> usize {
@@ -140,12 +144,6 @@ impl Widget for Pane {
     fn on_hover(&mut self, point: &Point2<f32>) {
         self.hover = within_widget(point, &self.dimensions);
     }
-
-    fn on_click(&mut self, _point: &Point2<f32>) -> Option<(WidgetID, UIAction)> {
-        // TODO: Need to pass children nodes
-        None
-    }
-
 
     /* TODO: fix all the drag issues
     /// original_pos is the mouse position at which the button was held before any dragging occurred

--- a/conwayste/src/ui/textfield.rs
+++ b/conwayste/src/ui/textfield.rs
@@ -1,4 +1,4 @@
-/*  Copyright 2019 the Conwayste Developers.
+/*  Copyright 2019-2020 the Conwayste Developers.
  *
  *  This file is part of conwayste.
  *

--- a/conwayste/src/ui/ui_errors.rs
+++ b/conwayste/src/ui/ui_errors.rs
@@ -22,7 +22,7 @@ custom_error! {pub UIError
     WidgetNotFound {reason: String} = "UIError::WidgetNotFound({reason})",
     InvalidAction {reason: String} = "UIError::InvalidAction({reason})",
     ActionRestricted{reason: String} = "UIError::ActionRestricted({reason})",
-    WidgetIDCollision{reason: String} = "UIError::WidgetIDCollision({reason})",
+    NodeIDCollision{reason: String} = "UIError::NodeIDCollision({reason})",
     InvalidArgument{reason: String} = "UIError::InvalidArgument({reason})",
 }
 

--- a/conwayste/src/ui/ui_errors.rs
+++ b/conwayste/src/ui/ui_errors.rs
@@ -1,4 +1,4 @@
-/*  Copyright 2019 the Conwayste Developers.
+/*  Copyright 2019-2020 the Conwayste Developers.
  *
  *  This file is part of Conwayste.
  *

--- a/conwayste/src/ui/widget.rs
+++ b/conwayste/src/ui/widget.rs
@@ -22,10 +22,11 @@ use ggez::nalgebra::{Point2, Vector2};
 
 use downcast_rs::Downcast;
 
+use id_tree::NodeId;
+
 use super::{
     UIAction,
     UIResult,
-    WidgetID
 };
 
 /// A user interface element trait that defines graphical, interactive behavior to be specified.
@@ -36,7 +37,10 @@ use super::{
 /// custom widget type.
 pub trait Widget: Downcast + std::fmt::Debug {
     /// Retrieves the widget's unique identifer
-    fn id(&self) -> WidgetID;
+    fn id(&self) -> Option<&NodeId>;
+
+    fn set_id(&mut self, new_id: NodeId);
+
 
     /// Retreives the widget's draw stack order
     fn z_index(&self) -> usize;
@@ -52,7 +56,7 @@ pub trait Widget: Downcast + std::fmt::Debug {
     }
 
     /// Action to be taken when the widget is given the provided point, and a mouse click occurs
-    fn on_click(&mut self, _point: &Point2<f32>) -> Option<(WidgetID, UIAction)> {
+    fn on_click(&mut self, _point: &Point2<f32>) -> Option<UIAction> {
         None
     }
 

--- a/conwayste/src/ui/widget.rs
+++ b/conwayste/src/ui/widget.rs
@@ -1,4 +1,4 @@
-/*  Copyright 2019 the Conwayste Developers.
+/*  Copyright 2019-2020 the Conwayste Developers.
  *
  *  This file is part of conwayste.
  *

--- a/conwayste/src/uilayout.rs
+++ b/conwayste/src/uilayout.rs
@@ -75,12 +75,8 @@ impl UILayout {
             chatbox_font_info,
             constants::CHATBOX_HISTORY
         );
-        match chatbox.set_rect(chatbox_rect) {
-            Ok(()) => { },
-            Err(e) => {
-                error!("Could not set size for chatbox during initialization! {:?}", e);
-            }
-        }
+        chatbox.set_rect(chatbox_rect)?;
+
         let chatbox = Box::new(chatbox);
 
         let textfield_rect = Rect::new(
@@ -111,12 +107,8 @@ impl UILayout {
                 "ServerList".to_owned()
             )
         );
-        match serverlist_button.set_rect(Rect::new(10.0, 10.0, 180.0, 50.0)) {
-            Ok(()) => { },
-            Err(e) => {
-                error!("Could not set size for serverlist button during initialization! {:?}", e );
-            }
-        }
+        serverlist_button.set_rect(Rect::new(10.0, 10.0, 180.0, 50.0))?;
+
         let mut inroom_button = Box::new(
             Button::new(
                 ctx,
@@ -125,12 +117,7 @@ impl UILayout {
                 "InRoom".to_owned()
             )
         );
-        match inroom_button.set_rect(Rect::new(10.0, 70.0, 180.0, 50.0)) {
-            Ok(()) => { },
-            Err(e) => {
-                error!("Could not set size for inroom button during initialization! {:?}", e);
-            }
-        }
+        inroom_button.set_rect(Rect::new(10.0, 70.0, 180.0, 50.0))?;
 
         let mut startgame_button = Box::new(
             Button::new(
@@ -140,12 +127,7 @@ impl UILayout {
                 "StartGame".to_owned()
             )
         );
-        match startgame_button.set_rect(Rect::new(10.0, 130.0, 180.0, 50.0)) {
-            Ok(()) => { },
-            Err(e) => {
-                error!("Could not set size for startgame button during initialization! {:?}", e);
-            }
-        }
+        startgame_button.set_rect(Rect::new(10.0, 130.0, 180.0, 50.0))?;
 
         let checkbox = Box::new(
             Checkbox::new(

--- a/conwayste/src/uilayout.rs
+++ b/conwayste/src/uilayout.rs
@@ -1,4 +1,4 @@
-/*  Copyright 2019 the Conwayste Developers.
+/*  Copyright 2019-2020 the Conwayste Developers.
  *
  *  This file is part of conwayste.
  *

--- a/conwayste/src/uimanager.rs
+++ b/conwayste/src/uimanager.rs
@@ -16,6 +16,7 @@
  *  along with conwayste.  If not, see
  *  <http://www.gnu.org/licenses/>. */
 #![allow(unused)]
+use id_tree::NodeId;
 
 use crate::Screen;
 use crate::uilayout::UILayout;
@@ -29,20 +30,18 @@ use crate::ui::{
     TextField,
     UIError,
     UIResult,
-    WidgetID,
 };
 
 // When adding support for a new widget, use this macro to define a routine which allows the
 // developer to search in a `UILayout`/`Screen` pair for a widget by its ID
 macro_rules! add_layering_support {
     ($type:ident) => {
-
-        impl $type {
+        impl<'a> $type {
             pub fn widget_from_screen_and_id(
-                ui: &mut UILayout,
+                ui: &'a mut UILayout,
                 screen: Screen,
-                id: WidgetID
-            ) -> UIResult<&mut $type> {
+                id: &'a NodeId
+            ) -> UIResult<&'a mut $type> {
                 if let Some(layer) = LayoutManager::get_screen_layering(ui, screen) {
                     return $type::widget_from_id(layer, id);
                 }
@@ -67,7 +66,7 @@ impl LayoutManager {
     pub fn focused_textfield_mut(ui: &mut UILayout, screen: Screen) -> UIResult<&mut TextField> {
         if let Some(layer) = Self::get_screen_layering(ui, screen) {
             if let Some(id) = layer.focused_widget_id() {
-                return TextField::widget_from_id(layer, id);
+                return TextField::widget_from_id(layer, &id);
             }
         }
         Err(Box::new(UIError::WidgetNotFound {

--- a/conwayste/src/uimanager.rs
+++ b/conwayste/src/uimanager.rs
@@ -1,4 +1,4 @@
-/*  Copyright 2019 the Conwayste Developers.
+/*  Copyright 2019-2020 the Conwayste Developers.
  *
  *  This file is part of conwayste.
  *


### PR DESCRIPTION
Resolves #97  

Simplified a lot of the code by using a `NodeId` instead of a `WidgetID`. 

Widgets are created without an identifier. As they are added to the layering's tree, `id_tree` generates a unique identifier which is then assigned to the widget. This is returned to the user in case they wish to keep track of a specific widget (like the chatbox, for example). 

Most of the time we use references to a `NodeId`, though there are a few exceptions to this rule and so a (relatively) cheap `clone` is used.

- [x] Try out option one to use `NodeId` from `id_tree` crate as a unique identifier
~~- [ ] Try out option two to use use our own implementation of `snowflake` or the like~~
- [x] Update copyright to 2020 for impacted files
- [x] Update unit tests
- [x] No new warnings
- [x] Verify no changes in behavior or functionality from prior implemenation

In the chatbox case, we'll eventually only need to keep track of the container's id instead of each component like is done in this PR. This will be much easier once #94 lands.