### PR TITLE
Add member names to enum variant fields in netwayste and clean up Option/Result usage

### DIFF
--- a/netwayste/examples/cli-client.rs
+++ b/netwayste/examples/cli-client.rs
@@ -37,7 +37,7 @@ use futures::sync::mpsc;
 use log::LevelFilter;
 use netwayste::{
     client::{ClientNetState, CLIENT_VERSION},
-    net::{NetwaysteEvent, RequestAction, Packet, ResponseCode},
+    net::NetwaysteEvent,
 };
 
 const SLEEP: Duration = Duration::from_millis(33);  // 30 "frames" per second

--- a/netwayste/src/net.rs
+++ b/netwayste/src/net.rs
@@ -113,11 +113,11 @@ pub enum ResponseCode {
     RoomList{rooms: Vec<RoomList>},   // list of rooms and their statuses
 
     // errors
-    BadRequest{error_msg: Option<String>},      // 400 unspecified error that is client's fault
-    Unauthorized{error_msg: Option<String>},    // 401 not logged in
-    TooManyRequests{error_msg: Option<String>}, // 429
-    ServerError{error_msg: Option<String>},     // 500
-    NotConnected{error_msg: Option<String>},    // no equivalent in HTTP due to handling at lower (TCP) level
+    BadRequest{error_msg: String},      // 400 unspecified error that is client's fault
+    Unauthorized{error_msg: String},    // 401 not logged in
+    TooManyRequests{error_msg: String}, // 429
+    ServerError{error_msg: String},     // 500
+    NotConnected{error_msg: String},    // no equivalent in HTTP due to handling at lower (TCP) level
     KeepAlive,                       // Server's heart is beating
 }
 
