### PR TITLE
Proptest as a dev dependency 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "conway"
-version = "0.3.0"
+version = "0.3.3"
 dependencies = [
  "custom_error 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -380,12 +380,12 @@ dependencies = [
 
 [[package]]
 name = "conwayste"
-version = "0.3.2-alpha3"
+version = "0.3.3"
 dependencies = [
  "chromatica 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "color-backtrace 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "conway 0.3.0",
+ "conway 0.3.3",
  "custom_error 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "downcast-rs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -394,7 +394,7 @@ dependencies = [
  "id_tree 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "netwayste 0.2.0",
+ "netwayste 0.3.3",
  "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1373,7 +1373,7 @@ dependencies = [
 
 [[package]]
 name = "netwayste"
-version = "0.2.0"
+version = "0.3.3"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/netwayste/Cargo.toml
+++ b/netwayste/Cargo.toml
@@ -19,9 +19,11 @@ bincode              = "0.9.2"
 base64               = "0.10.1"
 rand                 = "0.6.5"
 time                 = "0.1"
-proptest             = "0.9"
 semver               = "0.9.0"
 tokio-dns-unofficial = "0.4"
 regex                = "1"
 clap                 = "2"
 color-backtrace      = "0.1"
+
+[dev-dependencies]
+proptest             = "0.9"


### PR DESCRIPTION
I did find that we can isolate the building of `proptest` to test case execution only by adding a `[dev-depenencies]` section to `Cargo.toml`. 

Dev-dependencies are not used when compiling a package for building, but are used for compiling tests, examples, and benchmarks.

https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#development-dependencies