@@ -239,8 +239,8 @@ pub enum Packet {
     },
     Update {
         // in-game: sent by server
-        chats:           Option<Vec<BroadcastChatMessage>>, // All non-acknowledged chats are sent each update
-        game_updates:    Option<Vec<GameUpdate>>,           //
+        chats:           Vec<BroadcastChatMessage>, // All non-acknowledged chats are sent each update
+        game_updates:    Vec<GameUpdate>,           // Information pertaining to a game tick update
         universe_update: UniUpdateType,                     //
     },
     UpdateReply {
@@ -969,8 +969,8 @@ pub enum NetwaysteEvent {
     PlayerList(Vec<String>),     // list of players in room or lobby with ping (ms)
     RoomList(Vec<RoomList>), // (room name, # players, game has started?)
     LeftRoom,
-    BadRequest(Option<String>),
-    ServerError(Option<String>),
+    BadRequest(String),
+    ServerError(String),
 
     // Updates
     ChatMessages(Vec<(String, String)>), // (player name, message)

--- a/netwayste/src/server.rs
+++ b/netwayste/src/server.rs
@@ -134,7 +134,7 @@ impl Player {
     }
 
     // Allow dead_code for unit testing
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn has_chatted(&self) -> bool {
         if self.game_info.is_none() {
             return false;
@@ -369,7 +369,7 @@ impl ServerState {
     pub fn list_players(&self, player_id: PlayerID) -> ResponseCode {
         let opt_room = self.get_room(player_id);
         if opt_room.is_none() {
-            return ResponseCode::BadRequest{error_msg: Some("cannot list players because in lobby.".to_owned())};
+            return ResponseCode::BadRequest{error_msg: "cannot list players because in lobby.".to_owned()};
         }
         let room = opt_room.unwrap();
 
@@ -387,7 +387,7 @@ impl ServerState {
         let player_in_game = self.is_player_in_game(player_id);
 
         if !player_in_game {
-            return ResponseCode::BadRequest{error_msg: Some(format!("Player {} has not joined a game.", player_id))};
+            return ResponseCode::BadRequest{error_msg: format!("Player {} has not joined a game.", player_id)};
         }
 
         // We're borrowing self mutably below, so let's grab this now
@@ -400,7 +400,7 @@ impl ServerState {
         let opt_room = self.get_room_mut(player_id);
 
         if opt_room.is_none() {
-            return ResponseCode::BadRequest{error_msg: Some( format!("Player \"{}\" should be in a room! None found.", player_id ))};
+            return ResponseCode::BadRequest{error_msg:  format!("Player \"{}\" should be in a room! None found.", player_id )};
         }
 
         let room = opt_room.unwrap();
@@ -435,13 +435,14 @@ impl ServerState {
     pub fn create_new_room(&mut self, opt_player_id: Option<PlayerID>, room_name: String) -> ResponseCode {
         // validate length
         if room_name.len() > MAX_ROOM_NAME {
-            return ResponseCode::BadRequest{error_msg: Some(format!("room name too long; max {} characters",
-                                                            MAX_ROOM_NAME))};
+            return ResponseCode::BadRequest{
+                error_msg: format!("room name too long; max {} characters", MAX_ROOM_NAME)
+            };
         }
 
         if let Some(player_id) = opt_player_id {
             if self.is_player_in_game(player_id) {
-                return ResponseCode::BadRequest{error_msg: Some("cannot create room because in-game".to_owned())};
+                return ResponseCode::BadRequest{error_msg: "cannot create room because in-game".to_owned()};
             }
         }
 
@@ -451,14 +452,14 @@ impl ServerState {
 
             return ResponseCode::OK;
         } else {
-            return ResponseCode::BadRequest{error_msg: Some(format!("room name already in use"))};
+            return ResponseCode::BadRequest{error_msg: format!("room name already in use")};
         }
     }
 
     pub fn join_room(&mut self, player_id: PlayerID, room_name: String) -> ResponseCode {
         let already_playing = self.is_player_in_game(player_id);
         if already_playing {
-            return ResponseCode::BadRequest{error_msg: Some("cannot join game because in-game".to_owned())};
+            return ResponseCode::BadRequest{error_msg: "cannot join game because in-game".to_owned()};
         }
 
         let player: &mut Player = self.players.get_mut(&player_id).unwrap();
@@ -474,13 +475,13 @@ impl ServerState {
                 return ResponseCode::JoinedRoom{room_name};
             }
         }
-        return ResponseCode::BadRequest{error_msg: Some(format!("no room named {:?}", room_name))};
+        return ResponseCode::BadRequest{error_msg: format!("no room named {:?}", room_name)};
     }
 
     pub fn leave_room(&mut self, player_id: PlayerID) -> ResponseCode {
         let already_playing = self.is_player_in_game(player_id);
         if !already_playing {
-            return ResponseCode::BadRequest{error_msg: Some("cannot leave game because in lobby".to_owned())};
+            return ResponseCode::BadRequest{error_msg: "cannot leave game because in lobby".to_owned()};
         }
 
         let player: &mut Player = self.players.get_mut(&player_id).unwrap();
@@ -547,10 +548,10 @@ impl ServerState {
                 return self.leave_room(player_id);
             }
             RequestAction::Connect{..}     => {
-                return ResponseCode::BadRequest{error_msg:  Some("already connected".to_owned())};
+                return ResponseCode::BadRequest{error_msg: "Already connected".to_owned()};
             },
             RequestAction::None => {
-                return ResponseCode::BadRequest{error_msg:  Some("Invalid request".to_owned())};
+                return ResponseCode::BadRequest{error_msg: "Invalid request".to_owned()};
             },
         }
     }
@@ -971,18 +972,18 @@ impl ServerState {
             let response = Packet::Response{
                 sequence:    0,
                 request_ack: None,
-                code:        ResponseCode::Unauthorized{error_msg: Some("not a unique name".to_owned())},
+                code:        ResponseCode::Unauthorized{error_msg: "not a unique name".to_owned()},
             };
             return response;
         }
     }
 
     // Right now we'll be constructing all client Update packets for _every_ room.
-    pub fn construct_client_updates(&mut self) -> Result<Option<Vec<(SocketAddr, Packet)>>, Box<dyn Error>> {
+    pub fn construct_client_updates(&mut self) -> Option<Vec<(SocketAddr, Packet)>> {
         let mut client_updates: Vec<(SocketAddr, Packet)> = vec![];
 
         if self.rooms.len() == 0 {
-            return Ok(None);
+            return None;
         }
 
         // For each room, determine if each player has unread messages based on chat_msg_seq_num
@@ -1000,16 +1001,19 @@ impl ServerState {
                 let player: &Player = opt_player.unwrap();
                 if player.game_info.is_none() { continue; }
 
-                let unsent_messages: Option<Vec<BroadcastChatMessage>> = self.collect_unacknowledged_messages(&room, player);
-                let messages_available = unsent_messages.is_some();
+                let mut unsent_messages  = vec![];
+                if let Some(new_messages) = self.collect_unacknowledged_messages(&room, player) {
+                    unsent_messages = new_messages.to_vec();
+                }
 
+                let messages_available = unsent_messages.len() != 0;
                 // XXX Requires implementation
                 let game_updates_available = false;
                 let universe_updates_available = false;
 
                 let update_packet = Packet::Update {
                     chats:           unsent_messages,
-                    game_updates:    None,
+                    game_updates:    vec![],
                     universe_update: UniUpdateType::NoChange,
                 };
 
@@ -1020,9 +1024,9 @@ impl ServerState {
         }
 
         if client_updates.len() > 0 {
-            Ok(Some(client_updates))
+            Some(client_updates)
         } else {
-            Ok(None)
+            None
         }
     }
 
@@ -1262,22 +1266,11 @@ pub fn main() {
 
                 Event::TickEvent => {
                     server_state.expire_old_messages_in_all_rooms(time::Instant::now());
-                    let client_update_packets_result = server_state.construct_client_updates();
-                    if client_update_packets_result.is_ok() {
-                        let opt_update_packets = client_update_packets_result.unwrap();
-
-                        if let Some(update_packets) = opt_update_packets {
-                            for update in update_packets {
-                                netwayste_send!(tx, update, ("[EVENT::TICK] Could not send client update."));
-                            }
+                    if let Some(update_packets) =  server_state.construct_client_updates() {
+                        for update in update_packets {
+                            netwayste_send!(tx, update, ("[EVENT::TICK] Could not send client update."));
                         }
                     }
-
-                    /*
-                    for x in server_state.network_map.values() {
-                        trace!("\n\n\nNETWORK QUEUE CAPACITIES\n-----------------------\nTX: {}\nRX: {}\n\n\n", x.tx_packets.as_queue_type().capacity(), x.rx_packets.as_queue_type().capacity());
-                    }
-                    */
 
                     server_state.remove_timed_out_clients();
                     server_state.tick  = 1usize.wrapping_add(server_state.tick);
@@ -1669,7 +1662,7 @@ mod netwayste_server_tests {
         };
 
         let response = server.handle_chat_message(player_id, "test msg".to_owned());
-        assert_eq!(response, ResponseCode::BadRequest{error_msg: Some(format!("Player {} has not joined a game.", player_id))});
+        assert_eq!(response, ResponseCode::BadRequest{error_msg: format!("Player {} has not joined a game.", player_id)});
     }
 
     #[test]
@@ -1750,7 +1743,7 @@ mod netwayste_server_tests {
         let mut server = ServerState::new();
         let room_name = "0123456789ABCDEF_#".to_owned();
 
-        assert_eq!(server.create_new_room(None, room_name), ResponseCode::BadRequest{error_msg: Some("room name too long; max 16 characters".to_owned())});
+        assert_eq!(server.create_new_room(None, room_name), ResponseCode::BadRequest{error_msg: "room name too long; max 16 characters".to_owned()});
     }
 
     #[test]
@@ -1759,7 +1752,7 @@ mod netwayste_server_tests {
         let mut server = ServerState::new();
         let room_name = "some room".to_owned();
         assert_eq!(server.create_new_room(None, room_name.clone()), ResponseCode::OK);
-        assert_eq!(server.create_new_room(None, room_name), ResponseCode::BadRequest{error_msg: Some("room name already in use".to_owned())});
+        assert_eq!(server.create_new_room(None, room_name), ResponseCode::BadRequest{error_msg: "room name already in use".to_owned()});
     }
 
     #[test]
@@ -1779,7 +1772,7 @@ mod netwayste_server_tests {
             server.join_room(player_id, room_name.to_owned());
         }
 
-        assert_eq!( server.create_new_room(Some(player_id), other_room_name), ResponseCode::BadRequest{error_msg: Some("cannot create room because in-game".to_owned())} );
+        assert_eq!( server.create_new_room(Some(player_id), other_room_name), ResponseCode::BadRequest{error_msg: "cannot create room because in-game".to_owned()});
     }
 
     #[test]
@@ -1812,7 +1805,7 @@ mod netwayste_server_tests {
             p.player_id
         };
         assert_eq!(server.join_room(player_id, room_name.clone()), ResponseCode::JoinedRoom{room_name: "some room".to_owned()});
-        assert_eq!( server.join_room(player_id, room_name), ResponseCode::BadRequest{error_msg: Some("cannot join game because in-game".to_owned())} );
+        assert_eq!( server.join_room(player_id, room_name), ResponseCode::BadRequest{error_msg: "cannot join game because in-game".to_owned()});
     }
 
     #[test]
@@ -1826,7 +1819,7 @@ mod netwayste_server_tests {
 
             p.player_id
         };
-        assert_eq!(server.join_room(player_id, "some room".to_owned()), ResponseCode::BadRequest{error_msg: Some("no room named \"some room\"".to_owned())} );
+        assert_eq!(server.join_room(player_id, "some room".to_owned()), ResponseCode::BadRequest{error_msg: "no room named \"some room\"".to_owned()});
     }
 
     #[test]
@@ -1863,7 +1856,7 @@ mod netwayste_server_tests {
             p.player_id
         };
 
-        assert_eq!( server.leave_room(player_id), ResponseCode::BadRequest{error_msg: Some("cannot leave game because in lobby".to_owned())} );
+        assert_eq!( server.leave_room(player_id), ResponseCode::BadRequest{error_msg: "cannot leave game because in lobby".to_owned()});
     }
 
     #[test]
@@ -1874,7 +1867,7 @@ mod netwayste_server_tests {
         let rand_player_id = PlayerID(0x2457); //RUST
         assert_eq!(server.create_new_room(None, room_name.clone()), ResponseCode::OK);
 
-        assert_eq!( server.leave_room(rand_player_id), ResponseCode::BadRequest{error_msg: Some("cannot leave game because in lobby".to_owned())} );
+        assert_eq!( server.leave_room(rand_player_id), ResponseCode::BadRequest{error_msg: "cannot leave game because in lobby".to_owned()});
     }
 
     #[test]
@@ -2123,7 +2116,7 @@ mod netwayste_server_tests {
             Packet::Response{sequence: _, request_ack: _, code} => {
                 match code {
                     ResponseCode::Unauthorized{error_msg} => {
-                        assert_eq!(error_msg, Some("not a unique name".to_owned()));
+                        assert_eq!(error_msg, "not a unique name".to_owned());
                     }
                     _ => panic!("Unexpected ResponseCode: {:?}", code)
                 }
@@ -2180,13 +2173,14 @@ mod netwayste_server_tests {
     #[test]
     fn process_request_action_connect_while_connected() {
         let mut server = ServerState::new();
+        let player_name = "some player".to_owned();
         server.create_new_room(None, "some room".to_owned().clone());
         let player_id: PlayerID = {
-            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
             player.player_id
         };
-        let result = server.process_request_action(player_id, RequestAction::Connect{name: "some player".to_owned(), client_version: "0.1.0".to_owned()});
-        assert_eq!(result, ResponseCode::BadRequest{error_msg: Some("already connected".to_owned())});
+        let result = server.process_request_action(player_id, RequestAction::Connect{name: player_name, client_version: "0.1.0".to_owned()});
+        assert_eq!(result, ResponseCode::BadRequest{error_msg: "Already connected".to_owned()});
     }
 
     #[test]
@@ -2198,7 +2192,7 @@ mod netwayste_server_tests {
             player.player_id
         };
         let result = server.process_request_action(player_id, RequestAction::None);
-        assert_eq!(result, ResponseCode::BadRequest{error_msg: Some("Invalid request".to_owned())});
+        assert_eq!(result, ResponseCode::BadRequest{error_msg: "Invalid request".to_owned()});
     }
 
     #[test]
@@ -2281,18 +2275,16 @@ mod netwayste_server_tests {
     #[test]
     fn construct_client_updates_no_rooms() {
         let mut server = ServerState::new();
-        let result = server.construct_client_updates();
-        assert!(result.is_ok());
-        assert!(result.unwrap().is_none());
+        let opt_updates = server.construct_client_updates();
+        assert!(opt_updates.is_none());
     }
 
     #[test]
     fn construct_client_updates_empty_rooms() {
         let mut server = ServerState::new();
         server.create_new_room(None, "some room".to_owned().clone());
-        let result = server.construct_client_updates();
-        assert!(result.is_ok());
-        assert!(result.unwrap().is_none());
+        let opt_updates = server.construct_client_updates();
+        assert!(opt_updates.is_none());
     }
 
     #[test]
@@ -2312,12 +2304,11 @@ mod netwayste_server_tests {
         server.handle_chat_message(player_id, message_text.clone());
         server.handle_chat_message(player_id, message_text.clone());
         server.handle_chat_message(player_id, message_text.clone());
-        let result = server.construct_client_updates();
 
-        assert!(result.is_ok());
-        let opt_output = result.unwrap();
-        assert!(opt_output.is_some());
-        let mut output: Vec<(SocketAddr, Packet)> = opt_output.unwrap();
+        let opt_updates = server.construct_client_updates();
+        assert!(opt_updates.is_some());
+
+        let mut output: Vec<(SocketAddr, Packet)> = opt_updates.unwrap();
 
         // Vector should contain a single item for this test
         assert_eq!(output.len(), 1);
@@ -2327,14 +2318,14 @@ mod netwayste_server_tests {
 
         match pkt {
             Packet::Update{chats, game_updates, universe_update} => {
-                assert_eq!(game_updates, None);
+                assert!(game_updates.is_empty());
                 assert_eq!(universe_update, UniUpdateType::NoChange);
-                assert!(chats.is_some());
+                assert!(!chats.is_empty());
 
                 // All client chat sequence numbers start counting at 1
                 let mut i=1;
 
-                for msg in chats.unwrap() {
+                for msg in chats {
                     assert_eq!(msg.player_name, player_name);
                     assert_eq!(msg.chat_seq, Some(i));
                     assert_eq!(msg.message, message_text);
@@ -2370,12 +2361,10 @@ mod netwayste_server_tests {
         }
 
         // We should then only return the last chat
-        let result = server.construct_client_updates();
+        let opt_updates = server.construct_client_updates();
 
-        assert!(result.is_ok());
-        let opt_output = result.unwrap();
-        assert!(opt_output.is_some());
-        let mut output: Vec<(SocketAddr, Packet)> = opt_output.unwrap();
+        assert!(opt_updates.is_some());
+        let mut output: Vec<(SocketAddr, Packet)> = opt_updates.unwrap();
 
         // Vector should contain a single item for this test
         assert_eq!(output.len(), 1);
@@ -2384,14 +2373,13 @@ mod netwayste_server_tests {
         assert_eq!(addr, fake_socket_addr());
 
         match pkt {
-            Packet::Update{chats, game_updates, universe_update} => {
-                assert_eq!(game_updates, None);
+            Packet::Update{mut chats, game_updates, universe_update} => {
+                assert!(game_updates.is_empty());
                 assert_eq!(universe_update, UniUpdateType::NoChange);
-                assert!(chats.is_some());
+                assert!(!chats.is_empty());
 
-                let mut messages = chats.unwrap();
-                assert_eq!(messages.len(), 1);
-                let msg = messages.pop().unwrap();
+                assert_eq!(chats.len(), 1);
+                let msg = chats.pop().unwrap();
 
                 assert_eq!(msg.player_name, player_name);
                 assert_eq!(msg.chat_seq, Some(3));

--- a/netwayste/src/tests.rs
+++ b/netwayste/src/tests.rs
@@ -1063,7 +1063,7 @@ mod netwayste_client_tests {
         let mut client_state = create_client_net_state();
         assert_eq!(client_state.chat_msg_seq_num, 0);
 
-        client_state.handle_incoming_chats(None);
+        client_state.handle_incoming_chats(vec![]);
         assert_eq!(client_state.chat_msg_seq_num, 0);
     }
 
@@ -1078,7 +1078,7 @@ mod netwayste_client_tests {
             incoming_messages.push(new_msg);
         }
 
-        client_state.handle_incoming_chats(Some(incoming_messages));
+        client_state.handle_incoming_chats(incoming_messages);
         assert_eq!(client_state.chat_msg_seq_num, 10);
     }
 
@@ -1089,7 +1089,7 @@ mod netwayste_client_tests {
 
         let incoming_messages = vec![ BroadcastChatMessage::new(10u64, "a player".to_owned(), format!("message {}", 10))];
 
-        client_state.handle_incoming_chats(Some(incoming_messages));
+        client_state.handle_incoming_chats(incoming_messages);
         assert_eq!(client_state.chat_msg_seq_num, 10);
     }
 
@@ -1101,7 +1101,7 @@ mod netwayste_client_tests {
 
         let incoming_messages = vec![ BroadcastChatMessage::new(11u64, "a player".to_owned(), format!("message {}", 11))];
 
-        client_state.handle_incoming_chats(Some(incoming_messages));
+        client_state.handle_incoming_chats(incoming_messages);
     }
 
     #[test]
@@ -1117,7 +1117,7 @@ mod netwayste_client_tests {
             incoming_messages.push(new_msg);
         }
 
-        client_state.handle_incoming_chats(Some(incoming_messages));
+        client_state.handle_incoming_chats(incoming_messages);
         assert_eq!(client_state.chat_msg_seq_num, 19);
 
         let mut seq_num = starting_chat_seq_num+1;


### PR DESCRIPTION
Related to issues #105 and #106 

Deciding to knock this out now since it's fairly straightforward.

- [x] Add names to anonymous client/server communication data structures
- [x] Update data structure usages in `client.rs`
- [x] Update data structure usages in `server.rs`
- [x] Clean up over usage of `Option` and `Result` for data and return types
- [x] No new warnings
- [x] Unit test pass