### PR TITLE
Add Server Status Command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,6 +585,7 @@ dependencies = [
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/conwayste/src/constants.rs
+++ b/conwayste/src/constants.rs
@@ -88,7 +88,7 @@ lazy_static! {
 pub const CHATBOX_BORDER_PIXELS: f32 = 1.0;
 pub const CHATBOX_LINE_SPACING: f32 = 2.0;
 pub const CHATBOX_HISTORY: usize = 20;
-pub const CHAT_TEXTFIELD_HEIGHT: f32 = (25.0);
+pub const CHAT_TEXTFIELD_HEIGHT: f32 = 25.0;
 
 // Layering's tree data structure capacities. Arbitrarily chosen.
 pub const LAYERING_NODE_CAPACITY: usize = 100;

--- a/dissect-netwayste/Cargo.toml
+++ b/dissect-netwayste/Cargo.toml
@@ -9,6 +9,7 @@ byteorder = "1.3.4"
 lazy_static = "1.3.0"
 netwayste   = { path = "../netwayste" }
 tokio-core  = "0.1.9"
+walkdir = "2"
 
 [dependencies.syn]
 version = "1.0.30"

--- a/dissect-netwayste/src/lib.rs
+++ b/dissect-netwayste/src/lib.rs
@@ -382,7 +382,7 @@ impl ConwaysteTree {
                             1, /*Can we get the size of inner struct?*/
                             ett_get_address(&*ett_info, name), /* Index in ett corresponding to this item */
                             ptr::null_mut(),
-                            name.as_ptr() as *const i8,
+                            field_name.as_ptr() as *const i8,
                         )
                     };
 

--- a/netwayste/examples/cli-client.rs
+++ b/netwayste/examples/cli-client.rs
@@ -99,6 +99,7 @@ fn read_stdin(channel_to_netwayste: mpsc::UnboundedSender<NetwaysteEvent>) {
 fn print_help() {
     info!("");
     info!("/help                  - print this text");
+    info!("/status                - get the server's status");
     info!("/connect <player_name> - connect to server");
     info!("/disconnect            - disconnect from server");
     info!("/list                  - list rooms when in lobby, or players when in game");
@@ -116,6 +117,11 @@ fn build_command_request_action(cmd: String, args: Vec<String>) -> NetwaysteEven
     match cmd.as_str() {
         "help" | "?" | "h" => {
             print_help();
+        }
+        "status" | "s" => {
+            let nonce = rand::random::<u64>();
+            println!("Nonce for get status: {}", nonce);
+            new_event = NetwaysteEvent::GetStatus(nonce);
         }
         "connect" | "c" => {
             if args.len() == 1 {

--- a/netwayste/examples/cli-client.rs
+++ b/netwayste/examples/cli-client.rs
@@ -17,7 +17,8 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#[macro_use] extern crate log;
+#[macro_use]
+extern crate log;
 extern crate color_backtrace;
 extern crate env_logger;
 extern crate futures;
@@ -40,7 +41,7 @@ use netwayste::{
     net::NetwaysteEvent,
 };
 
-const SLEEP: Duration = Duration::from_millis(33);  // 30 "frames" per second
+const SLEEP: Duration = Duration::from_millis(33); // 30 "frames" per second
 
 #[derive(PartialEq, Debug, Clone)]
 enum UserInput {
@@ -571,79 +572,79 @@ mod tests {
     */
 
     /* XXX testXXX
-    #[test]
-    fn handle_incoming_event_basic_tx_rx_queueing_cannot_process_all_responses() {
-        let mut client_state = create_client_net_state();
-        let (udp_tx, _) = mpsc::unbounded();
-        let (exit_tx, _) = mpsc::unbounded();
-        let connect_cmd = UserInput::Command {
-            cmd: "connect".to_owned(),
-            args: vec!["name".to_owned()],
-        };
-        let new_room_cmd = UserInput::Command {
-            cmd: "new".to_owned(),
-            args: vec!["room_name".to_owned()],
-        };
-        let join_room_cmd = UserInput::Command {
-            cmd: "join".to_owned(),
-            args: vec!["room_name".to_owned()],
-        };
-        let leave_room_cmd = UserInput::Command {
-            cmd: "leave".to_owned(),
-            args: vec![],
-        };
+        #[test]
+        fn handle_incoming_event_basic_tx_rx_queueing_cannot_process_all_responses() {
+            let mut client_state = create_client_net_state();
+            let (udp_tx, _) = mpsc::unbounded();
+            let (exit_tx, _) = mpsc::unbounded();
+            let connect_cmd = UserInput::Command {
+                cmd: "connect".to_owned(),
+                args: vec!["name".to_owned()],
+            };
+            let new_room_cmd = UserInput::Command {
+                cmd: "new".to_owned(),
+                args: vec!["room_name".to_owned()],
+            };
+            let join_room_cmd = UserInput::Command {
+                cmd: "join".to_owned(),
+                args: vec!["room_name".to_owned()],
+            };
+            let leave_room_cmd = UserInput::Command {
+                cmd: "leave".to_owned(),
+                args: vec![],
+            };
 
-        client_state.sequence = 0;
-        client_state.response_sequence = 1;
-        client_state.handle_user_input_event(&udp_tx, &exit_tx, connect_cmd); // Seq 0
-        client_state.cookie = Some("ThisDoesNotReallyMatterAsLongAsItExists".to_owned());
-        // dequeue connect since we don't actually want to process it later
-        client_state.network.tx_packets.clear();
-        client_state.handle_user_input_event(&udp_tx, &exit_tx, new_room_cmd); // Seq 1
-        client_state.handle_user_input_event(&udp_tx, &exit_tx, join_room_cmd.clone()); // Seq 2
-        client_state.room = Some("room_name".to_owned());
-        client_state.handle_user_input_event(&udp_tx, &exit_tx, leave_room_cmd); // Seq 3
-        client_state.room = None; // Temporarily set to None so we can process the next join
-        client_state.handle_user_input_event(&udp_tx, &exit_tx, join_room_cmd); // Seq 4
-        client_state.room = Some("room_name".to_owned());
-        assert_eq!(client_state.sequence, 4);
-        assert_eq!(client_state.response_sequence, 1);
-        assert_eq!(client_state.network.tx_packets.len(), 4);
-        assert_eq!(client_state.network.rx_packets.len(), 0);
+            client_state.sequence = 0;
+            client_state.response_sequence = 1;
+            client_state.handle_user_input_event(&udp_tx, &exit_tx, connect_cmd); // Seq 0
+            client_state.cookie = Some("ThisDoesNotReallyMatterAsLongAsItExists".to_owned());
+            // dequeue connect since we don't actually want to process it later
+            client_state.network.tx_packets.clear();
+            client_state.handle_user_input_event(&udp_tx, &exit_tx, new_room_cmd); // Seq 1
+            client_state.handle_user_input_event(&udp_tx, &exit_tx, join_room_cmd.clone()); // Seq 2
+            client_state.room = Some("room_name".to_owned());
+            client_state.handle_user_input_event(&udp_tx, &exit_tx, leave_room_cmd); // Seq 3
+            client_state.room = None; // Temporarily set to None so we can process the next join
+            client_state.handle_user_input_event(&udp_tx, &exit_tx, join_room_cmd); // Seq 4
+            client_state.room = Some("room_name".to_owned());
+            assert_eq!(client_state.sequence, 4);
+            assert_eq!(client_state.response_sequence, 1);
+            assert_eq!(client_state.network.tx_packets.len(), 4);
+            assert_eq!(client_state.network.rx_packets.len(), 0);
 
-        let room_response = Packet::Response {
-            sequence: 1,
-            request_ack: Some(1),
-            code: ResponseCode::OK,
-        };
-        let join_response = Packet::Response {
-            sequence: 2,
-            request_ack: Some(2),
-            code: ResponseCode::OK,
-        };
-        let _leave_response = Packet::Response {
-            sequence: 3,
-            request_ack: Some(3),
-            code: ResponseCode::OK,
-        };
-        let join2_response = Packet::Response {
-            sequence: 4,
-            request_ack: Some(4),
-            code: ResponseCode::OK,
-        };
+            let room_response = Packet::Response {
+                sequence: 1,
+                request_ack: Some(1),
+                code: ResponseCode::OK,
+            };
+            let join_response = Packet::Response {
+                sequence: 2,
+                request_ack: Some(2),
+                code: ResponseCode::OK,
+            };
+            let _leave_response = Packet::Response {
+                sequence: 3,
+                request_ack: Some(3),
+                code: ResponseCode::OK,
+            };
+            let join2_response = Packet::Response {
+                sequence: 4,
+                request_ack: Some(4),
+                code: ResponseCode::OK,
+            };
 
-        // The intent is that 3 never arrives
-        client_state.handle_incoming_event(&udp_tx, Some(join2_response)); // 4 arrives
-        assert_eq!(client_state.network.tx_packets.len(), 3);
-        assert_eq!(client_state.network.rx_packets.len(), 1);
-        client_state.handle_incoming_event(&udp_tx, Some(join_response)); // 2 arrives
-        assert_eq!(client_state.network.tx_packets.len(), 2);
-        assert_eq!(client_state.network.rx_packets.len(), 2);
-        client_state.handle_incoming_event(&udp_tx, Some(room_response)); // 1 arrives
-        assert_eq!(client_state.network.tx_packets.len(), 1);
-        assert_eq!(client_state.network.rx_packets.len(), 1);
-    }
-*/
+            // The intent is that 3 never arrives
+            client_state.handle_incoming_event(&udp_tx, Some(join2_response)); // 4 arrives
+            assert_eq!(client_state.network.tx_packets.len(), 3);
+            assert_eq!(client_state.network.rx_packets.len(), 1);
+            client_state.handle_incoming_event(&udp_tx, Some(join_response)); // 2 arrives
+            assert_eq!(client_state.network.tx_packets.len(), 2);
+            assert_eq!(client_state.network.rx_packets.len(), 2);
+            client_state.handle_incoming_event(&udp_tx, Some(room_response)); // 1 arrives
+            assert_eq!(client_state.network.tx_packets.len(), 1);
+            assert_eq!(client_state.network.rx_packets.len(), 1);
+        }
+    */
 
     /* XXX testXXX
     #[test]
@@ -712,5 +713,4 @@ mod tests {
         assert_eq!(client_state.network.rx_packets.len(), 0);
     }
     */
-
 }

--- a/netwayste/examples/cli-client.rs
+++ b/netwayste/examples/cli-client.rs
@@ -221,8 +221,8 @@ fn main() {
         // This is inefficient -- it would be better not to poll for messages on the channel.
         // However, we are polling in GUI client's update() function so do it here as well.
         match ggez_server_response.try_recv() {
-            Ok(response_code) => {
-                println!("{:?}", response_code);
+            Ok(nw_event_from_server_code) => {
+                println!("{:?}", nw_event_from_server_code);
             }
             Err(TryRecvError::Empty) => {
                 // Nothing to do in the empty case

--- a/netwayste/examples/cli-client.rs
+++ b/netwayste/examples/cli-client.rs
@@ -39,6 +39,7 @@ use log::LevelFilter;
 use netwayste::{
     client::{ClientNetState, CLIENT_VERSION},
     net::NetwaysteEvent,
+    utils::PingPong,
 };
 
 const SLEEP: Duration = Duration::from_millis(33); // 30 "frames" per second
@@ -119,9 +120,8 @@ fn build_command_request_action(cmd: String, args: Vec<String>) -> NetwaysteEven
             print_help();
         }
         "status" | "s" => {
-            let nonce = rand::random::<u64>();
-            println!("Nonce for get status: {}", nonce);
-            new_event = NetwaysteEvent::GetStatus(nonce);
+            let ping= PingPong::ping();
+            new_event = NetwaysteEvent::GetStatus(ping);
         }
         "connect" | "c" => {
             if args.len() == 1 {

--- a/netwayste/examples/cli-client.rs
+++ b/netwayste/examples/cli-client.rs
@@ -223,6 +223,12 @@ fn main() {
         match ggez_server_response.try_recv() {
             Ok(nw_event_from_server_code) => {
                 println!("{:?}", nw_event_from_server_code);
+
+                if let NetwaysteEvent::Status(_pkt, opt_latency) = nw_event_from_server_code {
+                    if let Some(latency_ms) = opt_latency {
+                        println!("Average Latency: {}", latency_ms);
+                    }
+                }
             }
             Err(TryRecvError::Empty) => {
                 // Nothing to do in the empty case

--- a/netwayste/src/client.rs
+++ b/netwayste/src/client.rs
@@ -36,7 +36,7 @@ use crate::net::{
     VERSION,
 };
 
-use crate::utils::PingFilter;
+use crate::utils::LatencyFilter;
 
 const TICK_INTERVAL_IN_MS: u64 = 1000;
 const NETWORK_INTERVAL_IN_MS: u64 = 1000;
@@ -65,7 +65,7 @@ pub struct ClientNetState {
     pub disconnect_initiated: bool,
     pub server_address: Option<SocketAddr>,
     pub channel_to_conwayste: std::sync::mpsc::Sender<NetwaysteEvent>,
-    ping_filter: PingFilter,
+    ping_filter: LatencyFilter,
 }
 
 impl ClientNetState {
@@ -83,7 +83,7 @@ impl ClientNetState {
             disconnect_initiated: false,
             server_address: None,
             channel_to_conwayste: channel_to_conwayste,
-            ping_filter: PingFilter::new(),
+            ping_filter: LatencyFilter::new(),
         }
     }
 
@@ -514,7 +514,7 @@ impl ClientNetState {
             );
         }
         if v4_addr_vec.len() > 1 {
-            // This is probably not the best option -- could pick based on ping time, random choice,
+            // This is probably not the best option -- could pick based on latency time, random choice,
             // and could also try other ones on connection failure.
             warn!(
                 "Multiple ({:?}) addresses returned; arbitrarily picking the first one.",

--- a/netwayste/src/client.rs
+++ b/netwayste/src/client.rs
@@ -18,27 +18,26 @@
  */
 
 use std::env;
+use std::error::Error;
 use std::io;
 use std::iter;
-use std::error::Error;
 use std::net::SocketAddr;
 use std::process::exit;
-use std::time::Instant;
 use std::time::Duration;
+use std::time::Instant;
 
-use futures::{Future, Sink, Stream, stream, future::ok, sync::mpsc};
+use futures::{future::ok, stream, sync::mpsc, Future, Sink, Stream};
 use regex::Regex;
 use tokio_core::reactor::{Core, Timeout};
 
 use crate::net::{
-    RequestAction, ResponseCode, Packet, RoomList,
-    BroadcastChatMessage, NetworkManager, NetworkQueue,
-    VERSION, has_connection_timed_out, bind, DEFAULT_PORT,
-    LineCodec, NetwaysteEvent
+    bind, has_connection_timed_out, BroadcastChatMessage, LineCodec, NetwaysteEvent,
+    NetworkManager, NetworkQueue, Packet, RequestAction, ResponseCode, RoomList, DEFAULT_PORT,
+    VERSION,
 };
 
-const TICK_INTERVAL_IN_MS:          u64    = 1000;
-const NETWORK_INTERVAL_IN_MS:       u64    = 1000;
+const TICK_INTERVAL_IN_MS: u64 = 1000;
+const NETWORK_INTERVAL_IN_MS: u64 = 1000;
 
 pub const CLIENT_VERSION: &str = "0.0.1";
 
@@ -47,40 +46,39 @@ enum Event {
     TickEvent,
     Incoming((SocketAddr, Option<Packet>)),
     NetworkEvent,
-    ConwaysteEvent(NetwaysteEvent)
+    ConwaysteEvent(NetwaysteEvent),
 }
 
 pub struct ClientNetState {
-    pub sequence:         u64,          // Sequence number of requests
-    pub response_sequence: u64,         // Value of the next expected sequence number from the server,
-                                        // and indicates the sequence number of the next process-able rx packet
-    pub name:             Option<String>,
-    pub room:             Option<String>,
-    pub cookie:           Option<String>,
+    pub sequence: u64,          // Sequence number of requests
+    pub response_sequence: u64, // Value of the next expected sequence number from the server,
+    // and indicates the sequence number of the next process-able rx packet
+    pub name: Option<String>,
+    pub room: Option<String>,
+    pub cookie: Option<String>,
     pub chat_msg_seq_num: u64,
-    pub tick:             usize,
-    pub network:          NetworkManager,
-    pub last_received:    Option<Instant>,
+    pub tick: usize,
+    pub network: NetworkManager,
+    pub last_received: Option<Instant>,
     pub disconnect_initiated: bool,
-    pub server_address:   Option<SocketAddr>,
-    pub channel_to_conwayste:     std::sync::mpsc::Sender<NetwaysteEvent>,
+    pub server_address: Option<SocketAddr>,
+    pub channel_to_conwayste: std::sync::mpsc::Sender<NetwaysteEvent>,
 }
 
 impl ClientNetState {
-
     pub fn new(channel_to_conwayste: std::sync::mpsc::Sender<NetwaysteEvent>) -> Self {
         ClientNetState {
-            sequence:        0,
+            sequence: 0,
             response_sequence: 0,
-            name:            None,
-            room:            None,
-            cookie:          None,
+            name: None,
+            room: None,
+            cookie: None,
             chat_msg_seq_num: 0,
-            tick:            0,
-            network:         NetworkManager::new().with_message_buffering(),
-            last_received:   None,
+            tick: 0,
+            network: NetworkManager::new().with_message_buffering(),
+            last_received: None,
             disconnect_initiated: false,
-            server_address:  None,
+            server_address: None,
             channel_to_conwayste: channel_to_conwayste,
         }
     }
@@ -102,22 +100,21 @@ impl ClientNetState {
             ref mut last_received,
             ref mut disconnect_initiated,
             ref mut server_address,
-            channel_to_conwayste: ref _channel_to_conwayste,          // Don't clear the channel to conwayste
+            channel_to_conwayste: ref _channel_to_conwayste, // Don't clear the channel to conwayste
         } = *self;
-        *sequence         = 0;
+        *sequence = 0;
         *response_sequence = 0;
-        *room             = None;
-        *cookie           = None;
+        *room = None;
+        *cookie = None;
         *chat_msg_seq_num = 0;
-        *tick             = 0;
-        *last_received    = None;
+        *tick = 0;
+        *last_received = None;
         *disconnect_initiated = false;
-        *server_address   = None;
+        *server_address = None;
         network.reset();
 
         trace!("ClientNetState reset!");
     }
-
 
     pub fn in_game(&self) -> bool {
         self.room.is_some()
@@ -127,8 +124,7 @@ impl ClientNetState {
         let client_version = &VERSION.to_owned();
         if client_version < server_version {
             warn!("\tClient Version: {}\n\tServer Version: {}\nnWarning: Client out-of-date. Please upgrade.", client_version, server_version);
-        }
-        else if client_version > server_version {
+        } else if client_version > server_version {
             warn!("\tClient Version: {}\n\tServer Version: {}\nWarning: Client Version greater than Server Version.", client_version, server_version);
         }
     }
@@ -137,47 +133,62 @@ impl ClientNetState {
         // If we can, start popping off the RX queue and handle contiguous packets immediately
         let mut dequeue_count = 0;
 
-        let rx_queue_count = self.network.rx_packets.get_contiguous_packets_count(self.response_sequence);
+        let rx_queue_count = self
+            .network
+            .rx_packets
+            .get_contiguous_packets_count(self.response_sequence);
         while dequeue_count < rx_queue_count {
-            let packet = self.network.rx_packets.as_queue_type_mut().pop_front().unwrap();
+            let packet = self
+                .network
+                .rx_packets
+                .as_queue_type_mut()
+                .pop_front()
+                .unwrap();
             trace!("{:?}", packet);
             match packet {
-                Packet::Response{sequence: _, request_ack: _, code} => {
+                Packet::Response {
+                    sequence: _,
+                    request_ack: _,
+                    code,
+                } => {
                     dequeue_count += 1;
                     self.response_sequence += 1;
                     self.process_event_code(code);
                 }
-                _ => panic!("Development bug: Non-response packet found in client RX queue")
+                _ => panic!("Development bug: Non-response packet found in client RX queue"),
             }
         }
     }
 
     fn process_event_code(&mut self, code: ResponseCode) {
         match code.clone() {
-            ResponseCode::OK => {
-                match self.handle_response_ok() {
-                    Ok(_) => {},
-                    Err(e) => error!("{:?}", e)
-                }
-            }
-            ResponseCode::LoggedIn{ref cookie, ref server_version} => {
+            ResponseCode::OK => match self.handle_response_ok() {
+                Ok(_) => {}
+                Err(e) => error!("{:?}", e),
+            },
+            ResponseCode::LoggedIn {
+                ref cookie,
+                ref server_version,
+            } => {
                 self.handle_logged_in(cookie.to_string(), server_version.to_string());
             }
             ResponseCode::LeaveRoom => {
                 self.handle_left_room();
             }
-            ResponseCode::JoinedRoom{ref room_name} => {
+            ResponseCode::JoinedRoom { ref room_name } => {
                 self.handle_joined_room(room_name);
             }
-            ResponseCode::PlayerList{ref players} => {
+            ResponseCode::PlayerList { ref players } => {
                 self.handle_player_list(players.to_vec());
             }
-            ResponseCode::RoomList{ref rooms} => {
+            ResponseCode::RoomList { ref rooms } => {
                 self.handle_room_list(rooms.to_vec());
             }
-            ResponseCode::KeepAlive => {},
+            ResponseCode::KeepAlive => {}
             // errors
-            ResponseCode::Unauthorized{error_msg: opt_error} => {
+            ResponseCode::Unauthorized {
+                error_msg: opt_error,
+            } => {
                 info!("Unauthorized action attempted by client: {:?}", opt_error);
             }
             _ => {
@@ -186,19 +197,31 @@ impl ClientNetState {
         }
 
         if code != ResponseCode::OK && code != ResponseCode::KeepAlive {
-            let nw_response: NetwaysteEvent = NetwaysteEvent::build_netwayste_event_from_response_code(code);
+            let nw_response: NetwaysteEvent =
+                NetwaysteEvent::build_netwayste_event_from_response_code(code);
             match self.channel_to_conwayste.send(nw_response) {
-                Err(e) => error!("Could not send a netwayste response via channel_to_conwayste: {:?}", e),
-                Ok(_) => ()
+                Err(e) => error!(
+                    "Could not send a netwayste response via channel_to_conwayste: {:?}",
+                    e
+                ),
+                Ok(_) => (),
             }
         }
     }
 
-    pub fn handle_incoming_event(&mut self, udp_tx: &mpsc::UnboundedSender<(SocketAddr, Packet)>, opt_packet: Option<Packet>) {
+    pub fn handle_incoming_event(
+        &mut self,
+        udp_tx: &mpsc::UnboundedSender<(SocketAddr, Packet)>,
+        opt_packet: Option<Packet>,
+    ) {
         // All `None` packets should get filtered out up the hierarchy
         let packet = opt_packet.unwrap();
         match packet.clone() {
-            Packet::Response{sequence, request_ack: _, code} => {
+            Packet::Response {
+                sequence,
+                request_ack: _,
+                code,
+            } => {
                 self.last_received = Some(Instant::now());
                 let code = code.clone();
                 if code != ResponseCode::KeepAlive {
@@ -210,11 +233,14 @@ impl ClientNetState {
 
                     // Only process responses we haven't seen
                     if self.response_sequence <= sequence {
-                        trace!("RX Buffering: Resp.Seq.: {}, {:?}", self.response_sequence, packet);
+                        trace!(
+                            "RX Buffering: Resp.Seq.: {}, {:?}",
+                            self.response_sequence,
+                            packet
+                        );
                         // println!("TX packets: {:?}", self.network.tx_packets);
                         // None means the packet was not found so we've probably already removed it.
-                        if let Some(_) = self.network.tx_packets.remove(&packet)
-                        {
+                        if let Some(_) = self.network.tx_packets.remove(&packet) {
                             self.network.rx_packets.buffer_item(packet);
                         }
 
@@ -223,28 +249,43 @@ impl ClientNetState {
                 }
             }
             // TODO game_updates, universe_update
-            Packet::Update{chats, game_updates: _, universe_update: _} => {
-
+            Packet::Update {
+                chats,
+                game_updates: _,
+                universe_update: _,
+            } => {
                 if chats.len() != 0 {
                     self.handle_incoming_chats(chats);
                 }
 
                 // Reply to the update
                 let packet = Packet::UpdateReply {
-                    cookie:               self.cookie.clone().unwrap(),
-                    last_chat_seq:        Some(self.chat_msg_seq_num),
+                    cookie: self.cookie.clone().unwrap(),
+                    last_chat_seq: Some(self.chat_msg_seq_num),
                     last_game_update_seq: None,
-                    last_gen:             None,
+                    last_gen: None,
                 };
 
-                netwayste_send!(udp_tx, (self.server_address.unwrap().clone(), packet),
-                         ("Could not send UpdateReply{{ {} }} to server", self.chat_msg_seq_num));
+                netwayste_send!(
+                    udp_tx,
+                    (self.server_address.unwrap().clone(), packet),
+                    (
+                        "Could not send UpdateReply{{ {} }} to server",
+                        self.chat_msg_seq_num
+                    )
+                );
             }
-            Packet::Request{..} => {
-                warn!("Ignoring packet from server normally sent by clients: {:?}", packet);
+            Packet::Request { .. } => {
+                warn!(
+                    "Ignoring packet from server normally sent by clients: {:?}",
+                    packet
+                );
             }
-            Packet::UpdateReply{..} => {
-                warn!("Ignoring packet from server normally sent by clients: {:?}", packet);
+            Packet::UpdateReply { .. } => {
+                warn!(
+                    "Ignoring packet from server normally sent by clients: {:?}",
+                    packet
+                );
             }
         }
     }
@@ -258,7 +299,12 @@ impl ClientNetState {
 
             let indices = self.network.tx_packets.get_retransmit_indices();
 
-            self.network.retransmit_expired_tx_packets(udp_tx, self.server_address.unwrap().clone(), Some(self.response_sequence), &indices);
+            self.network.retransmit_expired_tx_packets(
+                udp_tx,
+                self.server_address.unwrap().clone(),
+                Some(self.response_sequence),
+                &indices,
+            );
         }
     }
 
@@ -270,7 +316,9 @@ impl ClientNetState {
                 cookie: self.cookie.clone(),
                 sequence: self.sequence,
                 response_ack: None,
-                action: RequestAction::KeepAlive{latest_response_ack: self.response_sequence},
+                action: RequestAction::KeepAlive {
+                    latest_response_ack: self.response_sequence,
+                },
             };
             let timed_out = has_connection_timed_out(self.last_received.unwrap());
 
@@ -283,17 +331,20 @@ impl ClientNetState {
                 }
                 self.reset();
             } else {
-                netwayste_send!(udp_tx, (self.server_address.unwrap().clone(), keep_alive), ("Could not send KeepAlive packets"));
+                netwayste_send!(
+                    udp_tx,
+                    (self.server_address.unwrap().clone(), keep_alive),
+                    ("Could not send KeepAlive packets")
+                );
             }
         }
 
         self.tick = 1usize.wrapping_add(self.tick);
     }
 
-
     pub fn handle_response_ok(&mut self) -> Result<(), Box<dyn Error>> {
-            info!("OK :)");
-            return Ok(());
+        info!("OK :)");
+        return Ok(());
     }
 
     pub fn handle_logged_in(&mut self, cookie: String, server_version: String) {
@@ -308,8 +359,8 @@ impl ClientNetState {
     }
 
     pub fn handle_joined_room(&mut self, room_name: &String) {
-            self.room = Some(room_name.clone());
-            info!("Joined room: {}", room_name);
+        self.room = Some(room_name.clone());
+        info!("Joined room: {}", room_name);
     }
 
     pub fn handle_left_room(&mut self) {
@@ -331,18 +382,17 @@ impl ClientNetState {
     pub fn handle_room_list(&mut self, rooms: Vec<RoomList>) {
         info!("---BEGIN GAME ROOM LIST---");
         for room in rooms {
-            info!("#name: {},\trunning? {:?},\tplayers: {:?}",
-                        room.room_name,
-                        room.in_progress,
-                        room.player_count);
+            info!(
+                "#name: {},\trunning? {:?},\tplayers: {:?}",
+                room.room_name, room.in_progress, room.player_count
+            );
         }
         info!("---END GAME ROOM LIST---");
     }
 
-    pub fn handle_incoming_chats(&mut self, mut chat_messages: Vec<BroadcastChatMessage> ) {
-        chat_messages.retain(|ref chat_message| {
-            self.chat_msg_seq_num < chat_message.chat_seq.unwrap()
-        });
+    pub fn handle_incoming_chats(&mut self, mut chat_messages: Vec<BroadcastChatMessage>) {
+        chat_messages
+            .retain(|ref chat_message| self.chat_msg_seq_num < chat_message.chat_seq.unwrap());
 
         let mut to_conwayste_msgs = vec![];
 
@@ -369,16 +419,21 @@ impl ClientNetState {
 
         let nw_response = NetwaysteEvent::ChatMessages(to_conwayste_msgs);
         match self.channel_to_conwayste.send(nw_response) {
-            Err(e) => error!("Could not send a netwayste response via channel_to_conwayste: {:?}", e),
-            Ok(_) => ()
+            Err(e) => error!(
+                "Could not send a netwayste response via channel_to_conwayste: {:?}",
+                e
+            ),
+            Ok(_) => (),
         }
     }
 
     /// Send a request action to the connected server
-    fn try_server_send(&mut self,
-            udp_tx: &mpsc::UnboundedSender<(SocketAddr, Packet)>,
-            exit_tx: &mpsc::UnboundedSender<()>,
-            action: RequestAction) {
+    fn try_server_send(
+        &mut self,
+        udp_tx: &mpsc::UnboundedSender<(SocketAddr, Packet)>,
+        exit_tx: &mpsc::UnboundedSender<()>,
+        action: RequestAction,
+    ) {
         if action != RequestAction::None {
             // Sequence number can increment once we're talking to a server
             if self.cookie != None {
@@ -393,27 +448,30 @@ impl ClientNetState {
             }
 
             let packet = Packet::Request {
-                sequence:     self.sequence,
+                sequence: self.sequence,
                 response_ack: Some(self.response_sequence),
-                cookie:       self.cookie.clone(),
-                action:       action,
+                cookie: self.cookie.clone(),
+                action: action,
             };
 
             trace!("{:?}", packet);
 
             self.network.tx_packets.buffer_item(packet.clone());
 
-            netwayste_send!(udp_tx, (self.server_address.unwrap().clone(), packet),
-                            ("Could not send user input cmd to server"));
-
+            netwayste_send!(
+                udp_tx,
+                (self.server_address.unwrap().clone(), packet),
+                ("Could not send user input cmd to server")
+            );
         }
     }
 
     /// Main executor for the client-side network layer for conwayste and should be run from a thread.
     /// Its two arguments are halves of a channel used for communication to send and receive Netwayste events.
-    pub fn start_network(channel_to_conwayste: std::sync::mpsc::Sender<NetwaysteEvent>,
-                         channel_from_conwayste: mpsc::UnboundedReceiver<NetwaysteEvent>) {
-
+    pub fn start_network(
+        channel_to_conwayste: std::sync::mpsc::Sender<NetwaysteEvent>,
+        channel_from_conwayste: mpsc::UnboundedReceiver<NetwaysteEvent>,
+    ) {
         let has_port_re = Regex::new(r":\d{1,5}$").unwrap(); // match a colon followed by number up to 5 digits (16-bit port)
         let mut server_str = env::args().nth(1).unwrap_or("localhost".to_owned());
         // if no port, add the default port
@@ -424,11 +482,12 @@ impl ClientNetState {
 
         // synchronously resolve DNS because... why not?
         trace!("Resolving {:?}...", server_str);
-        let addr_vec = tokio_dns::resolve_sock_addr(&server_str[..]).wait()      // wait() is synchronous!!!
-                        .unwrap_or_else(|e| {
-                                error!("failed to resolve: {:?}", e);
-                                exit(1);
-                            });
+        let addr_vec = tokio_dns::resolve_sock_addr(&server_str[..])
+            .wait() // wait() is synchronous!!!
+            .unwrap_or_else(|e| {
+                error!("failed to resolve: {:?}", e);
+                exit(1);
+            });
         if addr_vec.len() == 0 {
             error!("resolution found 0 addresses");
             exit(1);
@@ -437,12 +496,18 @@ impl ClientNetState {
         let addr_vec_len = addr_vec.len();
         let v4_addr_vec: Vec<_> = addr_vec.into_iter().filter(|addr| addr.is_ipv4()).collect(); // filter out IPv6
         if v4_addr_vec.len() < addr_vec_len {
-            warn!("Filtered out {} IPv6 addresses -- IPv6 is not implemented.", addr_vec_len - v4_addr_vec.len() );
+            warn!(
+                "Filtered out {} IPv6 addresses -- IPv6 is not implemented.",
+                addr_vec_len - v4_addr_vec.len()
+            );
         }
         if v4_addr_vec.len() > 1 {
             // This is probably not the best option -- could pick based on ping time, random choice,
             // and could also try other ones on connection failure.
-            warn!("Multiple ({:?}) addresses returned; arbitrarily picking the first one.", v4_addr_vec.len());
+            warn!(
+                "Multiple ({:?}) addresses returned; arbitrarily picking the first one.",
+                v4_addr_vec.len()
+            );
         }
 
         let addr = v4_addr_vec[0];
@@ -458,8 +523,8 @@ impl ClientNetState {
 
         // Channels
         let (udp_sink, udp_stream) = udp.framed(LineCodec).split();
-        let (udp_tx, udp_rx) = mpsc::unbounded();    // create a channel because we can't pass the sink around everywhere
-        let (exit_tx, exit_rx) = mpsc::unbounded();  // send () to exit_tx channel to quit the client
+        let (udp_tx, udp_rx) = mpsc::unbounded(); // create a channel because we can't pass the sink around everywhere
+        let (exit_tx, exit_rx) = mpsc::unbounded(); // send () to exit_tx channel to quit the client
 
         trace!("Locally bound to {:?}.", local_addr);
         trace!("Will connect to remote {:?}.", addr);
@@ -468,49 +533,43 @@ impl ClientNetState {
         let mut initial_client_state = ClientNetState::new(channel_to_conwayste);
         initial_client_state.server_address = Some(addr);
 
-        let iter_stream = stream::iter_ok::<_, io::Error>(iter::repeat( () )); // just a Stream that emits () forever
-        // .and_then is like .map except that it processes returned Futures
-        let tick_stream = iter_stream.and_then(|_| {
-            let timeout = Timeout::new(Duration::from_millis(TICK_INTERVAL_IN_MS), &handle).unwrap();
-            timeout.and_then(move |_| {
-                ok(Event::TickEvent)
+        let iter_stream = stream::iter_ok::<_, io::Error>(iter::repeat(())); // just a Stream that emits () forever
+                                                                             // .and_then is like .map except that it processes returned Futures
+        let tick_stream = iter_stream
+            .and_then(|_| {
+                let timeout =
+                    Timeout::new(Duration::from_millis(TICK_INTERVAL_IN_MS), &handle).unwrap();
+                timeout.and_then(move |_| ok(Event::TickEvent))
             })
-        }).map_err(|e| {
-            error!("Got error from tick stream: {:?}", e);
-            exit(1);
-        });
+            .map_err(|e| {
+                error!("Got error from tick stream: {:?}", e);
+                exit(1);
+            });
 
         let packet_stream = udp_stream
-            .filter(|&(_, ref opt_packet)| {
-                *opt_packet != None
-            })
-            .map(|packet_tuple| {
-                Event::Incoming(packet_tuple)
-            })
+            .filter(|&(_, ref opt_packet)| *opt_packet != None)
+            .map(|packet_tuple| Event::Incoming(packet_tuple))
             .map_err(|e| {
                 error!("Got error from packet_stream {:?}", e);
                 exit(1);
             });
 
-        let network_stream = stream::iter_ok::<_, io::Error>(iter::repeat( () ));
-        let network_stream = network_stream.and_then(|_| {
-            let timeout = Timeout::new(Duration::from_millis(NETWORK_INTERVAL_IN_MS), &handle).unwrap();
-            timeout.and_then(move |_| {
-                ok(Event::NetworkEvent)
+        let network_stream = stream::iter_ok::<_, io::Error>(iter::repeat(()));
+        let network_stream = network_stream
+            .and_then(|_| {
+                let timeout =
+                    Timeout::new(Duration::from_millis(NETWORK_INTERVAL_IN_MS), &handle).unwrap();
+                timeout.and_then(move |_| ok(Event::NetworkEvent))
             })
-        }).map_err(|e| {
-            error!("Got error from network_stream {:?}", e);
-            exit(1);
-        });
+            .map_err(|e| {
+                error!("Got error from network_stream {:?}", e);
+                exit(1);
+            });
 
         let conwayste_rx = channel_from_conwayste.map_err(|_| panic!());
         let conwayste_stream = conwayste_rx
-            .filter(|event| {
-                *event != NetwaysteEvent::None
-            })
-            .map(|event| {
-                Event::ConwaysteEvent(event)
-            })
+            .filter(|event| *event != NetwaysteEvent::None)
+            .map(|event| Event::ConwaysteEvent(event))
             .map_err(|e| {
                 error!("Got error from conwayste event channel {:?}", e);
                 exit(1);
@@ -520,58 +579,67 @@ impl ClientNetState {
             .select(packet_stream)
             .select(network_stream)
             .select(conwayste_stream)
-            .fold(initial_client_state, move |mut client_state: ClientNetState, event| {
-                match event {
-                    Event::Incoming((_addr, opt_packet)) => {
-                        client_state.handle_incoming_event(&udp_tx, opt_packet);
-                    }
-                    Event::TickEvent => {
-                        client_state.handle_tick_event(&udp_tx);
-                    }
-                    Event::NetworkEvent => {
-                        client_state.handle_network_event(&udp_tx);
-                    }
-                    Event::ConwaysteEvent(netwayste_request) => {
-                        let action: RequestAction = NetwaysteEvent::build_request_action_from_netwayste_event(netwayste_request, client_state.in_game());
-                        match action {
-                            RequestAction::Connect{ref name, ..} => {
-                                // TODO: do not store the name on client_state since that's the wrong
-                                // place for it.
-                                client_state.name = Some(name.to_owned());
-                            }
-                            _ => {}
+            .fold(
+                initial_client_state,
+                move |mut client_state: ClientNetState, event| {
+                    match event {
+                        Event::Incoming((_addr, opt_packet)) => {
+                            client_state.handle_incoming_event(&udp_tx, opt_packet);
                         }
-                        client_state.try_server_send(&udp_tx, &exit_tx, action);
+                        Event::TickEvent => {
+                            client_state.handle_tick_event(&udp_tx);
+                        }
+                        Event::NetworkEvent => {
+                            client_state.handle_network_event(&udp_tx);
+                        }
+                        Event::ConwaysteEvent(netwayste_request) => {
+                            let action: RequestAction =
+                                NetwaysteEvent::build_request_action_from_netwayste_event(
+                                    netwayste_request,
+                                    client_state.in_game(),
+                                );
+                            match action {
+                                RequestAction::Connect { ref name, .. } => {
+                                    // TODO: do not store the name on client_state since that's the wrong
+                                    // place for it.
+                                    client_state.name = Some(name.to_owned());
+                                }
+                                _ => {}
+                            }
+                            client_state.try_server_send(&udp_tx, &exit_tx, action);
+                        }
                     }
-                }
 
-                // finally, return the updated client state for the next iteration
-                ok(client_state)
-            })
+                    // finally, return the updated client state for the next iteration
+                    ok(client_state)
+                },
+            )
             .map(|_| ())
             .map_err(|_| ());
 
         // listen on the channel created above and send it to the UDP sink
-        let sink_fut = udp_rx.fold(udp_sink, |udp_sink, outgoing_item| {
-            udp_sink.send(outgoing_item).map_err(|e| {
+        let sink_fut = udp_rx
+            .fold(udp_sink, |udp_sink, outgoing_item| {
+                udp_sink.send(outgoing_item).map_err(|e| {
                     error!("Got error while attempting to send UDP packet: {:?}", e);
                     exit(1);
                 })
-        }).map(|_| ()).map_err(|_| ());
+            })
+            .map(|_| ())
+            .map_err(|_| ());
 
-        let exit_fut = exit_rx
-                        .into_future()
-                        .map(|_| ())
-                        .map_err(|e| {
-                                    error!("Got error from exit_fut: {:?}", e);
-                                    exit(1);
-                                });
+        let exit_fut = exit_rx.into_future().map(|_| ()).map_err(|e| {
+            error!("Got error from exit_fut: {:?}", e);
+            exit(1);
+        });
 
         let combined_fut = exit_fut
-                            .select(main_loop_fut).map(|_| ()).map_err(|_| ())
-                            .select(sink_fut).map_err(|_| ());
+            .select(main_loop_fut)
+            .map(|_| ())
+            .map_err(|_| ())
+            .select(sink_fut)
+            .map_err(|_| ());
 
         drop(core.run(combined_fut).unwrap());
     }
 }
-

--- a/netwayste/src/client.rs
+++ b/netwayste/src/client.rs
@@ -293,7 +293,7 @@ impl ClientNetState {
                 self.latency_filter.update();
 
                 self.channel_to_conwayste
-                    .send(NetwaysteEvent::Status(packet))
+                    .send(NetwaysteEvent::Status(packet, self.latency_filter.average_latency_ms))
                     .unwrap_or_else(|e| {
                         error!(
                             "Could not send a netwayste response via channel_to_conwayste: {:?}",

--- a/netwayste/src/client.rs
+++ b/netwayste/src/client.rs
@@ -612,7 +612,7 @@ impl ClientNetState {
 
                                 netwayste_send!(
                                     udp_tx,
-                                    (server_address, Packet::GetStatus{nonce}),
+                                    (server_address, Packet::GetStatus { nonce }),
                                     ("Could not send user input cmd to server")
                                 );
                             } else {

--- a/netwayste/src/client.rs
+++ b/netwayste/src/client.rs
@@ -65,7 +65,7 @@ pub struct ClientNetState {
     pub disconnect_initiated: bool,
     pub server_address: Option<SocketAddr>,
     pub channel_to_conwayste: std::sync::mpsc::Sender<NetwaysteEvent>,
-    ping_filter: LatencyFilter,
+    latency_filter: LatencyFilter,
 }
 
 impl ClientNetState {
@@ -83,7 +83,7 @@ impl ClientNetState {
             disconnect_initiated: false,
             server_address: None,
             channel_to_conwayste: channel_to_conwayste,
-            ping_filter: LatencyFilter::new(),
+            latency_filter: LatencyFilter::new(),
         }
     }
 
@@ -105,7 +105,7 @@ impl ClientNetState {
             ref mut disconnect_initiated,
             ref mut server_address,
             channel_to_conwayste: ref _channel_to_conwayste, // Don't clear the channel to conwayste
-            ref mut ping_filter,
+            ref mut latency_filter,
         } = *self;
         *sequence = 0;
         *response_sequence = 0;
@@ -117,7 +117,7 @@ impl ClientNetState {
         *disconnect_initiated = false;
         *server_address = None;
         network.reset();
-        ping_filter.reset();
+        latency_filter.reset();
 
         trace!("ClientNetState reset!");
     }
@@ -290,7 +290,7 @@ impl ClientNetState {
                 );
             }
             Packet::Status { .. } => {
-                self.ping_filter.update();
+                self.latency_filter.update();
 
                 self.channel_to_conwayste
                     .send(NetwaysteEvent::Status(packet))
@@ -610,7 +610,7 @@ impl ClientNetState {
                             if let NetwaysteEvent::GetStatus(ping) = netwayste_request {
                                 let server_address = client_state.server_address.unwrap().clone();
 
-                                client_state.ping_filter.start();
+                                client_state.latency_filter.start();
 
                                 netwayste_send!(
                                     udp_tx,

--- a/netwayste/src/client.rs
+++ b/netwayste/src/client.rs
@@ -275,17 +275,21 @@ impl ClientNetState {
                     )
                 );
             }
-            Packet::Request { .. } => {
+            Packet::Request { .. } | Packet::UpdateReply { .. } | Packet::GetStatus { .. } => {
                 warn!(
                     "Ignoring packet from server normally sent by clients: {:?}",
                     packet
                 );
             }
-            Packet::UpdateReply { .. } => {
-                warn!(
-                    "Ignoring packet from server normally sent by clients: {:?}",
-                    packet
-                );
+            Packet::Status { .. } => {
+                self.channel_to_conwayste
+                    .send(NetwaysteEvent::Status(packet))
+                    .unwrap_or_else(|e| {
+                        error!(
+                            "Could not send a netwayste response via channel_to_conwayste: {:?}",
+                            e
+                        );
+                    });
             }
         }
     }

--- a/netwayste/src/lib.rs
+++ b/netwayste/src/lib.rs
@@ -22,11 +22,11 @@ extern crate env_logger;
 extern crate futures;
 #[macro_use]
 extern crate log;
+extern crate clap;
 extern crate rand;
 extern crate semver;
 extern crate serde;
 extern crate tokio_core;
-extern crate clap;
 
 #[macro_use]
 pub mod net;

--- a/netwayste/src/lib.rs
+++ b/netwayste/src/lib.rs
@@ -31,7 +31,7 @@ extern crate tokio_core;
 #[macro_use]
 pub mod net;
 pub mod client;
-mod utils;
+pub mod utils;
 
 #[cfg(test)]
 pub mod tests;

--- a/netwayste/src/lib.rs
+++ b/netwayste/src/lib.rs
@@ -31,6 +31,7 @@ extern crate tokio_core;
 #[macro_use]
 pub mod net;
 pub mod client;
+mod utils;
 
 #[cfg(test)]
 pub mod tests;

--- a/netwayste/src/net.rs
+++ b/netwayste/src/net.rs
@@ -17,29 +17,32 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-use std::cmp::{PartialEq, PartialOrd, Ordering};
-use std::fmt::Debug;
-use std::{io, fmt, str, result, time::{Duration, Instant}};
-use std::net::{self, SocketAddr};
+use std::cmp::{Ordering, PartialEq, PartialOrd};
 use std::collections::VecDeque;
+use std::fmt::Debug;
+use std::net::{self, SocketAddr};
+use std::{
+    fmt, io, result, str,
+    time::{Duration, Instant},
+};
 
+use bincode::{deserialize, serialize, Infinite};
 use futures::sync::mpsc;
-use tokio_core::net::{UdpSocket, UdpCodec};
+use semver::{SemVerError, Version};
+use serde::{Deserialize, Serialize};
+use tokio_core::net::{UdpCodec, UdpSocket};
 use tokio_core::reactor::Handle;
-use bincode::{serialize, deserialize, Infinite};
-use semver::{Version, SemVerError};
-use serde::{Serialize, Deserialize};
 
 pub const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 pub const DEFAULT_HOST: &str = "0.0.0.0";
 pub const DEFAULT_PORT: u16 = 2016;
-pub const TIMEOUT_IN_SECONDS:    u64   = 5;
-pub const NETWORK_QUEUE_LENGTH: usize = 600;        // spot testing with poor network (~675 cmds) showed a max of ~512 length
-                                                // keep this for now until the performance issues are resolved
+pub const TIMEOUT_IN_SECONDS: u64 = 5;
+pub const NETWORK_QUEUE_LENGTH: usize = 600; // spot testing with poor network (~675 cmds) showed a max of ~512 length
+                                             // keep this for now until the performance issues are resolved
 const RETRANSMISSION_THRESHOLD_IN_MS: Duration = Duration::from_millis(400);
-const RETRY_THRESHOLD_IN_MS: usize = 2;             //
+const RETRY_THRESHOLD_IN_MS: usize = 2; //
 const RETRY_AGGRESSIVE_THRESHOLD_IN_MS: usize = 5;
-const RETRANSMISSION_COUNT: usize = 32;   // Testing some ideas out:. Resend length 16x2, 16=libconway::history_size)
+const RETRANSMISSION_COUNT: usize = 32; // Testing some ideas out:. Resend length 16x2, 16=libconway::history_size)
 
 // For unit testing, I cover duplicate sequence numbers. The search returns Ok(index) on a slice with a matching value.
 // Instead of returning that index, I return this much larger value and avoid insertion into the queues.
@@ -84,19 +87,29 @@ impl From<io::Error> for NetError {
     }
 }
 
-
 ////////////////////// Data model ////////////////////////
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub enum RequestAction {
-    None,   // never actually sent
-    Connect{name: String, client_version: String},
+    None, // never actually sent
+    Connect {
+        name: String,
+        client_version: String,
+    },
     Disconnect,
-    KeepAlive{latest_response_ack: u64},     // Send latest response ack on each heartbeat
+    KeepAlive {
+        latest_response_ack: u64,
+    }, // Send latest response ack on each heartbeat
     ListPlayers,
-    ChatMessage{message: String},
+    ChatMessage {
+        message: String,
+    },
     ListRooms,
-    NewRoom{room_name: String},
-    JoinRoom{room_name: String},
+    NewRoom {
+        room_name: String,
+    },
+    JoinRoom {
+        room_name: String,
+    },
     LeaveRoom,
 }
 
@@ -105,30 +118,49 @@ pub enum RequestAction {
 pub enum ResponseCode {
     // success - these are all 200 in HTTP
     // TODO: Many of these should contain the sequence number being acknowledged
-    OK,                               // 200 no data
-    LoggedIn{cookie: String, server_version: String},        // player is logged in -- (cookie, server version)
-    JoinedRoom{room_name: String},    // player has joined the room
-    LeaveRoom,                        // player has left the room
-    PlayerList{players: Vec<String>}, // list of players in room or lobby
-    RoomList{rooms: Vec<RoomList>},   // list of rooms and their statuses
+    OK, // 200 no data
+    LoggedIn {
+        cookie: String,
+        server_version: String,
+    }, // player is logged in -- (cookie, server version)
+    JoinedRoom {
+        room_name: String,
+    }, // player has joined the room
+    LeaveRoom, // player has left the room
+    PlayerList {
+        players: Vec<String>,
+    }, // list of players in room or lobby
+    RoomList {
+        rooms: Vec<RoomList>,
+    }, // list of rooms and their statuses
 
     // errors
-    BadRequest{error_msg: String},      // 400 unspecified error that is client's fault
-    Unauthorized{error_msg: String},    // 401 not logged in
-    TooManyRequests{error_msg: String}, // 429
-    ServerError{error_msg: String},     // 500
-    NotConnected{error_msg: String},    // no equivalent in HTTP due to handling at lower (TCP) level
-    KeepAlive,                       // Server's heart is beating
+    BadRequest {
+        error_msg: String,
+    }, // 400 unspecified error that is client's fault
+    Unauthorized {
+        error_msg: String,
+    }, // 401 not logged in
+    TooManyRequests {
+        error_msg: String,
+    }, // 429
+    ServerError {
+        error_msg: String,
+    }, // 500
+    NotConnected {
+        error_msg: String,
+    }, // no equivalent in HTTP due to handling at lower (TCP) level
+    KeepAlive, // Server's heart is beating
 }
 
 // chat messages sent from server to all clients other than originating client
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct BroadcastChatMessage {
-    pub chat_seq:    Option<u64>,   // Some(<number>) when sent to clients (starts at 0 for first
-                                    // chat message sent to this client in this room); None when
-                                    // internal to server
+    pub chat_seq: Option<u64>, // Some(<number>) when sent to clients (starts at 0 for first
+    // chat message sent to this client in this room); None when
+    // internal to server
     pub player_name: String,
-    pub message:     String,        // should not contain newlines
+    pub message: String, // should not contain newlines
 }
 
 impl PartialEq for BroadcastChatMessage {
@@ -162,14 +194,16 @@ impl BroadcastChatMessage {
         BroadcastChatMessage {
             chat_seq: Some(sequence),
             player_name: name,
-            message: msg
+            message: msg,
         }
     }
 
     fn sequence_number(&self) -> u64 {
         if let Some(v) = self.chat_seq {
             v
-        } else { 0 }
+        } else {
+            0
+        }
     }
 }
 
@@ -177,34 +211,34 @@ impl BroadcastChatMessage {
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct GenState {
     // state of the Universe
-    pub gen:        u64,
+    pub gen: u64,
     pub dummy_data: u8,
 }
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
-pub struct GenDiff  {
+pub struct GenDiff {
     // difference between states of Universe
-    pub old_gen:    u64,
-    pub new_gen:    u64,
+    pub old_gen: u64,
+    pub new_gen: u64,
     pub dummy_data: u8,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct GameOutcome {
-    pub winner: Option<String>,     // Some(<name>) if winner, or None, meaning it was a tie/forfeit
+    pub winner: Option<String>, // Some(<name>) if winner, or None, meaning it was a tie/forfeit
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub enum GameUpdateType {
     GameStart,
-    NewUserList(Vec<String>),   // list of names of all users including current user
+    NewUserList(Vec<String>), // list of names of all users including current user
     GameFinish(GameOutcome),
-    GameClose,   // kicks user back to arena
+    GameClose, // kicks user back to arena
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct GameUpdate {
-    pub game_update_seq: Option<u64>,  // see BroadcastChatMessage chat_seq field for Some/None meaning
-    update_type:         GameUpdateType,
+    pub game_update_seq: Option<u64>, // see BroadcastChatMessage chat_seq field for Some/None meaning
+    update_type: GameUpdateType,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
@@ -225,46 +259,62 @@ pub struct RoomList {
 pub enum Packet {
     Request {
         // sent by client
-        sequence:        u64,
-        response_ack:    Option<u64>,    // Next expected  sequence number the Server responds with to the Client.
-                                         // Stated differently, the client has seen Server responses from 0 to response_ack-1.
-        cookie:          Option<String>, // present if and only if action != connect
-        action:          RequestAction,
+        sequence: u64,
+        response_ack: Option<u64>, // Next expected  sequence number the Server responds with to the Client.
+        // Stated differently, the client has seen Server responses from 0 to response_ack-1.
+        cookie: Option<String>, // present if and only if action != connect
+        action: RequestAction,
     },
     Response {
         // sent by server in reply to client
-        sequence:        u64,
-        request_ack:     Option<u64>,     // most recent request sequence number received
-        code:            ResponseCode,
+        sequence: u64,
+        request_ack: Option<u64>, // most recent request sequence number received
+        code: ResponseCode,
     },
     Update {
         // in-game: sent by server
-        chats:           Vec<BroadcastChatMessage>, // All non-acknowledged chats are sent each update
-        game_updates:    Vec<GameUpdate>,           // Information pertaining to a game tick update
-        universe_update: UniUpdateType,                     //
+        chats: Vec<BroadcastChatMessage>, // All non-acknowledged chats are sent each update
+        game_updates: Vec<GameUpdate>,    // Information pertaining to a game tick update
+        universe_update: UniUpdateType,   //
     },
     UpdateReply {
         // in-game: sent by client in reply to server
-        cookie:               String,
-        last_chat_seq:        Option<u64>, // sequence number of latest chat msg. received from server
+        cookie: String,
+        last_chat_seq: Option<u64>, // sequence number of latest chat msg. received from server
         last_game_update_seq: Option<u64>, // seq. number of latest game update from server
-        last_gen:             Option<u64>, // generation number client is currently at
-    }
+        last_gen: Option<u64>,      // generation number client is currently at
+    },
 }
 
 impl Packet {
     #[allow(unused)]
     pub fn sequence_number(&self) -> u64 {
-        if let Packet::Request{ sequence, response_ack: _, cookie: _, action: _ } = self {
+        if let Packet::Request {
+            sequence,
+            response_ack: _,
+            cookie: _,
+            action: _,
+        } = self
+        {
             *sequence
-        } else if let Packet::Response{ sequence, request_ack: _, code: _ } = self {
+        } else if let Packet::Response {
+            sequence,
+            request_ack: _,
+            code: _,
+        } = self
+        {
             *sequence
-        } else if let Packet::Update{ chats: _, game_updates: _, universe_update } = self {
+        } else if let Packet::Update {
+            chats: _,
+            game_updates: _,
+            universe_update,
+        } = self
+        {
             // TODO revisit once mechanics are fleshed out
             match universe_update {
-                UniUpdateType::State(gs) => { gs.gen },
-                UniUpdateType::Diff(gd) => { gd.new_gen },
-                UniUpdateType::NoChange => 0
+                UniUpdateType::State(gs) => gs.gen,
+                UniUpdateType::Diff(gd) => gd.new_gen,
+                UniUpdateType::NoChange => 0,
             }
         } else {
             unimplemented!(); // UpdateReply is not saved
@@ -273,22 +323,36 @@ impl Packet {
 
     #[allow(unused)]
     pub fn set_response_sequence(&mut self, new_ack: Option<u64>) {
-        if let Packet::Request{ sequence: _, ref mut response_ack, cookie: _, action: _ } = *self {
+        if let Packet::Request {
+            sequence: _,
+            ref mut response_ack,
+            cookie: _,
+            action: _,
+        } = *self
+        {
             *response_ack = new_ack;
-        }
-        else if let Packet::Response{ sequence: _, ref mut request_ack, code: _ } = *self {
+        } else if let Packet::Response {
+            sequence: _,
+            ref mut request_ack,
+            code: _,
+        } = *self
+        {
             *request_ack = new_ack;
-        }
-        else {
+        } else {
             unimplemented!();
         }
     }
 
     #[allow(unused)]
     pub fn response_sequence(&self) -> u64 {
-        if let Packet::Request{sequence: _, ref response_ack, cookie: _, action: _} = *self {
-            if let Some(response_ack) = response_ack
-            {
+        if let Packet::Request {
+            sequence: _,
+            ref response_ack,
+            cookie: _,
+            action: _,
+        } = *self
+        {
+            if let Some(response_ack) = response_ack {
                 *response_ack
             } else {
                 0
@@ -351,7 +415,7 @@ impl Ord for Packet {
 #[allow(dead_code)]
 pub struct LineCodec;
 impl UdpCodec for LineCodec {
-    type In = (SocketAddr, Option<Packet>);   // if 2nd element is None, it means deserialization failure
+    type In = (SocketAddr, Option<Packet>); // if 2nd element is None, it means deserialization failure
     type Out = (SocketAddr, Packet);
 
     fn decode(&mut self, addr: &SocketAddr, buf: &[u8]) -> io::Result<Self::In> {
@@ -381,10 +445,21 @@ impl UdpCodec for LineCodec {
 
 //////////////// Network interface ////////////////
 #[allow(dead_code)]
-pub fn bind(handle: &Handle, opt_host: Option<&str>, opt_port: Option<u16>) -> Result<UdpSocket, NetError> {
-
-    let host = if let Some(host) = opt_host { host } else { DEFAULT_HOST };
-    let port = if let Some(port) = opt_port { port } else { DEFAULT_PORT };
+pub fn bind(
+    handle: &Handle,
+    opt_host: Option<&str>,
+    opt_port: Option<u16>,
+) -> Result<UdpSocket, NetError> {
+    let host = if let Some(host) = opt_host {
+        host
+    } else {
+        DEFAULT_HOST
+    };
+    let port = if let Some(port) = opt_port {
+        port
+    } else {
+        DEFAULT_PORT
+    };
     let addr: SocketAddr = format!("{}:{}", host, port).parse()?;
     let sock = UdpSocket::bind(&addr, &handle).expect("failed to bind socket");
     Ok(sock)
@@ -401,8 +476,8 @@ pub fn has_connection_timed_out(last_received: Instant) -> bool {
 }
 
 pub struct NetworkStatistics {
-    pub tx_packets_failed: u64,     // From the perspective of the Network OSI layer
-    pub tx_packets_success: u64,    // From the perspective of the Network OSI layer
+    pub tx_packets_failed: u64, // From the perspective of the Network OSI layer
+    pub tx_packets_success: u64, // From the perspective of the Network OSI layer
 }
 
 impl NetworkStatistics {
@@ -419,11 +494,10 @@ impl NetworkStatistics {
             ref mut tx_packets_failed,
             ref mut tx_packets_success,
         } = *self;
-        *tx_packets_failed     = 0;
-        *tx_packets_success    = 0;
+        *tx_packets_failed = 0;
+        *tx_packets_success = 0;
     }
 }
-
 
 pub trait Sequenced: Ord {
     fn sequence_number(&self) -> u64;
@@ -441,7 +515,7 @@ impl Sequenced for BroadcastChatMessage {
     }
 }
 
-pub trait NetworkQueue<T: Ord+Sequenced+Debug+Clone> {
+pub trait NetworkQueue<T: Ord + Sequenced + Debug + Clone> {
     fn new() -> Self;
 
     fn head_of_queue(&self) -> Option<&T> {
@@ -458,7 +532,9 @@ pub trait NetworkQueue<T: Ord+Sequenced+Debug+Clone> {
         if opt_newest_packet.is_some() {
             let newest_packet: &T = opt_newest_packet.unwrap();
             Some(newest_packet.sequence_number())
-        } else { None }
+        } else {
+            None
+        }
     }
 
     fn oldest_seq_num(&self) -> Option<u64> {
@@ -467,7 +543,9 @@ pub trait NetworkQueue<T: Ord+Sequenced+Debug+Clone> {
         if opt_oldest_packet.is_some() {
             let oldest_packet: &T = opt_oldest_packet.unwrap();
             Some(oldest_packet.sequence_number())
-        } else { None }
+        } else {
+            None
+        }
     }
 
     fn push_back(&mut self, item: T) {
@@ -488,7 +566,7 @@ pub trait NetworkQueue<T: Ord+Sequenced+Debug+Clone> {
 
     /// I've deemed 'far away' to mean the half of the max value of the type.
     fn is_seq_sufficiently_far_away(&self, a: u64, b: u64) -> bool {
-        static HALFWAYPOINT: u64 = u64::max_value()/2;
+        static HALFWAYPOINT: u64 = u64::max_value() / 2;
         if a > b {
             a - b > HALFWAYPOINT
         } else {
@@ -498,14 +576,16 @@ pub trait NetworkQueue<T: Ord+Sequenced+Debug+Clone> {
 
     /// Checks if the insertion of `sequence` induces a newly wrapped queue state.
     /// If we have already wrapped in the buffer, then it shouldn't cause another wrap due to the nature of the problem.
-    fn will_seq_cause_a_wrap(&self,
-                            buffer_wrap_index: Option<usize>,
-                            sequence: u64,
-                            oldest_seq_num: u64,
-                            newest_seq_num: u64) -> bool {
+    fn will_seq_cause_a_wrap(
+        &self,
+        buffer_wrap_index: Option<usize>,
+        sequence: u64,
+        oldest_seq_num: u64,
+        newest_seq_num: u64,
+    ) -> bool {
         if buffer_wrap_index.is_none() {
             self.is_seq_sufficiently_far_away(sequence, oldest_seq_num)
-            && self.is_seq_sufficiently_far_away(sequence, newest_seq_num)
+                && self.is_seq_sufficiently_far_away(sequence, newest_seq_num)
         } else {
             false
         }
@@ -557,27 +637,26 @@ impl NetQueue<Packet> {
     pub fn get_retransmit_indices(&self) -> Vec<usize> {
         let iter = self.attempts.iter();
         iter.enumerate()
-            .filter(|(_, ts)|
-                (
-                    (Instant::now() - ts.time) >= RETRANSMISSION_THRESHOLD_IN_MS)
+            .filter(|(_, ts)| {
+                ((Instant::now() - ts.time) >= RETRANSMISSION_THRESHOLD_IN_MS)
                     || (ts.retries >= RETRY_THRESHOLD_IN_MS)
                     || (ts.retries >= RETRY_AGGRESSIVE_THRESHOLD_IN_MS)
-                )
+            })
             .map(|(i, _)| i)
             .take(RETRANSMISSION_COUNT)
             .collect::<Vec<usize>>()
     }
-
 }
 
 impl<T> NetworkQueue<T> for NetQueue<T>
-        where T: Sequenced+Debug+Clone {
-
+where
+    T: Sequenced + Debug + Clone,
+{
     fn new() -> Self {
         NetQueue {
-            queue:          ItemQueue::<T>::with_capacity(NETWORK_QUEUE_LENGTH),
-            attempts:     VecDeque::<NetAttempt>::with_capacity(NETWORK_QUEUE_LENGTH),
-            buffer_wrap_index: None
+            queue: ItemQueue::<T>::with_capacity(NETWORK_QUEUE_LENGTH),
+            attempts: VecDeque::<NetAttempt>::with_capacity(NETWORK_QUEUE_LENGTH),
+            buffer_wrap_index: None,
         }
     }
 
@@ -593,7 +672,7 @@ impl<T> NetworkQueue<T> for NetQueue<T>
         let queue = self.as_queue_type_mut();
         let queue_size = queue.len();
         if queue_size >= NETWORK_QUEUE_LENGTH {
-            for _ in 0..(queue_size-NETWORK_QUEUE_LENGTH) {
+            for _ in 0..(queue_size - NETWORK_QUEUE_LENGTH) {
                 queue.pop_front();
             }
         }
@@ -618,7 +697,10 @@ impl<T> NetworkQueue<T> for NetQueue<T>
         };
         match result {
             Err(_) => {
-                warn!("Packet (Seq: {}) not present in queue! Was it removed already?", pkt.sequence_number());
+                warn!(
+                    "Packet (Seq: {}) not present in queue! Was it removed already?",
+                    pkt.sequence_number()
+                );
                 return None;
             }
             Ok(index) => {
@@ -671,7 +753,12 @@ impl<T> NetworkQueue<T> for NetQueue<T>
         if sequence < oldest_seq_num {
             // Special case with max_value where we do not need to search for the insertion spot.
             if newest_seq_num == u64::max_value() {
-                if self.will_seq_cause_a_wrap(self.buffer_wrap_index, sequence, oldest_seq_num, newest_seq_num) {
+                if self.will_seq_cause_a_wrap(
+                    self.buffer_wrap_index,
+                    sequence,
+                    oldest_seq_num,
+                    newest_seq_num,
+                ) {
                     self.push_back(item);
                     self.attempts.push_back(NetAttempt::new());
                     self.buffer_wrap_index = Some(self.len() - 1);
@@ -684,7 +771,8 @@ impl<T> NetworkQueue<T> for NetQueue<T>
                 // an older sequence number arrived late.
                 if self.is_seq_sufficiently_far_away(sequence, newest_seq_num) {
                     if let Some(buffer_wrap_index) = self.buffer_wrap_index {
-                        let insertion_index = self.find_rx_insertion_index_in_subset(0, buffer_wrap_index, &item);
+                        let insertion_index =
+                            self.find_rx_insertion_index_in_subset(0, buffer_wrap_index, &item);
                         self.buffer_wrap_index = Some(buffer_wrap_index + 1);
                         packet_exists = self.insert_into_rx_queue(insertion_index, item);
                     }
@@ -696,11 +784,20 @@ impl<T> NetworkQueue<T> for NetQueue<T>
                 // The new seq num appears to be older than everything,
                 // but it may be far enough in value to induce a wrap.
                 let insertion_index: Option<usize>;
-                if self.will_seq_cause_a_wrap(self.buffer_wrap_index, sequence, oldest_seq_num, newest_seq_num) {
+                if self.will_seq_cause_a_wrap(
+                    self.buffer_wrap_index,
+                    sequence,
+                    oldest_seq_num,
+                    newest_seq_num,
+                ) {
                     insertion_index = Some(self.len());
                     self.buffer_wrap_index = insertion_index;
                 } else if let Some(buffer_wrap_index) = self.buffer_wrap_index {
-                    insertion_index = self.find_rx_insertion_index_in_subset(buffer_wrap_index, self.len(), &item);
+                    insertion_index = self.find_rx_insertion_index_in_subset(
+                        buffer_wrap_index,
+                        self.len(),
+                        &item,
+                    );
                 } else {
                     insertion_index = self.find_rx_insertion_index(&item);
                 }
@@ -716,7 +813,8 @@ impl<T> NetworkQueue<T> for NetQueue<T>
                 }
                 panic!("Previously thought to be dead code. Prove us wrong!");
             }
-        } else { // Sequence >= oldest_seq_num
+        } else {
+            // Sequence >= oldest_seq_num
             let insertion_index: Option<usize>;
             if sequence < newest_seq_num {
                 insertion_index = self.find_rx_insertion_index(&item);
@@ -725,10 +823,16 @@ impl<T> NetworkQueue<T> for NetQueue<T>
                 // Time to see if we have wrapped already, and if not, we
                 // need to see if we are about to wrap based on this insertion.
                 if let Some(buffer_wrap_index) = self.buffer_wrap_index {
-                    insertion_index = self.find_rx_insertion_index_in_subset(0, buffer_wrap_index, &item);
+                    insertion_index =
+                        self.find_rx_insertion_index_in_subset(0, buffer_wrap_index, &item);
                     self.buffer_wrap_index = Some(buffer_wrap_index + 1);
                 } else {
-                    if self.will_seq_cause_a_wrap(self.buffer_wrap_index, sequence, oldest_seq_num, newest_seq_num) {
+                    if self.will_seq_cause_a_wrap(
+                        self.buffer_wrap_index,
+                        sequence,
+                        oldest_seq_num,
+                        newest_seq_num,
+                    ) {
                         // Sequence is far enough, and we haven't wrapped, so it arrived late.
                         // Push it to the front of the queue
                         insertion_index = Some(0);
@@ -745,8 +849,10 @@ impl<T> NetworkQueue<T> for NetQueue<T>
     }
 }
 
-impl<T> NetQueue<T> where T: Sequenced+Debug+Clone {
-
+impl<T> NetQueue<T>
+where
+    T: Sequenced + Debug + Clone,
+{
     /// Searching within the queue, but when we have no idea where to insert.
     /// We accomplish this by splitting the VecDequeue into a slice tuple and then binary searching on each slice.
     /// Small note: The splitting of VecDequeue is into its 'front' and 'back' halves, based on how 'push_front'
@@ -776,16 +882,21 @@ impl<T> NetQueue<T> where T: Sequenced+Debug+Clone {
                     // Could not find a place to insert
                     (_, _) => None,
                 }
-            },
+            }
             #[cfg(test)]
-            (_,_) => Some(MATCH_FOUND_SENTINEL),
+            (_, _) => Some(MATCH_FOUND_SENTINEL),
             #[cfg(not(test))]
-            (_,_) => None,
+            (_, _) => None,
         }
     }
 
     // Search within the RX queue when we know which subset interests us.
-    fn find_rx_insertion_index_in_subset(&self, start: usize, end: usize, item: &T) -> Option<usize> {
+    fn find_rx_insertion_index_in_subset(
+        &self,
+        start: usize,
+        end: usize,
+        item: &T,
+    ) -> Option<usize> {
         let search_space: Vec<&T> = self.queue.iter().skip(start).take(end).collect();
         let result = search_space.as_slice().binary_search(&item);
         match result {
@@ -803,7 +914,8 @@ impl<T> NetQueue<T> where T: Sequenced+Debug+Clone {
         if let Some(insertion_index) = index {
             if insertion_index != MATCH_FOUND_SENTINEL {
                 if cfg!(test) {
-                    self.as_queue_type_mut().insert(insertion_index, item.clone());
+                    self.as_queue_type_mut()
+                        .insert(insertion_index, item.clone());
                     self.attempts.push_back(NetAttempt::new());
                 }
             }
@@ -811,7 +923,9 @@ impl<T> NetQueue<T> where T: Sequenced+Debug+Clone {
                 self.as_queue_type_mut().insert(insertion_index, item);
                 self.attempts.push_back(NetAttempt::new());
             }
-        } else { exists = true; } // Packet is present in queue, hence None.
+        } else {
+            exists = true;
+        } // Packet is present in queue, hence None.
         return exists;
     }
 
@@ -833,12 +947,12 @@ impl<T> NetQueue<T> where T: Sequenced+Debug+Clone {
 }
 
 pub struct NetworkManager {
-    pub statistics:       NetworkStatistics,
-    pub tx_packets:       NetQueue<Packet>,                       // Back = Newest, Front = Oldest
-    pub rx_packets:       NetQueue<Packet>,                       // Back = Newest, Front = Oldest
+    pub statistics: NetworkStatistics,
+    pub tx_packets: NetQueue<Packet>, // Back = Newest, Front = Oldest
+    pub rx_packets: NetQueue<Packet>, // Back = Newest, Front = Oldest
     pub rx_chat_messages: Option<NetQueue<BroadcastChatMessage>>, // Back = Newest, Front = Oldest;
-                                                                 //     Messages are drained into the Client;
-                                                                 //     Server does not use this structure.
+                                      //     Messages are drained into the Client;
+                                      //     Server does not use this structure.
 }
 
 impl NetworkManager {
@@ -846,8 +960,8 @@ impl NetworkManager {
     pub fn new() -> Self {
         NetworkManager {
             statistics: NetworkStatistics::new(),
-            tx_packets:  NetQueue::<Packet>::new(),
-            rx_packets:  NetQueue::<Packet>::new(),
+            tx_packets: NetQueue::<Packet>::new(),
+            rx_packets: NetQueue::<Packet>::new(),
             rx_chat_messages: None,
         }
     }
@@ -858,7 +972,7 @@ impl NetworkManager {
             statistics: self.statistics,
             tx_packets: self.tx_packets,
             rx_packets: self.rx_packets,
-            rx_chat_messages:  Some(NetQueue::<BroadcastChatMessage>::new()),
+            rx_chat_messages: Some(NetQueue::<BroadcastChatMessage>::new()),
         }
     }
 
@@ -887,18 +1001,18 @@ impl NetworkManager {
     }
 
     #[allow(unused)]
-    pub fn retransmit_expired_tx_packets(&mut self,
-         udp_tx: &mpsc::UnboundedSender<(SocketAddr, Packet)>,
-         addr: SocketAddr,
-         confirmed_ack: Option<u64>,
-         indices: &Vec<usize>) {
-
+    pub fn retransmit_expired_tx_packets(
+        &mut self,
+        udp_tx: &mpsc::UnboundedSender<(SocketAddr, Packet)>,
+        addr: SocketAddr,
+        confirmed_ack: Option<u64>,
+        indices: &Vec<usize>,
+    ) {
         let mut error_occurred = false;
         let mut failed_index = 0;
 
         // Retransmit all packets after that are still in the queue after RETRANSMISSION_THRESHOLD_IN_MS
         for &index in indices.iter() {
-
             let mut send_counter = 1;
 
             if let Some(ts) = self.tx_packets.attempts.get_mut(index) {
@@ -918,22 +1032,29 @@ impl NetworkManager {
                 pkt.set_response_sequence(confirmed_ack);
                 trace!("[Retransmitting (Times={})] {:?}", send_counter, pkt);
                 for _ in 0..send_counter {
-                    netwayste_send!(udp_tx, (addr, (*pkt).clone()),
-                                ("Could not retransmit packet to server: {:?}", pkt));
+                    netwayste_send!(
+                        udp_tx,
+                        (addr, (*pkt).clone()),
+                        ("Could not retransmit packet to server: {:?}", pkt)
+                    );
                 }
             } else {
                 error_occurred = true;
                 failed_index = index;
                 break;
             }
-
         }
 
         if error_occurred {
             // Panic during development, probably want to make this error later on
-            panic!("ERROR: Index ({}) in attempt queue out-of-bounds in tx packets queue,
+            panic!(
+                "ERROR: Index ({}) in attempt queue out-of-bounds in tx packets queue,
                             or perhaps `None`?:\n\t {:?}\n{:?}\n{:?}",
-                    failed_index, indices, self.tx_packets.queue.len(), self.tx_packets.attempts.len());
+                failed_index,
+                indices,
+                self.tx_packets.queue.len(),
+                self.tx_packets.attempts.len()
+            );
         }
     }
 
@@ -949,7 +1070,6 @@ impl NetworkManager {
             num_to_remove -= 1;
         }
     }
-
 }
 
 #[derive(PartialEq, Debug, Clone)]
@@ -958,18 +1078,18 @@ pub enum NetwaysteEvent {
     None,
 
     // Requests
-    Connect(String, String),            // Player name, version
+    Connect(String, String), // Player name, version
     Disconnect,
     List,
-    ChatMessage(String),                // chat message
-    NewRoom(String),                    // room name
-    JoinRoom(String),                   // room name
+    ChatMessage(String), // chat message
+    NewRoom(String),     // room name
+    JoinRoom(String),    // room name
     LeaveRoom,
 
     // Responses
-    LoggedIn(String),                   // player is logged in -- (version)
-    JoinedRoom(String),                 // player has joined the room
-    PlayerList(Vec<String>),     // list of players in room or lobby with ping (ms)
+    LoggedIn(String),        // player is logged in -- (version)
+    JoinedRoom(String),      // player has joined the room
+    PlayerList(Vec<String>), // list of players in room or lobby with ping (ms)
     RoomList(Vec<RoomList>), // (room name, # players, game has started?)
     LeftRoom,
     BadRequest(String),
@@ -977,24 +1097,22 @@ pub enum NetwaysteEvent {
 
     // Updates
     ChatMessages(Vec<(String, String)>), // (player name, message)
-    UniverseUpdate,                       // TODO add libconway stuff for current universe gen
-
+    UniverseUpdate,                      // TODO add libconway stuff for current universe gen
 }
 
 impl NetwaysteEvent {
-
     #[allow(unused)]
-    pub fn build_request_action_from_netwayste_event(nw_event: NetwaysteEvent, is_in_game: bool) -> RequestAction {
+    pub fn build_request_action_from_netwayste_event(
+        nw_event: NetwaysteEvent,
+        is_in_game: bool,
+    ) -> RequestAction {
         match nw_event {
-            NetwaysteEvent::None => {
-                RequestAction::None
-            }
-            NetwaysteEvent::Connect(name, version) => {
-                RequestAction::Connect{name: name, client_version: version}
-            }
-            NetwaysteEvent::Disconnect => {
-                RequestAction::Disconnect
-            }
+            NetwaysteEvent::None => RequestAction::None,
+            NetwaysteEvent::Connect(name, version) => RequestAction::Connect {
+                name: name,
+                client_version: version,
+            },
+            NetwaysteEvent::Disconnect => RequestAction::Disconnect,
             NetwaysteEvent::List => {
                 // players or rooms
                 if is_in_game {
@@ -1004,12 +1122,10 @@ impl NetwaysteEvent {
                     RequestAction::ListRooms
                 }
             }
-            NetwaysteEvent::ChatMessage(msg) => {
-                RequestAction::ChatMessage{message: msg}
-            }
+            NetwaysteEvent::ChatMessage(msg) => RequestAction::ChatMessage { message: msg },
             NetwaysteEvent::NewRoom(name) => {
                 if !is_in_game {
-                    RequestAction::NewRoom{room_name: name}
+                    RequestAction::NewRoom { room_name: name }
                 } else {
                     debug!("Command failed: You are in a game");
                     RequestAction::None
@@ -1017,7 +1133,7 @@ impl NetwaysteEvent {
             }
             NetwaysteEvent::JoinRoom(name) => {
                 if !is_in_game {
-                    RequestAction::JoinRoom{room_name: name}
+                    RequestAction::JoinRoom { room_name: name }
                 } else {
                     debug!("Command failed: You are already in a game");
                     RequestAction::None
@@ -1032,7 +1148,10 @@ impl NetwaysteEvent {
                 }
             }
             _ => {
-                panic!("Unexpected netwayste event during request action construction! {:?}", nw_event);
+                panic!(
+                    "Unexpected netwayste event during request action construction! {:?}",
+                    nw_event
+                );
             }
         }
     }
@@ -1040,34 +1159,23 @@ impl NetwaysteEvent {
     #[allow(unused)]
     pub fn build_netwayste_event_from_response_code(code: ResponseCode) -> NetwaysteEvent {
         match code {
-            ResponseCode::LoggedIn{cookie: _, server_version} => {
-                NetwaysteEvent::LoggedIn(server_version)
-            }
-            ResponseCode::JoinedRoom{room_name} => {
-                NetwaysteEvent::JoinedRoom(room_name)
-            }
-            ResponseCode::PlayerList{players} => {
-                NetwaysteEvent::PlayerList(players)
-            }
-            ResponseCode::RoomList{rooms} => {
-                NetwaysteEvent::RoomList(rooms)
-            }
-            ResponseCode::LeaveRoom => {
-                NetwaysteEvent::LeftRoom
-            }
-            ResponseCode::BadRequest{error_msg} => {
-                NetwaysteEvent::BadRequest(error_msg)
-            }
-            ResponseCode::ServerError{error_msg} => {
-                NetwaysteEvent::ServerError(error_msg)
-            }
-            ResponseCode::Unauthorized{error_msg} => {
-                NetwaysteEvent::BadRequest(error_msg)
-            }
+            ResponseCode::LoggedIn {
+                cookie: _,
+                server_version,
+            } => NetwaysteEvent::LoggedIn(server_version),
+            ResponseCode::JoinedRoom { room_name } => NetwaysteEvent::JoinedRoom(room_name),
+            ResponseCode::PlayerList { players } => NetwaysteEvent::PlayerList(players),
+            ResponseCode::RoomList { rooms } => NetwaysteEvent::RoomList(rooms),
+            ResponseCode::LeaveRoom => NetwaysteEvent::LeftRoom,
+            ResponseCode::BadRequest { error_msg } => NetwaysteEvent::BadRequest(error_msg),
+            ResponseCode::ServerError { error_msg } => NetwaysteEvent::ServerError(error_msg),
+            ResponseCode::Unauthorized { error_msg } => NetwaysteEvent::BadRequest(error_msg),
             _ => {
-                panic!("Unexpected response code during netwayste event construction: {:?}", code);
+                panic!(
+                    "Unexpected response code during netwayste event construction: {:?}",
+                    code
+                );
             }
         }
     }
-
 }

--- a/netwayste/src/net.rs
+++ b/netwayste/src/net.rs
@@ -1129,7 +1129,7 @@ pub enum NetwaysteEvent {
 
     // Server Status
     GetStatus(PingPong),
-    Status(Packet), // Only uses the `Packet::Status` variant
+    Status(Packet, Option<u64>), // `Packet::Status` variant only; u64 is latency. None if not yet calculated.
 }
 
 impl NetwaysteEvent {

--- a/netwayste/src/server.rs
+++ b/netwayste/src/server.rs
@@ -17,46 +17,47 @@
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#[macro_use] extern crate log;
-#[macro_use] mod net;
+#[macro_use]
+extern crate log;
+#[macro_use]
+mod net;
 
 #[cfg(test)]
 #[macro_use]
 extern crate proptest;
 
 use netwayste::net::{
-    RequestAction, ResponseCode, Packet, LineCodec, bind, RoomList,
-    UniUpdateType, BroadcastChatMessage, NetworkManager,
-    NetworkQueue, get_version, VERSION, has_connection_timed_out,
-    DEFAULT_HOST, DEFAULT_PORT,
+    bind, get_version, has_connection_timed_out, BroadcastChatMessage, LineCodec, NetworkManager,
+    NetworkQueue, Packet, RequestAction, ResponseCode, RoomList, UniUpdateType, DEFAULT_HOST,
+    DEFAULT_PORT, VERSION,
 };
 
+use std::collections::HashMap;
+use std::collections::VecDeque;
 use std::error::Error;
+use std::fmt;
 use std::io::{self, ErrorKind, Write};
 use std::iter;
 use std::net::SocketAddr;
 use std::process::exit;
-use std::time::{Duration, Instant};
-use std::collections::HashMap;
-use std::fmt;
 use std::time;
-use std::collections::VecDeque;
+use std::time::{Duration, Instant};
 
-use tokio_core::reactor::{Core, Timeout};
 use chrono::Local;
+use clap::{App, Arg};
+use futures::{future::ok, stream, sync::mpsc, Future, Sink, Stream};
 use log::LevelFilter;
-use futures::{Future, Sink, Stream, stream, future::ok, sync::mpsc};
 use rand::RngCore;
 use semver::Version;
-use clap::{App, Arg};
+use tokio_core::reactor::{Core, Timeout};
 
-pub const TICK_INTERVAL_IN_MS:    u64      = 10;
-pub const NETWORK_INTERVAL_IN_MS: u64      = 100;    // Arbitrarily chosen
-pub const HEARTBEAT_INTERVAL_IN_MS: u64    = 1000;    // Arbitrarily chosen
-pub const MAX_ROOM_NAME:          usize    = 16;
-pub const MAX_NUM_CHAT_MESSAGES:  usize    = 128;
-pub const MAX_AGE_CHAT_MESSAGES:  usize    = 60*5; // seconds
-pub const SERVER_ID:              PlayerID = PlayerID(u64::max_value()); // 0xFFFF....FFFF
+pub const TICK_INTERVAL_IN_MS: u64 = 10;
+pub const NETWORK_INTERVAL_IN_MS: u64 = 100; // Arbitrarily chosen
+pub const HEARTBEAT_INTERVAL_IN_MS: u64 = 1000; // Arbitrarily chosen
+pub const MAX_ROOM_NAME: usize = 16;
+pub const MAX_NUM_CHAT_MESSAGES: usize = 128;
+pub const MAX_AGE_CHAT_MESSAGES: usize = 60 * 5; // seconds
+pub const SERVER_ID: PlayerID = PlayerID(u64::max_value()); // 0xFFFF....FFFF
 
 #[derive(PartialEq, Debug, Clone, Copy, Eq, Hash)]
 pub struct PlayerID(pub u64);
@@ -78,23 +79,23 @@ impl fmt::Display for RoomID {
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct Player {
-    pub player_id:     PlayerID,
-    pub cookie:        String,
-    pub addr:          SocketAddr,
-    pub name:          String,
-    pub request_ack:   Option<u64>,          // The next number we expect is request_ack + 1
-    pub next_resp_seq: u64,                  // This is the sequence number for the Response packet the Server sends to the Client
-    pub game_info:     Option<PlayerInGameInfo>,   // none means in lobby
-    pub last_received: time::Instant,        // Time of last message received from player
+    pub player_id: PlayerID,
+    pub cookie: String,
+    pub addr: SocketAddr,
+    pub name: String,
+    pub request_ack: Option<u64>, // The next number we expect is request_ack + 1
+    pub next_resp_seq: u64, // This is the sequence number for the Response packet the Server sends to the Client
+    pub game_info: Option<PlayerInGameInfo>, // none means in lobby
+    pub last_received: time::Instant, // Time of last message received from player
 }
 
 // info for a player as it relates to a game/room
 #[derive(PartialEq, Debug, Clone)]
 pub struct PlayerInGameInfo {
     room_id: RoomID,
-    chat_msg_seq_num: Option<u64>,    // Server has confirmed the client has received messages up to this value.
-    //XXX PlayerGenState ID within Universe
-    //XXX update statuses
+    chat_msg_seq_num: Option<u64>, // Server has confirmed the client has received messages up to this value.
+                                   //XXX PlayerGenState ID within Universe
+                                   //XXX update statuses
 }
 
 impl Player {
@@ -145,36 +146,35 @@ impl Player {
         }
         return false;
     }
-
 }
 
 #[derive(PartialEq, Debug, Clone)]
 pub struct ServerChatMessage {
-    pub seq_num:     u64,     // sequence number
-    pub player_id:   PlayerID,
+    pub seq_num: u64, // sequence number
+    pub player_id: PlayerID,
     pub player_name: String,
-    pub message:     String,
-    pub timestamp:   Instant,
+    pub message: String,
+    pub timestamp: Instant,
 }
 
 #[derive(Clone, PartialEq)]
 pub struct Room {
     pub room_id: RoomID,
-    pub name:         String,
-    pub player_ids:   Vec<PlayerID>,
+    pub name: String,
+    pub player_ids: Vec<PlayerID>,
     pub game_running: bool,
-    pub universe:     u64,    // Temp until we integrate
+    pub universe: u64, // Temp until we integrate
     pub latest_seq_num: u64,
-    pub messages:     VecDeque<ServerChatMessage>    // Front == Oldest, Back == Newest
+    pub messages: VecDeque<ServerChatMessage>, // Front == Oldest, Back == Newest
 }
 
 pub struct ServerState {
-    pub tick:           usize,
-    pub players:        HashMap<PlayerID, Player>,
-    pub player_map:     HashMap<String, PlayerID>,  // map cookie to player ID
-    pub rooms:          HashMap<RoomID, Room>,
-    pub room_map:       HashMap<String, RoomID>,    // map room name to room ID
-    pub network_map:    HashMap<PlayerID, NetworkManager>,  // map Player ID to Player's network data
+    pub tick: usize,
+    pub players: HashMap<PlayerID, Player>,
+    pub player_map: HashMap<String, PlayerID>, // map cookie to player ID
+    pub rooms: HashMap<RoomID, Room>,
+    pub room_map: HashMap<String, RoomID>, // map room name to room ID
+    pub network_map: HashMap<PlayerID, NetworkManager>, // map Player ID to Player's network data
 }
 
 //////////////// Utilities ///////////////////////
@@ -224,7 +224,7 @@ impl ServerChatMessage {
             player_name: name,
             message: msg,
             seq_num: seq_num,
-            timestamp: time::Instant::now()
+            timestamp: time::Instant::now(),
         }
     }
 }
@@ -236,10 +236,10 @@ impl Room {
         Room {
             room_id: RoomID(new_uuid()),
             name: name,
-            player_ids:   player_ids,
+            player_ids: player_ids,
             game_running: false,
-            universe:     0,
-            messages:     VecDeque::<ServerChatMessage>::with_capacity(MAX_NUM_CHAT_MESSAGES),
+            universe: 0,
+            messages: VecDeque::<ServerChatMessage>::with_capacity(MAX_NUM_CHAT_MESSAGES),
             latest_seq_num: 0,
         }
     }
@@ -249,7 +249,7 @@ impl Room {
     pub fn discard_older_messages(&mut self) {
         let queue_size = self.messages.len();
         if queue_size >= MAX_NUM_CHAT_MESSAGES {
-            for _ in 0..(queue_size-MAX_NUM_CHAT_MESSAGES+1) {
+            for _ in 0..(queue_size - MAX_NUM_CHAT_MESSAGES + 1) {
                 self.messages.pop_front();
             }
         }
@@ -297,15 +297,15 @@ impl Room {
         let oldest_msg = opt_oldest_msg.unwrap();
 
         // Skip over these messages since we've already acked them
-        let amount_to_consume: u64 =
-            if chat_msg_seq_num >= oldest_msg.seq_num {
-                ((chat_msg_seq_num - oldest_msg.seq_num) + 1) % (MAX_NUM_CHAT_MESSAGES as u64)
-            } else if chat_msg_seq_num < oldest_msg.seq_num && oldest_msg.seq_num != newest_msg.seq_num {
-                // Sequence number has wrapped
-                (<u64>::max_value() - oldest_msg.seq_num) + chat_msg_seq_num + 1
-            } else {
-                0
-            };
+        let amount_to_consume: u64 = if chat_msg_seq_num >= oldest_msg.seq_num {
+            ((chat_msg_seq_num - oldest_msg.seq_num) + 1) % (MAX_NUM_CHAT_MESSAGES as u64)
+        } else if chat_msg_seq_num < oldest_msg.seq_num && oldest_msg.seq_num != newest_msg.seq_num
+        {
+            // Sequence number has wrapped
+            (<u64>::max_value() - oldest_msg.seq_num) + chat_msg_seq_num + 1
+        } else {
+            0
+        };
 
         return amount_to_consume;
     }
@@ -314,12 +314,16 @@ impl Room {
     pub fn broadcast(&mut self, event: String) {
         self.discard_older_messages();
         let seq_num = self.increment_seq_num();
-        self.add_message(ServerChatMessage::new(SERVER_ID, "Server".to_owned(), event, seq_num));
+        self.add_message(ServerChatMessage::new(
+            SERVER_ID,
+            "Server".to_owned(),
+            event,
+            seq_num,
+        ));
     }
 }
 
 impl ServerState {
-
     pub fn get_player(&self, player_id: PlayerID) -> &Player {
         let opt_player = self.players.get(&player_id);
 
@@ -346,7 +350,7 @@ impl ServerState {
             return None;
         };
 
-        Some(player.game_info.as_ref().unwrap().room_id)  // unwrap ok because of test above
+        Some(player.game_info.as_ref().unwrap().room_id) // unwrap ok because of test above
     }
 
     pub fn get_room_mut(&mut self, player_id: PlayerID) -> Option<&mut Room> {
@@ -370,7 +374,9 @@ impl ServerState {
     pub fn list_players(&self, player_id: PlayerID) -> ResponseCode {
         let opt_room = self.get_room(player_id);
         if opt_room.is_none() {
-            return ResponseCode::BadRequest{error_msg: "cannot list players because in lobby.".to_owned()};
+            return ResponseCode::BadRequest {
+                error_msg: "cannot list players because in lobby.".to_owned(),
+            };
         }
         let room = opt_room.unwrap();
 
@@ -381,14 +387,16 @@ impl ServerState {
             }
         });
 
-        return ResponseCode::PlayerList{players};
+        return ResponseCode::PlayerList { players };
     }
 
     pub fn handle_chat_message(&mut self, player_id: PlayerID, msg: String) -> ResponseCode {
         let player_in_game = self.is_player_in_game(player_id);
 
         if !player_in_game {
-            return ResponseCode::BadRequest{error_msg: format!("Player {} has not joined a game.", player_id)};
+            return ResponseCode::BadRequest {
+                error_msg: format!("Player {} has not joined a game.", player_id),
+            };
         }
 
         // We're borrowing self mutably below, so let's grab this now
@@ -401,7 +409,9 @@ impl ServerState {
         let opt_room = self.get_room_mut(player_id);
 
         if opt_room.is_none() {
-            return ResponseCode::BadRequest{error_msg:  format!("Player \"{}\" should be in a room! None found.", player_id )};
+            return ResponseCode::BadRequest {
+                error_msg: format!("Player \"{}\" should be in a room! None found.", player_id),
+            };
         }
 
         let room = opt_room.unwrap();
@@ -419,11 +429,11 @@ impl ServerState {
             let room_details = RoomList {
                 room_name: gs.name.clone(),
                 player_count: gs.player_ids.len() as u8,
-                in_progress: gs.game_running
+                in_progress: gs.game_running,
             };
             rooms.push(room_details);
         });
-        ResponseCode::RoomList{rooms}
+        ResponseCode::RoomList { rooms }
     }
 
     /// Creates a new room. Does _not_ check whether it already exists!
@@ -436,17 +446,23 @@ impl ServerState {
         id
     }
 
-    pub fn create_new_room(&mut self, opt_player_id: Option<PlayerID>, room_name: String) -> ResponseCode {
+    pub fn create_new_room(
+        &mut self,
+        opt_player_id: Option<PlayerID>,
+        room_name: String,
+    ) -> ResponseCode {
         // validate length
         if room_name.len() > MAX_ROOM_NAME {
-            return ResponseCode::BadRequest{
-                error_msg: format!("room name too long; max {} characters", MAX_ROOM_NAME)
+            return ResponseCode::BadRequest {
+                error_msg: format!("room name too long; max {} characters", MAX_ROOM_NAME),
             };
         }
 
         if let Some(player_id) = opt_player_id {
             if self.is_player_in_game(player_id) {
-                return ResponseCode::BadRequest{error_msg: "cannot create room because in-game".to_owned()};
+                return ResponseCode::BadRequest {
+                    error_msg: "cannot create room because in-game".to_owned(),
+                };
             }
         }
 
@@ -456,14 +472,18 @@ impl ServerState {
 
             return ResponseCode::OK;
         } else {
-            return ResponseCode::BadRequest{error_msg: format!("room name already in use")};
+            return ResponseCode::BadRequest {
+                error_msg: format!("room name already in use"),
+            };
         }
     }
 
     pub fn join_room(&mut self, player_id: PlayerID, room_name: &str) -> ResponseCode {
         let already_playing = self.is_player_in_game(player_id);
         if already_playing {
-            return ResponseCode::BadRequest{error_msg: "cannot join game because in-game".to_owned()};
+            return ResponseCode::BadRequest {
+                error_msg: "cannot join game because in-game".to_owned(),
+            };
         }
 
         let player: &mut Player = self.players.get_mut(&player_id).unwrap();
@@ -474,23 +494,29 @@ impl ServerState {
                 gs.player_ids.push(player_id);
                 player.game_info = Some(PlayerInGameInfo {
                     room_id: gs.room_id.clone(),
-                    chat_msg_seq_num: None
+                    chat_msg_seq_num: None,
                 });
-                return ResponseCode::JoinedRoom{room_name: room_name.to_owned()};
+                return ResponseCode::JoinedRoom {
+                    room_name: room_name.to_owned(),
+                };
             }
         }
-        ResponseCode::BadRequest{error_msg: format!("no room named {:?}", room_name)}
+        ResponseCode::BadRequest {
+            error_msg: format!("no room named {:?}", room_name),
+        }
     }
 
     pub fn leave_room(&mut self, player_id: PlayerID) -> ResponseCode {
         let already_playing = self.is_player_in_game(player_id);
         if !already_playing {
-            return ResponseCode::BadRequest{error_msg: "cannot leave game because in lobby".to_owned()};
+            return ResponseCode::BadRequest {
+                error_msg: "cannot leave game because in lobby".to_owned(),
+            };
         }
 
         let player: &mut Player = self.players.get_mut(&player_id).unwrap();
         {
-            let room_id = &player.game_info.as_ref().unwrap().room_id;  // unwrap ok because of test above
+            let room_id = &player.game_info.as_ref().unwrap().room_id; // unwrap ok because of test above
             for ref mut gs in self.rooms.values_mut() {
                 if gs.room_id == *room_id {
                     // remove player_id from room's player_ids
@@ -510,7 +536,7 @@ impl ServerState {
             let broadcast_msg = format!("Player {} has left.", player.name);
             let room: &mut Room = self.get_room_mut(player_id).unwrap(); // safe because in game check verifies room's existence
             room.broadcast(broadcast_msg);
-            let _left = self.leave_room(player_id);     // Ignore return since we don't care
+            let _left = self.leave_room(player_id); // Ignore return since we don't care
         }
         self.player_map.remove(player_cookie);
         self.players.remove(&player_id);
@@ -525,38 +551,48 @@ impl ServerState {
     }
 
     // not used for connect
-    pub fn process_request_action(&mut self, player_id: PlayerID, action: RequestAction) -> ResponseCode {
+    pub fn process_request_action(
+        &mut self,
+        player_id: PlayerID,
+        action: RequestAction,
+    ) -> ResponseCode {
         match action {
             RequestAction::Disconnect => {
                 return self.handle_disconnect(player_id);
-            },
-            RequestAction:: KeepAlive{latest_response_ack: _} => {
+            }
+            RequestAction::KeepAlive {
+                latest_response_ack: _,
+            } => {
                 return ResponseCode::OK;
-            },
+            }
             RequestAction::ListPlayers => {
                 return self.list_players(player_id);
-            },
-            RequestAction::ChatMessage{message} => {
+            }
+            RequestAction::ChatMessage { message } => {
                 return self.handle_chat_message(player_id, message);
-            },
+            }
             RequestAction::ListRooms => {
                 return self.list_rooms();
             }
-            RequestAction::NewRoom{room_name}  => {
+            RequestAction::NewRoom { room_name } => {
                 return self.create_new_room(Some(player_id), room_name);
             }
-            RequestAction::JoinRoom{room_name} => {
+            RequestAction::JoinRoom { room_name } => {
                 return self.join_room(player_id, &room_name);
             }
-            RequestAction::LeaveRoom   => {
+            RequestAction::LeaveRoom => {
                 return self.leave_room(player_id);
             }
-            RequestAction::Connect{..}     => {
-                return ResponseCode::BadRequest{error_msg: "Already connected".to_owned()};
-            },
+            RequestAction::Connect { .. } => {
+                return ResponseCode::BadRequest {
+                    error_msg: "Already connected".to_owned(),
+                };
+            }
             RequestAction::None => {
-                return ResponseCode::BadRequest{error_msg: "Invalid request".to_owned()};
-            },
+                return ResponseCode::BadRequest {
+                    error_msg: "Invalid request".to_owned(),
+                };
+            }
         }
     }
 
@@ -590,7 +626,7 @@ impl ServerState {
     pub fn get_player_id_by_cookie(&self, cookie: &str) -> Option<PlayerID> {
         match self.player_map.get(cookie) {
             Some(player_id) => Some(*player_id),
-            None => None
+            None => None,
         }
     }
 
@@ -608,7 +644,7 @@ impl ServerState {
         let player: &mut Player = self.get_player_mut(player_id);
         if let Some(ack) = player.request_ack {
             trace!("[CAN PROCESS?] Ack: {} Sqn: {}", ack, sequence_number);
-            ack+1 == sequence_number
+            ack + 1 == sequence_number
         } else {
             // request_ack has not been set yet, likely first packet
             player.request_ack = Some(0);
@@ -618,17 +654,22 @@ impl ServerState {
 
     /// Processes a player's request action for all non Connect requests. If necessary, a response is buffered
     /// for later transmission
-    pub fn process_player_request_action(&mut self, player_id: PlayerID, action: RequestAction)
-        -> Result<Option<Packet>, Box<dyn Error>>
-    {
+    pub fn process_player_request_action(
+        &mut self,
+        player_id: PlayerID,
+        action: RequestAction,
+    ) -> Result<Option<Packet>, Box<dyn Error>> {
         match action {
-            RequestAction::Connect{..} => unreachable!(),
+            RequestAction::Connect { .. } => unreachable!(),
             _ => {
                 if let Some(response) = self.prepare_response(player_id, action.clone()) {
                     // Buffer all responses to the client for [re-]transmission
                     let network: Option<&mut NetworkManager> = self.network_map.get_mut(&player_id);
                     if let Some(player_net) = network {
-                        trace!("[A Response to Client Request added to TX Buffer]{:?}", response);
+                        trace!(
+                            "[A Response to Client Request added to TX Buffer]{:?}",
+                            response
+                        );
                         player_net.tx_packets.buffer_item(response.clone());
                     }
                     Ok(Some(response))
@@ -661,15 +702,20 @@ impl ServerState {
         {
             let network: Option<&mut NetworkManager> = self.network_map.get_mut(&player_id);
             if let Some(player_net) = network {
-                rx_queue_count = player_net.rx_packets.get_contiguous_packets_count(latest_processed_seq_num+1);
+                rx_queue_count = player_net
+                    .rx_packets
+                    .get_contiguous_packets_count(latest_processed_seq_num + 1);
                 // ameen: can I use take().filter().collect()?
                 while dequeue_count < rx_queue_count {
-                    let packet = player_net.rx_packets.as_queue_type_mut().pop_front().unwrap();
+                    let packet = player_net
+                        .rx_packets
+                        .as_queue_type_mut()
+                        .pop_front()
+                        .unwrap();
 
                     // It is possible that a previously buffered packet (due to out-of-order) was resent by the client,
                     // and processed immediately upon receipt. We need to skip these.
-                    if packet.sequence_number() > latest_processed_seq_num
-                    {
+                    if packet.sequence_number() > latest_processed_seq_num {
                         processable_packets.push(packet);
                     }
 
@@ -681,12 +727,19 @@ impl ServerState {
         for packet in processable_packets {
             trace!("[Processing Client Request from RX Buffer]: {:?}", packet);
             match packet {
-                Packet::Request{sequence, response_ack: _, cookie: _, action} => {
+                Packet::Request {
+                    sequence,
+                    response_ack: _,
+                    cookie: _,
+                    action,
+                } => {
                     latest_processed_seq_num += 1;
                     assert!(sequence == latest_processed_seq_num);
                     let _response_packet = self.process_player_request_action(player_id, action);
                 }
-                _ => panic!("Development bug: Non-response packet found in client buffered RX queue")
+                _ => {
+                    panic!("Development bug: Non-response packet found in client buffered RX queue")
+                }
             }
         }
     }
@@ -697,7 +750,7 @@ impl ServerState {
         }
     }
 
-    pub fn process_buffered_packets_in_lobby(&mut self){
+    pub fn process_buffered_packets_in_lobby(&mut self) {
         let mut players_to_update: Vec<PlayerID> = vec![];
 
         if self.players.len() == 0 {
@@ -717,7 +770,10 @@ impl ServerState {
         }
     }
 
-    pub fn resend_expired_tx_packets(&mut self, udp_tx: &mpsc::UnboundedSender<(SocketAddr, Packet)>) {
+    pub fn resend_expired_tx_packets(
+        &mut self,
+        udp_tx: &mpsc::UnboundedSender<(SocketAddr, Packet)>,
+    ) {
         let mut players_to_update: Vec<PlayerID> = vec![];
 
         if self.players.len() == 0 {
@@ -734,16 +790,20 @@ impl ServerState {
                 let player_addr: SocketAddr = self.get_player_mut(player_id).addr;
                 let ack = self.get_player_mut(player_id).request_ack;
 
-                let player_network: Option<&mut NetworkManager> = self.network_map.get_mut(&player_id);
+                let player_network: Option<&mut NetworkManager> =
+                    self.network_map.get_mut(&player_id);
                 if let Some(player_net) = player_network {
                     if player_net.tx_packets.len() == 0 {
                         continue;
                     }
 
                     let indices = player_net.tx_packets.get_retransmit_indices();
-                    trace!("[Sending expired responses to client from TX Buffer]: {:?} Len: {}", player_id, indices.len());
+                    trace!(
+                        "[Sending expired responses to client from TX Buffer]: {:?} Len: {}",
+                        player_id,
+                        indices.len()
+                    );
                     player_net.retransmit_expired_tx_packets(udp_tx, player_addr, ack, &indices);
-
                 } else {
                     error!("I haven't found a NetworkManager for Player: {}", player_id);
                     continue;
@@ -766,10 +826,14 @@ impl ServerState {
 
             for &player_id in &room.player_ids {
                 let opt_player: Option<&Player> = self.players.get(&player_id);
-                if opt_player.is_none() { continue; }
+                if opt_player.is_none() {
+                    continue;
+                }
 
                 let player: &Player = opt_player.unwrap();
-                if player.game_info.is_none() { continue; }
+                if player.game_info.is_none() {
+                    continue;
+                }
 
                 players_to_update.push(player_id);
             }
@@ -781,19 +845,22 @@ impl ServerState {
     }
 
     /// Clear out the transmission queue of any packets the client has acknowledged
-    pub fn clear_transmission_queue_on_ack(&mut self, player_id: PlayerID, response_ack: Option<u64>) {
+    pub fn clear_transmission_queue_on_ack(
+        &mut self,
+        player_id: PlayerID,
+        response_ack: Option<u64>,
+    ) {
         if let Some(response_ack) = response_ack {
             if let Some(ref mut player_network) = self.network_map.get_mut(&player_id) {
                 let mut removal_count = 0;
                 for resp_pkt in player_network.tx_packets.as_queue_type_mut().iter() {
-                    if response_ack > 0 && (resp_pkt.sequence_number() <= response_ack-1)
-                    {
+                    if response_ack > 0 && (resp_pkt.sequence_number() <= response_ack - 1) {
                         removal_count += 1;
                     } else {
                         break;
                     }
                     // else {
-                        // TODO handle wrapped case & unit tests
+                    // TODO handle wrapped case & unit tests
                     // }
                 }
 
@@ -812,58 +879,95 @@ impl ServerState {
     ///  3. Client should notified if version requires updating
     ///  4. Ignore if already received or processed
     /// Always returns either Ok(Some(Packet::Response{...})), Ok(None), or error.
-    pub fn decode_packet(&mut self, addr: SocketAddr, packet: Packet)
-        -> Result<Option<Packet>, Box<dyn Error>>
-    {
+    pub fn decode_packet(
+        &mut self,
+        addr: SocketAddr,
+        packet: Packet,
+    ) -> Result<Option<Packet>, Box<dyn Error>> {
         match packet.clone() {
-            _pkt @ Packet::Response{..} | _pkt @ Packet::Update{..} => {
-                return Err(Box::new(io::Error::new(ErrorKind::InvalidData, "invalid packet type")));
+            _pkt @ Packet::Response { .. } | _pkt @ Packet::Update { .. } => {
+                return Err(Box::new(io::Error::new(
+                    ErrorKind::InvalidData,
+                    "invalid packet type",
+                )));
             }
-            Packet::Request{sequence, response_ack, cookie, action} => {
-
+            Packet::Request {
+                sequence,
+                response_ack,
+                cookie,
+                action,
+            } => {
                 match action {
-                    RequestAction::Connect{..} => (),
-                    RequestAction::KeepAlive{latest_response_ack: _} => (),
+                    RequestAction::Connect { .. } => (),
+                    RequestAction::KeepAlive {
+                        latest_response_ack: _,
+                    } => (),
                     _ => {
                         if cookie == None {
-                            return Err(Box::new(io::Error::new(ErrorKind::InvalidData, "no cookie")));
+                            return Err(Box::new(io::Error::new(
+                                ErrorKind::InvalidData,
+                                "no cookie",
+                            )));
                         } else {
-                            trace!("[Request] cookie: {:?} sequence: {} resp_ack: {:?} event: {:?}", cookie, sequence,
-                                                                                                 response_ack, action);
+                            trace!(
+                                "[Request] cookie: {:?} sequence: {} resp_ack: {:?} event: {:?}",
+                                cookie,
+                                sequence,
+                                response_ack,
+                                action
+                            );
                         }
                     }
                 }
                 // handle connect (create user, and save cookie)
-                if let RequestAction::Connect{name, client_version} = action {
+                if let RequestAction::Connect {
+                    name,
+                    client_version,
+                } = action
+                {
                     if validate_client_version(client_version) {
                         let response = self.handle_new_connection(name, addr);
                         return Ok(Some(response));
                     } else {
-                        return Err(Box::new(io::Error::new(ErrorKind::Other, "client out of date -- please upgrade")));
+                        return Err(Box::new(io::Error::new(
+                            ErrorKind::Other,
+                            "client out of date -- please upgrade",
+                        )));
                     };
                 } else {
                     // look up player by cookie
                     let cookie = match cookie {
                         Some(cookie) => cookie,
                         None => {
-                            return Err(Box::new(io::Error::new(ErrorKind::InvalidData, "cookie required for non-connect actions")));
+                            return Err(Box::new(io::Error::new(
+                                ErrorKind::InvalidData,
+                                "cookie required for non-connect actions",
+                            )));
                         }
                     };
                     let player_id = match self.get_player_id_by_cookie(cookie.as_str()) {
                         Some(player_id) => player_id,
                         None => {
-                            return Err(Box::new(io::Error::new(ErrorKind::PermissionDenied, "invalid cookie")));
+                            return Err(Box::new(io::Error::new(
+                                ErrorKind::PermissionDenied,
+                                "invalid cookie",
+                            )));
                         }
                     };
 
                     let mut player: &mut Player = self.get_player_mut(player_id);
-                    player.last_received = time::Instant::now();   // reset time of last received packet from player
+                    player.last_received = time::Instant::now(); // reset time of last received packet from player
                     match action.clone() {
-                        RequestAction::KeepAlive{latest_response_ack} => {
+                        RequestAction::KeepAlive {
+                            latest_response_ack,
+                        } => {
                             // If the client does not send new requests, the Server will never get a reply for
                             // the set of responses it may have sent. This will result in the transmission queue contents
                             // flooding the Client on retranmission.
-                            self.clear_transmission_queue_on_ack(player_id, Some(latest_response_ack));
+                            self.clear_transmission_queue_on_ack(
+                                player_id,
+                                Some(latest_response_ack),
+                            );
                             return Ok(None);
                         }
                         _ => (),
@@ -896,18 +1000,29 @@ impl ServerState {
                     Ok(None)
                 }
             }
-            Packet::UpdateReply{cookie, last_chat_seq, last_game_update_seq: _, last_gen: _} => {
+            Packet::UpdateReply {
+                cookie,
+                last_chat_seq,
+                last_game_update_seq: _,
+                last_gen: _,
+            } => {
                 let opt_player_id = self.get_player_id_by_cookie(cookie.as_str());
 
                 if opt_player_id.is_none() {
-                    return Err(Box::new(io::Error::new(ErrorKind::PermissionDenied, "invalid cookie")));
+                    return Err(Box::new(io::Error::new(
+                        ErrorKind::PermissionDenied,
+                        "invalid cookie",
+                    )));
                 }
 
                 let player_id = opt_player_id.unwrap();
                 let opt_player = self.players.get_mut(&player_id);
 
                 if opt_player.is_none() {
-                    return Err(Box::new(io::Error::new(ErrorKind::NotFound, "player not found")));
+                    return Err(Box::new(io::Error::new(
+                        ErrorKind::NotFound,
+                        "player not found",
+                    )));
                 }
 
                 let player: &mut Player = opt_player.unwrap();
@@ -917,18 +1032,23 @@ impl ServerState {
                 }
                 Ok(None)
             }
-
         }
     }
 
-    pub fn prepare_response(&mut self, player_id: PlayerID, action: RequestAction) -> Option<Packet> {
+    pub fn prepare_response(
+        &mut self,
+        player_id: PlayerID,
+        action: RequestAction,
+    ) -> Option<Packet> {
         let response_code = self.process_request_action(player_id, action.clone());
 
         let (sequence, request_ack);
 
         match action {
             // Filtered away at the decoding packet layer
-            RequestAction::KeepAlive{latest_response_ack: _} => unreachable!(),
+            RequestAction::KeepAlive {
+                latest_response_ack: _,
+            } => unreachable!(),
             // Prepare a response for all other requests
             _ => {
                 let opt_player: Option<&mut Player> = self.players.get_mut(&player_id);
@@ -937,7 +1057,7 @@ impl ServerState {
                     Some(player) => {
                         sequence = player.increment_response_seq_num();
                         if let Some(ack) = player.request_ack {
-                            player.request_ack = Some(ack+1);
+                            player.request_ack = Some(ack + 1);
                             request_ack = player.request_ack;
                         } else {
                             panic!("Player's request ack has never been set. It should have been set after the first packet!");
@@ -952,10 +1072,10 @@ impl ServerState {
             }
         }
 
-        Some(Packet::Response{
-            sequence:    sequence,
+        Some(Packet::Response {
+            sequence: sequence,
             request_ack: request_ack,
-            code:        response_code,
+            code: response_code,
         })
     }
 
@@ -965,18 +1085,23 @@ impl ServerState {
             let cookie = player.cookie.clone();
 
             // Sequence is assumed to start at 0 for all new connections
-            let response = Packet::Response{
-                sequence:    0,
+            let response = Packet::Response {
+                sequence: 0,
                 request_ack: Some(0), // Should start at seq_num 0 unless client's network state was not properly reset
-                code:        ResponseCode::LoggedIn{cookie, server_version: VERSION.to_owned()},
+                code: ResponseCode::LoggedIn {
+                    cookie,
+                    server_version: VERSION.to_owned(),
+                },
             };
             return response;
         } else {
             // not a unique name
-            let response = Packet::Response{
-                sequence:    0,
+            let response = Packet::Response {
+                sequence: 0,
                 request_ack: None,
-                code:        ResponseCode::Unauthorized{error_msg: "not a unique name".to_owned()},
+                code: ResponseCode::Unauthorized {
+                    error_msg: "not a unique name".to_owned(),
+                },
             };
             return response;
         }
@@ -993,19 +1118,22 @@ impl ServerState {
         // For each room, determine if each player has unread messages based on chat_msg_seq_num
         // TODO: POOR PERFORMANCE BOUNTY
         for room in self.rooms.values() {
-
             if room.messages.is_empty() || room.player_ids.len() == 0 {
                 continue;
             }
 
             for &player_id in &room.player_ids {
                 let opt_player = self.players.get(&player_id);
-                if opt_player.is_none() { continue; }
+                if opt_player.is_none() {
+                    continue;
+                }
 
                 let player: &Player = opt_player.unwrap();
-                if player.game_info.is_none() { continue; }
+                if player.game_info.is_none() {
+                    continue;
+                }
 
-                let mut unsent_messages  = vec![];
+                let mut unsent_messages = vec![];
                 if let Some(new_messages) = self.collect_unacknowledged_messages(&room, player) {
                     unsent_messages = new_messages.to_vec();
                 }
@@ -1016,13 +1144,13 @@ impl ServerState {
                 let universe_updates_available = false;
 
                 let update_packet = Packet::Update {
-                    chats:           unsent_messages,
-                    game_updates:    vec![],
+                    chats: unsent_messages,
+                    game_updates: vec![],
                     universe_update: UniUpdateType::NoChange,
                 };
 
                 if messages_available || game_updates_available || universe_updates_available {
-                    client_updates.push( (player.addr.clone(), update_packet) );
+                    client_updates.push((player.addr.clone(), update_packet));
                 }
             }
         }
@@ -1036,7 +1164,11 @@ impl ServerState {
 
     /// Creates a vector of messages that the provided Player has not yet acknowledged.
     /// Exits early if the player is already caught up.
-    pub fn collect_unacknowledged_messages(&self, room: &Room, player: &Player) -> Option<Vec<BroadcastChatMessage>> {
+    pub fn collect_unacknowledged_messages(
+        &self,
+        room: &Room,
+        player: &Player,
+    ) -> Option<Vec<BroadcastChatMessage>> {
         // Only send what a player has not yet seen
         let raw_unsent_messages: VecDeque<ServerChatMessage>;
         match player.get_confirmed_chat_seq_num() {
@@ -1052,13 +1184,21 @@ impl ServerState {
                     // Player is caught up
                     return None;
                 } else if chat_msg_seq_num > newest_msg.seq_num {
-                    error!("Misbehaving client {:?};\nClient says it has more messages than we sent!", player);
+                    error!(
+                        "Misbehaving client {:?};\nClient says it has more messages than we sent!",
+                        player
+                    );
                     return None;
                 } else {
                     let amount_to_consume = room.get_message_skip_count(chat_msg_seq_num);
 
                     // Cast to usize is safe because our message containers are limited by MAX_NUM_CHAT_MESSAGES
-                    raw_unsent_messages = room.messages.iter().skip(amount_to_consume as usize).cloned().collect();
+                    raw_unsent_messages = room
+                        .messages
+                        .iter()
+                        .skip(amount_to_consume as usize)
+                        .cloned()
+                        .collect();
                 }
             }
             None => {
@@ -1071,9 +1211,12 @@ impl ServerState {
             return None;
         }
 
-        let unsent_messages: Vec<BroadcastChatMessage> = raw_unsent_messages.iter().map(|msg| {
-            BroadcastChatMessage::new(msg.seq_num, msg.player_name.clone(), msg.message.clone())
-        }).collect();
+        let unsent_messages: Vec<BroadcastChatMessage> = raw_unsent_messages
+            .iter()
+            .map(|msg| {
+                BroadcastChatMessage::new(msg.seq_num, msg.player_name.clone(), msg.message.clone())
+            })
+            .collect();
 
         return Some(unsent_messages);
     }
@@ -1082,7 +1225,10 @@ impl ServerState {
         if self.rooms.len() != 0 {
             for room in self.rooms.values_mut() {
                 if room.has_players() && !room.messages.is_empty() {
-                    room.messages.retain(|ref m| current_timestamp - m.timestamp < Duration::from_secs(MAX_AGE_CHAT_MESSAGES as u64) );
+                    room.messages.retain(|ref m| {
+                        current_timestamp - m.timestamp
+                            < Duration::from_secs(MAX_AGE_CHAT_MESSAGES as u64)
+                    });
                 }
             }
         }
@@ -1092,13 +1238,13 @@ impl ServerState {
         let cookie = new_cookie();
         let player_id = PlayerID(new_uuid());
         let player = Player {
-            player_id:     player_id.clone(),
-            cookie:        cookie.clone(),
-            addr:          addr,
-            name:          name,
-            request_ack:   None,
+            player_id: player_id.clone(),
+            cookie: cookie.clone(),
+            addr: addr,
+            name: name,
+            request_ack: None,
             next_resp_seq: 0,
-            game_info:     None,
+            game_info: None,
             last_received: Instant::now(),
         };
 
@@ -1127,25 +1273,23 @@ impl ServerState {
         for player_id in timed_out_players {
             self.handle_disconnect(player_id);
         }
-
     }
 
     /// Creates a new struct representing the global state of this server. Initially, there is one
     /// room -- "general".
     pub fn new() -> Self {
         let mut server_state = ServerState {
-            tick:       0,
-            players:    HashMap::<PlayerID, Player>::new(),
-            rooms:      HashMap::<RoomID, Room>::new(),
+            tick: 0,
+            players: HashMap::<PlayerID, Player>::new(),
+            rooms: HashMap::<RoomID, Room>::new(),
             player_map: HashMap::<String, PlayerID>::new(),
-            room_map:   HashMap::<String, RoomID>::new(),
+            room_map: HashMap::<String, RoomID>::new(),
             network_map: HashMap::<PlayerID, NetworkManager>::new(),
         };
         server_state.new_room("general".to_owned());
         server_state
     }
 }
-
 
 //////////////// Event Handling /////////////////
 #[allow(unused)]
@@ -1154,37 +1298,48 @@ enum Event {
     Request((SocketAddr, Option<Packet>)),
     NetworkTickEvent,
     HeartBeat,
-//    Notify((SocketAddr, Option<Packet>)),
+    //    Notify((SocketAddr, Option<Packet>)),
 }
 
 pub fn main() {
     env_logger::Builder::new()
-    .format(|buf, record| {
-        writeln!(buf,
-            "{} [{:5}] - {}",
-            Local::now().format("%a %Y-%m-%d %H:%M:%S%.6f"),
-            record.level(),
-            record.args(),
-        )
-    })
-    .filter(None, LevelFilter::Trace)
-    .filter(Some("futures"), LevelFilter::Off)
-    .filter(Some("tokio_core"), LevelFilter::Off)
-    .filter(Some("tokio_reactor"), LevelFilter::Off)
-    .init();
+        .format(|buf, record| {
+            writeln!(
+                buf,
+                "{} [{:5}] - {}",
+                Local::now().format("%a %Y-%m-%d %H:%M:%S%.6f"),
+                record.level(),
+                record.args(),
+            )
+        })
+        .filter(None, LevelFilter::Trace)
+        .filter(Some("futures"), LevelFilter::Off)
+        .filter(Some("tokio_core"), LevelFilter::Off)
+        .filter(Some("tokio_reactor"), LevelFilter::Off)
+        .init();
 
     let matches = App::new("server")
         .about("game server for Conwayste")
-        .arg(Arg::with_name("address")
-             .short("l")
-             .long("listen")
-             .help(&format!("address to listen for connections on [default {}]", DEFAULT_HOST))
-             .takes_value(true))
-        .arg(Arg::with_name("port")
-             .short("p")
-             .long("port")
-             .help(&format!("port to listen for connections on [default {}]", DEFAULT_PORT))
-             .takes_value(true))
+        .arg(
+            Arg::with_name("address")
+                .short("l")
+                .long("listen")
+                .help(&format!(
+                    "address to listen for connections on [default {}]",
+                    DEFAULT_HOST
+                ))
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("port")
+                .short("p")
+                .long("port")
+                .help(&format!(
+                    "port to listen for connections on [default {}]",
+                    DEFAULT_PORT
+                ))
+                .takes_value(true),
+        )
         .get_matches();
 
     let mut core = Core::new().unwrap();
@@ -1194,132 +1349,150 @@ pub fn main() {
 
     let opt_port = matches.value_of("port").map(|p_str| {
         p_str.parse::<u16>().unwrap_or_else(|e| {
-            error!("Error while attempting to parse {:?} as port number: {:?}", p_str, e);
+            error!(
+                "Error while attempting to parse {:?} as port number: {:?}",
+                p_str, e
+            );
             exit(1);
         })
     });
-    let udp = bind(&handle,
-                        matches.value_of("address"),
-                        opt_port)
-        .unwrap_or_else(|e| {
-            error!("Error while trying to bind UDP socket: {:?}", e);
-            exit(1);
-        });
+    let udp = bind(&handle, matches.value_of("address"), opt_port).unwrap_or_else(|e| {
+        error!("Error while trying to bind UDP socket: {:?}", e);
+        exit(1);
+    });
 
-    trace!("Listening for connections on {:?}...", udp.local_addr().unwrap());
+    trace!(
+        "Listening for connections on {:?}...",
+        udp.local_addr().unwrap()
+    );
 
     let (udp_sink, udp_stream) = udp.framed(LineCodec).split();
 
     let initial_server_state = ServerState::new();
 
-    let iter_stream = stream::iter_ok::<_, io::Error>(iter::repeat( () ));
-    let tick_stream = iter_stream.and_then(|_| {
-        let timeout = Timeout::new(Duration::from_millis(TICK_INTERVAL_IN_MS), &handle).unwrap();
-        timeout.and_then(move |_| {
-            ok(Event::TickEvent)
-        })
-    }).map_err(|_| ());
-
-    let packet_stream = udp_stream
-        .filter(|&(_, ref opt_packet)| {
-            *opt_packet != None
-        })
-        .map(|packet_tuple| {
-            Event::Request(packet_tuple)
+    let iter_stream = stream::iter_ok::<_, io::Error>(iter::repeat(()));
+    let tick_stream = iter_stream
+        .and_then(|_| {
+            let timeout =
+                Timeout::new(Duration::from_millis(TICK_INTERVAL_IN_MS), &handle).unwrap();
+            timeout.and_then(move |_| ok(Event::TickEvent))
         })
         .map_err(|_| ());
 
-    let network_tick_stream = stream::iter_ok::<_, io::Error>(iter::repeat( () ));
-    let network_tick_stream = network_tick_stream.and_then(|_| {
-        let timeout = Timeout::new(Duration::from_millis(NETWORK_INTERVAL_IN_MS), &handle).unwrap();
-        timeout.and_then(move |_| {
-            ok(Event::NetworkTickEvent)
-        })
-    }).map_err(|_| ());
+    let packet_stream = udp_stream
+        .filter(|&(_, ref opt_packet)| *opt_packet != None)
+        .map(|packet_tuple| Event::Request(packet_tuple))
+        .map_err(|_| ());
 
-    let heartbeat_stream = stream::iter_ok::<_, io::Error>(iter::repeat( () ));
-    let heartbeat_stream = heartbeat_stream.and_then(|_| {
-        let timeout = Timeout::new(Duration::from_millis(HEARTBEAT_INTERVAL_IN_MS), &handle).unwrap();
-        timeout.and_then(move |_| {
-            ok(Event::HeartBeat)
+    let network_tick_stream = stream::iter_ok::<_, io::Error>(iter::repeat(()));
+    let network_tick_stream = network_tick_stream
+        .and_then(|_| {
+            let timeout =
+                Timeout::new(Duration::from_millis(NETWORK_INTERVAL_IN_MS), &handle).unwrap();
+            timeout.and_then(move |_| ok(Event::NetworkTickEvent))
         })
-    }).map_err(|_| ());
+        .map_err(|_| ());
+
+    let heartbeat_stream = stream::iter_ok::<_, io::Error>(iter::repeat(()));
+    let heartbeat_stream = heartbeat_stream
+        .and_then(|_| {
+            let timeout =
+                Timeout::new(Duration::from_millis(HEARTBEAT_INTERVAL_IN_MS), &handle).unwrap();
+            timeout.and_then(move |_| ok(Event::HeartBeat))
+        })
+        .map_err(|_| ());
 
     let server_fut = tick_stream
         .select(packet_stream)
         .select(network_tick_stream)
         .select(heartbeat_stream)
-        .fold(initial_server_state, move |mut server_state: ServerState, event: Event | {
-            match event {
-                Event::Request(packet_tuple) => {
-                     // With the above filter, `packet` should never be None
-                    let (addr, opt_packet) = packet_tuple;
+        .fold(
+            initial_server_state,
+            move |mut server_state: ServerState, event: Event| {
+                match event {
+                    Event::Request(packet_tuple) => {
+                        // With the above filter, `packet` should never be None
+                        let (addr, opt_packet) = packet_tuple;
 
-                    // Decode incoming and send a Response to the Requester
-                    if let Some(packet) = opt_packet {
-                        let decode_result = server_state.decode_packet(addr, packet.clone());
-                        if decode_result.is_ok() {
-                            let opt_response_packet = decode_result.unwrap();
+                        // Decode incoming and send a Response to the Requester
+                        if let Some(packet) = opt_packet {
+                            let decode_result = server_state.decode_packet(addr, packet.clone());
+                            if decode_result.is_ok() {
+                                let opt_response_packet = decode_result.unwrap();
 
-                            if let Some(response_packet) = opt_response_packet {
-                                let response = (addr.clone(), response_packet);
-                                netwayste_send!(tx, response, ("[EVENT::REQUEST] Immediate response failed."));
+                                if let Some(response_packet) = opt_response_packet {
+                                    let response = (addr.clone(), response_packet);
+                                    netwayste_send!(
+                                        tx,
+                                        response,
+                                        ("[EVENT::REQUEST] Immediate response failed.")
+                                    );
+                                }
+                            } else {
+                                let err = decode_result.unwrap_err();
+                                error!("Decoding packet failed, from {:?}: {:?}", addr, err);
                             }
-                        } else {
-                            let err = decode_result.unwrap_err();
-                            error!("Decoding packet failed, from {:?}: {:?}", addr, err);
+                        }
+                    }
+
+                    Event::TickEvent => {
+                        server_state.expire_old_messages_in_all_rooms(time::Instant::now());
+                        if let Some(update_packets) = server_state.construct_client_updates() {
+                            for update in update_packets {
+                                netwayste_send!(
+                                    tx,
+                                    update,
+                                    ("[EVENT::TICK] Could not send client update.")
+                                );
+                            }
+                        }
+
+                        server_state.remove_timed_out_clients();
+                        server_state.tick = 1usize.wrapping_add(server_state.tick);
+                    }
+
+                    Event::NetworkTickEvent => {
+                        // Process players in rooms
+                        server_state.process_buffered_packets_in_rooms();
+
+                        // Process players in lobby
+                        server_state.process_buffered_packets_in_lobby();
+
+                        server_state.resend_expired_tx_packets(&tx);
+                    }
+
+                    Event::HeartBeat => {
+                        for player in server_state.players.values() {
+                            let keep_alive = Packet::Response {
+                                sequence: 0,
+                                request_ack: None,
+                                code: ResponseCode::KeepAlive,
+                            };
+                            netwayste_send!(
+                                tx,
+                                (player.addr, keep_alive),
+                                ("[EVENT::HEARTBEAT] Could not send to Player: {:?}", player)
+                            );
                         }
                     }
                 }
 
-                Event::TickEvent => {
-                    server_state.expire_old_messages_in_all_rooms(time::Instant::now());
-                    if let Some(update_packets) =  server_state.construct_client_updates() {
-                        for update in update_packets {
-                            netwayste_send!(tx, update, ("[EVENT::TICK] Could not send client update."));
-                        }
-                    }
+                // return the updated client for the next iteration
+                ok(server_state)
+            },
+        )
+        .map(|_| ())
+        .map_err(|_| ());
 
-                    server_state.remove_timed_out_clients();
-                    server_state.tick  = 1usize.wrapping_add(server_state.tick);
-                }
-
-                Event::NetworkTickEvent => {
-                    // Process players in rooms
-                    server_state.process_buffered_packets_in_rooms();
-
-                    // Process players in lobby
-                    server_state.process_buffered_packets_in_lobby();
-
-                    server_state.resend_expired_tx_packets(&tx);
-                }
-
-                Event::HeartBeat => {
-                    for player in server_state.players.values() {
-                        let keep_alive = Packet::Response {
-                            sequence: 0,
-                            request_ack: None,
-                            code: ResponseCode::KeepAlive
-                        };
-                        netwayste_send!(tx, (player.addr, keep_alive), ("[EVENT::HEARTBEAT] Could not send to Player: {:?}", player));
-                    }
-                }
-            }
-
-            // return the updated client for the next iteration
-            ok(server_state)
+    let sink_fut = rx
+        .fold(udp_sink, |udp_sink, outgoing_item| {
+            let udp_sink = udp_sink.send(outgoing_item).map_err(|_| ()); // this method flushes (if too slow, use send_all)
+            udp_sink
         })
         .map(|_| ())
         .map_err(|_| ());
 
-    let sink_fut = rx.fold(udp_sink, |udp_sink, outgoing_item| {
-            let udp_sink = udp_sink.send(outgoing_item).map_err(|_| ());    // this method flushes (if too slow, use send_all)
-            udp_sink
-        }).map(|_| ()).map_err(|_| ());
-
-    let combined_fut = server_fut.map(|_| ())
-        .select(sink_fut)
-        .map(|_| ());   // wait for either server_fut or sink_fut to complete
+    let combined_fut = server_fut.map(|_| ()).select(sink_fut).map(|_| ()); // wait for either server_fut or sink_fut to complete
 
     drop(core.run(combined_fut));
 }
@@ -1327,8 +1500,8 @@ pub fn main() {
 #[cfg(test)]
 mod netwayste_server_tests {
     use super::*;
-    use netwayste::net::NetAttempt;
     use ::proptest::strategy::*;
+    use netwayste::net::NetAttempt;
 
     fn fake_socket_addr() -> SocketAddr {
         use std::net::{IpAddr, Ipv4Addr};
@@ -1343,7 +1516,8 @@ mod netwayste_server_tests {
         server.create_new_room(None, String::from(room_name));
 
         let (player_id, player_name) = {
-            let p: &mut Player = server.add_new_player(String::from("some name"), fake_socket_addr());
+            let p: &mut Player =
+                server.add_new_player(String::from("some name"), fake_socket_addr());
 
             (p.player_id, p.name.clone())
         };
@@ -1353,11 +1527,11 @@ mod netwayste_server_tests {
         }
         let resp_code: ResponseCode = server.list_players(player_id);
         match resp_code {
-            ResponseCode::PlayerList{players} => {
+            ResponseCode::PlayerList { players } => {
                 assert_eq!(players.len(), 1);
                 assert_eq!(*players.first().unwrap(), player_name);
             }
-            resp_code @ _ => panic!("Unexpected response code: {:?}", resp_code)
+            resp_code @ _ => panic!("Unexpected response code: {:?}", resp_code),
         }
     }
 
@@ -1368,7 +1542,8 @@ mod netwayste_server_tests {
         // make a new room
         server.create_new_room(None, String::from(room_name));
         let player_id = {
-            let p: &mut Player = server.add_new_player(String::from("some name"), fake_socket_addr());
+            let p: &mut Player =
+                server.add_new_player(String::from("some name"), fake_socket_addr());
             p.player_id
         };
         // make the player join the room
@@ -1387,7 +1562,8 @@ mod netwayste_server_tests {
         server.create_new_room(None, String::from(room_name));
 
         let (player_id, player_cookie) = {
-            let p: &mut Player = server.add_new_player(String::from("some name"), fake_socket_addr());
+            let p: &mut Player =
+                server.add_new_player(String::from("some name"), fake_socket_addr());
 
             (p.player_id, p.cookie.clone())
         };
@@ -1397,12 +1573,17 @@ mod netwayste_server_tests {
         }
 
         // A chat-less player now has something to to say
-        server.decode_packet(fake_socket_addr(), Packet::UpdateReply {
-            cookie: player_cookie.clone(),
-            last_chat_seq: Some(1),
-            last_game_update_seq: None,
-            last_gen: None
-        }).unwrap();
+        server
+            .decode_packet(
+                fake_socket_addr(),
+                Packet::UpdateReply {
+                    cookie: player_cookie.clone(),
+                    last_chat_seq: Some(1),
+                    last_game_update_seq: None,
+                    last_gen: None,
+                },
+            )
+            .unwrap();
 
         {
             let player = server.get_player(player_id);
@@ -1410,12 +1591,17 @@ mod netwayste_server_tests {
         }
 
         // Older messages are ignored
-        server.decode_packet(fake_socket_addr(), Packet::UpdateReply {
-            cookie: player_cookie.clone(),
-            last_chat_seq: Some(0),
-            last_game_update_seq: None,
-            last_gen: None
-        }).unwrap();
+        server
+            .decode_packet(
+                fake_socket_addr(),
+                Packet::UpdateReply {
+                    cookie: player_cookie.clone(),
+                    last_chat_seq: Some(0),
+                    last_game_update_seq: None,
+                    last_gen: None,
+                },
+            )
+            .unwrap();
 
         {
             let player = server.get_player(player_id);
@@ -1423,12 +1609,17 @@ mod netwayste_server_tests {
         }
 
         // So are absent messages
-        server.decode_packet(fake_socket_addr(), Packet::UpdateReply {
-            cookie: player_cookie,
-            last_chat_seq: None,
-            last_game_update_seq: None,
-            last_gen: None
-        }).unwrap();
+        server
+            .decode_packet(
+                fake_socket_addr(),
+                Packet::UpdateReply {
+                    cookie: player_cookie,
+                    last_chat_seq: None,
+                    last_game_update_seq: None,
+                    last_gen: None,
+                },
+            )
+            .unwrap();
 
         {
             let player = server.get_player(player_id);
@@ -1444,7 +1635,8 @@ mod netwayste_server_tests {
         server.create_new_room(None, String::from(room_name));
 
         let (player_id, _) = {
-            let p: &mut Player = server.add_new_player(String::from("some name"), fake_socket_addr());
+            let p: &mut Player =
+                server.add_new_player(String::from("some name"), fake_socket_addr());
 
             (p.player_id, p.cookie.clone())
         };
@@ -1486,7 +1678,10 @@ mod netwayste_server_tests {
         };
         {
             let room: &Room = server.get_room(player_id).unwrap();
-            assert_eq!(room.get_message_skip_count(acked_message_count), acked_message_count);
+            assert_eq!(
+                room.get_message_skip_count(acked_message_count),
+                acked_message_count
+            );
         }
 
         // player acknowledged all six
@@ -1498,7 +1693,10 @@ mod netwayste_server_tests {
         };
         {
             let room: &Room = server.get_room(player_id).unwrap();
-            assert_eq!(room.get_message_skip_count(acked_message_count), acked_message_count);
+            assert_eq!(
+                room.get_message_skip_count(acked_message_count),
+                acked_message_count
+            );
         }
     }
 
@@ -1511,7 +1709,8 @@ mod netwayste_server_tests {
         server.create_new_room(None, String::from(room_name));
 
         let player_id = {
-            let p: &mut Player = server.add_new_player(String::from("some name"), fake_socket_addr());
+            let p: &mut Player =
+                server.add_new_player(String::from("some name"), fake_socket_addr());
 
             p.player_id
         };
@@ -1524,12 +1723,22 @@ mod netwayste_server_tests {
         // First pass, add messages with sequence numbers through the max of u64
         for seq_num in start_seq_num..u64::max_value() {
             let room: &mut Room = server.get_room_mut(player_id).unwrap();
-            room.add_message(ServerChatMessage::new(player_id, String::from("some name"), String::from("some msg"), seq_num));
+            room.add_message(ServerChatMessage::new(
+                player_id,
+                String::from("some name"),
+                String::from("some msg"),
+                seq_num,
+            ));
         }
         // Second pass, from wrap-point, `0`, eight times
         for seq_num in 0..8 {
             let room: &mut Room = server.get_room_mut(player_id).unwrap();
-            room.add_message(ServerChatMessage::new(player_id, String::from("some name"), String::from("some msg"), seq_num));
+            room.add_message(ServerChatMessage::new(
+                player_id,
+                String::from("some name"),
+                String::from("some msg"),
+                seq_num,
+            ));
         }
 
         let acked_message_count = {
@@ -1545,19 +1754,24 @@ mod netwayste_server_tests {
             // 2 unacked which are less than u64::max_value()
             // 8 unacked which are after the numerical wrap
             let unacked_count = 15 - (8 + 2);
-            assert_eq!(room.get_message_skip_count(acked_message_count), unacked_count);
+            assert_eq!(
+                room.get_message_skip_count(acked_message_count),
+                unacked_count
+            );
         }
     }
 
     #[test]
-    fn collect_unacknowledged_messages_a_rooms_unacknowledged_chat_messages_are_collected_for_their_player() {
+    fn collect_unacknowledged_messages_a_rooms_unacknowledged_chat_messages_are_collected_for_their_player(
+    ) {
         let mut server = ServerState::new();
         let room_name = "some name";
 
         server.create_new_room(None, String::from(room_name));
 
         let player_id = {
-            let p: &mut Player = server.add_new_player(String::from("some name"), fake_socket_addr());
+            let p: &mut Player =
+                server.add_new_player(String::from("some name"), fake_socket_addr());
 
             p.player_id
         };
@@ -1575,7 +1789,12 @@ mod netwayste_server_tests {
 
         {
             let room: &mut Room = server.get_room_mut(player_id).unwrap();
-            room.add_message(ServerChatMessage::new(player_id, String::from("some name"), String::from("some msg"), 1));
+            room.add_message(ServerChatMessage::new(
+                player_id,
+                String::from("some name"),
+                String::from("some msg"),
+                1,
+            ));
         }
         {
             // Room has a message, player has yet to ack it
@@ -1600,15 +1819,15 @@ mod netwayste_server_tests {
     }
 
     #[test]
-    fn collect_unacknowledged_messages_an_active_room_which_expired_all_messages_returns_none()
-    {
+    fn collect_unacknowledged_messages_an_active_room_which_expired_all_messages_returns_none() {
         let mut server = ServerState::new();
         let room_name = "some name";
 
         server.create_new_room(None, String::from(room_name));
 
         let player_id = {
-            let p: &mut Player = server.add_new_player(String::from("some name"), fake_socket_addr());
+            let p: &mut Player =
+                server.add_new_player(String::from("some name"), fake_socket_addr());
 
             p.player_id
         };
@@ -1619,10 +1838,16 @@ mod netwayste_server_tests {
         {
             // Add a message to the room and then age it so it will expire
             let room: &mut Room = server.get_room_mut(player_id).unwrap();
-            room.add_message(ServerChatMessage::new(player_id, String::from("some name"), String::from("some msg"), 1));
+            room.add_message(ServerChatMessage::new(
+                player_id,
+                String::from("some name"),
+                String::from("some msg"),
+                1,
+            ));
 
             let message: &mut ServerChatMessage = room.messages.get_mut(0).unwrap();
-            let travel_to_the_past = Instant::now().checked_sub(Duration::from_secs(MAX_AGE_CHAT_MESSAGES as u64));
+            let travel_to_the_past =
+                Instant::now().checked_sub(Duration::from_secs(MAX_AGE_CHAT_MESSAGES as u64));
             if travel_to_the_past.is_none() {
                 warn!("skipping rest of test; cannot travel to the past :(");
                 return;
@@ -1656,8 +1881,7 @@ mod netwayste_server_tests {
     }
 
     #[test]
-    fn handle_chat_message_player_not_in_game()
-    {
+    fn handle_chat_message_player_not_in_game() {
         let mut server = ServerState::new();
         let room_name = "some name";
 
@@ -1670,20 +1894,24 @@ mod netwayste_server_tests {
         };
 
         let response = server.handle_chat_message(player_id, "test msg".to_owned());
-        assert_eq!(response, ResponseCode::BadRequest{error_msg: format!("Player {} has not joined a game.", player_id)});
+        assert_eq!(
+            response,
+            ResponseCode::BadRequest {
+                error_msg: format!("Player {} has not joined a game.", player_id)
+            }
+        );
     }
 
     #[test]
-    fn handle_chat_message_player_in_game_one_message()
-    {
-
+    fn handle_chat_message_player_in_game_one_message() {
         let mut server = ServerState::new();
         let room_name = "some name";
 
         server.create_new_room(None, room_name.to_owned());
 
         let player_id = {
-            let p: &mut Player = server.add_new_player("some player".to_string(), fake_socket_addr());
+            let p: &mut Player =
+                server.add_new_player("some player".to_string(), fake_socket_addr());
 
             p.player_id
         };
@@ -1698,16 +1926,15 @@ mod netwayste_server_tests {
     }
 
     #[test]
-    fn handle_chat_message_player_in_game_many_messages()
-    {
-
+    fn handle_chat_message_player_in_game_many_messages() {
         let mut server = ServerState::new();
         let room_name = "some name";
 
         server.create_new_room(None, room_name.to_owned());
 
         let player_id = {
-            let p: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            let p: &mut Player =
+                server.add_new_player("some player".to_owned(), fake_socket_addr());
 
             p.player_id
         };
@@ -1724,8 +1951,7 @@ mod netwayste_server_tests {
     }
 
     #[test]
-    fn create_new_room_good_case()
-    {
+    fn create_new_room_good_case() {
         {
             let mut server = ServerState::new();
             let room_name = "some name".to_owned();
@@ -1742,137 +1968,192 @@ mod netwayste_server_tests {
     }
 
     #[test]
-    fn create_new_room_name_is_too_long()
-    {
+    fn create_new_room_name_is_too_long() {
         let mut server = ServerState::new();
         let room_name = "0123456789ABCDEF_#".to_owned();
 
-        assert_eq!(server.create_new_room(None, room_name), ResponseCode::BadRequest{error_msg: "room name too long; max 16 characters".to_owned()});
+        assert_eq!(
+            server.create_new_room(None, room_name),
+            ResponseCode::BadRequest {
+                error_msg: "room name too long; max 16 characters".to_owned()
+            }
+        );
     }
 
     #[test]
-    fn create_new_room_name_taken()
-    {
+    fn create_new_room_name_taken() {
         let mut server = ServerState::new();
         let room_name = "some room".to_owned();
-        assert_eq!(server.create_new_room(None, room_name.clone()), ResponseCode::OK);
-        assert_eq!(server.create_new_room(None, room_name), ResponseCode::BadRequest{error_msg: "room name already in use".to_owned()});
+        assert_eq!(
+            server.create_new_room(None, room_name.clone()),
+            ResponseCode::OK
+        );
+        assert_eq!(
+            server.create_new_room(None, room_name),
+            ResponseCode::BadRequest {
+                error_msg: "room name already in use".to_owned()
+            }
+        );
     }
 
     #[test]
-    fn create_new_room_player_already_in_room()
-    {
+    fn create_new_room_player_already_in_room() {
         let mut server = ServerState::new();
         let room_name = "some room".to_owned();
         let other_room_name = "another room".to_owned();
-        assert_eq!(server.create_new_room(None, room_name.clone()), ResponseCode::OK);
+        assert_eq!(
+            server.create_new_room(None, room_name.clone()),
+            ResponseCode::OK
+        );
 
         let player_id = {
-            let p: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            let p: &mut Player =
+                server.add_new_player("some player".to_owned(), fake_socket_addr());
 
             p.player_id
         };
         server.join_room(player_id, &room_name);
 
-        assert_eq!( server.create_new_room(Some(player_id), other_room_name), ResponseCode::BadRequest{error_msg: "cannot create room because in-game".to_owned()});
+        assert_eq!(
+            server.create_new_room(Some(player_id), other_room_name),
+            ResponseCode::BadRequest {
+                error_msg: "cannot create room because in-game".to_owned()
+            }
+        );
     }
 
     #[test]
-    fn create_new_room_join_room_good_case()
-    {
-
+    fn create_new_room_join_room_good_case() {
         let mut server = ServerState::new();
         let room_name = "some room";
-        assert_eq!(server.create_new_room(None, room_name.to_owned()), ResponseCode::OK);
+        assert_eq!(
+            server.create_new_room(None, room_name.to_owned()),
+            ResponseCode::OK
+        );
 
         let player_id = {
-            let p: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            let p: &mut Player =
+                server.add_new_player("some player".to_owned(), fake_socket_addr());
 
             p.player_id
         };
-        assert_eq!(server.join_room(player_id, room_name), ResponseCode::JoinedRoom{room_name: "some room".to_owned()});
+        assert_eq!(
+            server.join_room(player_id, room_name),
+            ResponseCode::JoinedRoom {
+                room_name: "some room".to_owned()
+            }
+        );
     }
 
     #[test]
-    fn join_room_player_already_in_room()
-    {
-
+    fn join_room_player_already_in_room() {
         let mut server = ServerState::new();
         let room_name = "some room";
-        assert_eq!(server.create_new_room(None, room_name.to_owned()), ResponseCode::OK);
+        assert_eq!(
+            server.create_new_room(None, room_name.to_owned()),
+            ResponseCode::OK
+        );
 
         let player_id = {
-            let p: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            let p: &mut Player =
+                server.add_new_player("some player".to_owned(), fake_socket_addr());
 
             p.player_id
         };
-        assert_eq!(server.join_room(player_id, room_name), ResponseCode::JoinedRoom{room_name: "some room".to_owned()});
-        assert_eq!( server.join_room(player_id, room_name), ResponseCode::BadRequest{error_msg: "cannot join game because in-game".to_owned()});
+        assert_eq!(
+            server.join_room(player_id, room_name),
+            ResponseCode::JoinedRoom {
+                room_name: "some room".to_owned()
+            }
+        );
+        assert_eq!(
+            server.join_room(player_id, room_name),
+            ResponseCode::BadRequest {
+                error_msg: "cannot join game because in-game".to_owned()
+            }
+        );
     }
 
     #[test]
-    fn join_room_room_does_not_exist()
-    {
-
+    fn join_room_room_does_not_exist() {
         let mut server = ServerState::new();
 
         let player_id = {
-            let p: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            let p: &mut Player =
+                server.add_new_player("some player".to_owned(), fake_socket_addr());
 
             p.player_id
         };
-        assert_eq!(server.join_room(player_id, "some room"), ResponseCode::BadRequest{error_msg: "no room named \"some room\"".to_owned()});
+        assert_eq!(
+            server.join_room(player_id, "some room"),
+            ResponseCode::BadRequest {
+                error_msg: "no room named \"some room\"".to_owned()
+            }
+        );
     }
 
     #[test]
-    fn leave_room_good_case()
-    {
+    fn leave_room_good_case() {
         let mut server = ServerState::new();
         let room_name = "some name";
 
         server.create_new_room(None, room_name.to_owned());
 
         let player_id = {
-            let p: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            let p: &mut Player =
+                server.add_new_player("some player".to_owned(), fake_socket_addr());
 
             p.player_id
         };
         server.join_room(player_id, room_name);
 
-        assert_eq!( server.leave_room(player_id), ResponseCode::LeaveRoom );
-
+        assert_eq!(server.leave_room(player_id), ResponseCode::LeaveRoom);
     }
 
     #[test]
-    fn leave_room_player_not_in_room()
-    {
+    fn leave_room_player_not_in_room() {
         let mut server = ServerState::new();
         let room_name = "some room".to_owned();
-        assert_eq!(server.create_new_room(None, room_name.clone()), ResponseCode::OK);
+        assert_eq!(
+            server.create_new_room(None, room_name.clone()),
+            ResponseCode::OK
+        );
 
         let player_id = {
-            let p: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            let p: &mut Player =
+                server.add_new_player("some player".to_owned(), fake_socket_addr());
 
             p.player_id
         };
 
-        assert_eq!( server.leave_room(player_id), ResponseCode::BadRequest{error_msg: "cannot leave game because in lobby".to_owned()});
+        assert_eq!(
+            server.leave_room(player_id),
+            ResponseCode::BadRequest {
+                error_msg: "cannot leave game because in lobby".to_owned()
+            }
+        );
     }
 
     #[test]
-    fn leave_room_unregistered_player_id()
-    {
+    fn leave_room_unregistered_player_id() {
         let mut server = ServerState::new();
         let room_name = "some room".to_owned();
         let rand_player_id = PlayerID(0x2457); //RUST
-        assert_eq!(server.create_new_room(None, room_name.clone()), ResponseCode::OK);
+        assert_eq!(
+            server.create_new_room(None, room_name.clone()),
+            ResponseCode::OK
+        );
 
-        assert_eq!( server.leave_room(rand_player_id), ResponseCode::BadRequest{error_msg: "cannot leave game because in lobby".to_owned()});
+        assert_eq!(
+            server.leave_room(rand_player_id),
+            ResponseCode::BadRequest {
+                error_msg: "cannot leave game because in lobby".to_owned()
+            }
+        );
     }
 
     #[test]
-    fn add_new_player_player_added_with_initial_sequence_number()
-    {
+    fn add_new_player_player_added_with_initial_sequence_number() {
         let mut server = ServerState::new();
         let name = "some player".to_owned();
 
@@ -1881,8 +2162,7 @@ mod netwayste_server_tests {
     }
 
     #[test]
-    fn is_unique_player_name_yes_and_no_case()
-    {
+    fn is_unique_player_name_yes_and_no_case() {
         let mut server = ServerState::new();
         let name = "some player".to_owned();
         assert_eq!(server.is_unique_player_name("some player"), true);
@@ -1894,8 +2174,7 @@ mod netwayste_server_tests {
     }
 
     #[test]
-    fn expire_old_messages_in_all_rooms_room_is_empty()
-    {
+    fn expire_old_messages_in_all_rooms_room_is_empty() {
         let mut server = ServerState::new();
         let room_name = "some room";
 
@@ -1907,14 +2186,13 @@ mod netwayste_server_tests {
         }
     }
 
-
     #[test]
-    fn expire_old_messages_in_all_rooms_one_room_good_case()
-    {
+    fn expire_old_messages_in_all_rooms_one_room_good_case() {
         let mut server = ServerState::new();
 
         let player_id: PlayerID = {
-            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            let player: &mut Player =
+                server.add_new_player("some player".to_owned(), fake_socket_addr());
             player.player_id
         };
 
@@ -1940,8 +2218,7 @@ mod netwayste_server_tests {
     }
 
     #[test]
-    fn expire_old_messages_in_all_rooms_several_rooms_good_case()
-    {
+    fn expire_old_messages_in_all_rooms_several_rooms_good_case() {
         let mut server = ServerState::new();
         let room_name = "some room";
         let room_name2 = "some room2";
@@ -1949,11 +2226,13 @@ mod netwayste_server_tests {
         let room_id = server.new_room(room_name.to_owned());
         let room_id2 = server.new_room(room_name2.to_owned());
         let player_id: PlayerID = {
-            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            let player: &mut Player =
+                server.add_new_player("some player".to_owned(), fake_socket_addr());
             player.player_id
         };
         let player_id2: PlayerID = {
-            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            let player: &mut Player =
+                server.add_new_player("some player".to_owned(), fake_socket_addr());
             player.player_id
         };
 
@@ -1984,14 +2263,14 @@ mod netwayste_server_tests {
     }
 
     #[test]
-    fn expire_old_messages_in_all_rooms_one_room_old_messages_are_wiped()
-    {
+    fn expire_old_messages_in_all_rooms_one_room_old_messages_are_wiped() {
         let mut server = ServerState::new();
         let room_name = "some room";
 
         server.create_new_room(None, room_name.to_owned().clone());
         let player_id: PlayerID = {
-            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            let player: &mut Player =
+                server.add_new_player("some player".to_owned(), fake_socket_addr());
             player.player_id
         };
 
@@ -2003,7 +2282,8 @@ mod netwayste_server_tests {
         server.handle_chat_message(player_id, "What's not to love?".to_owned());
 
         let current_timestamp = Instant::now();
-        let travel_to_the_past = current_timestamp.checked_sub(Duration::from_secs((MAX_AGE_CHAT_MESSAGES+1) as u64));
+        let travel_to_the_past =
+            current_timestamp.checked_sub(Duration::from_secs((MAX_AGE_CHAT_MESSAGES + 1) as u64));
         if travel_to_the_past.is_none() {
             warn!("skipping rest of test; cannot travel to the past :(");
             return;
@@ -2012,7 +2292,12 @@ mod netwayste_server_tests {
         for ref mut room in server.rooms.values_mut() {
             println!("Room: {:?}", room.name);
             for m in room.messages.iter_mut() {
-                println!("{:?}, {:?},       {:?}", m.timestamp, travel_to_the_past, m.timestamp - travel_to_the_past);
+                println!(
+                    "{:?}, {:?},       {:?}",
+                    m.timestamp,
+                    travel_to_the_past,
+                    m.timestamp - travel_to_the_past
+                );
                 m.timestamp = travel_to_the_past;
             }
         }
@@ -2026,20 +2311,21 @@ mod netwayste_server_tests {
     }
 
     #[test]
-    fn expire_old_messages_in_all_rooms_several_rooms_old_messages_are_wiped()
-    {
+    fn expire_old_messages_in_all_rooms_several_rooms_old_messages_are_wiped() {
         let mut server = ServerState::new();
         let room_name = "some room";
         let room_name2 = "some room 2";
 
         server.create_new_room(None, room_name.to_owned().clone());
         let player_id: PlayerID = {
-            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            let player: &mut Player =
+                server.add_new_player("some player".to_owned(), fake_socket_addr());
             player.player_id
         };
         server.create_new_room(None, room_name2.to_owned().clone());
         let player_id2: PlayerID = {
-            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            let player: &mut Player =
+                server.add_new_player("some player".to_owned(), fake_socket_addr());
             player.player_id
         };
 
@@ -2052,7 +2338,8 @@ mod netwayste_server_tests {
         server.handle_chat_message(player_id2, "What's not to love?".to_owned());
 
         let current_timestamp = Instant::now();
-        let travel_to_the_past = current_timestamp.checked_sub(Duration::from_secs((MAX_AGE_CHAT_MESSAGES+1) as u64));
+        let travel_to_the_past =
+            current_timestamp.checked_sub(Duration::from_secs((MAX_AGE_CHAT_MESSAGES + 1) as u64));
         if travel_to_the_past.is_none() {
             warn!("skipping rest of test; cannot travel to the past :(");
             return;
@@ -2061,7 +2348,12 @@ mod netwayste_server_tests {
         for ref mut room in server.rooms.values_mut() {
             println!("Room: {:?}", room.name);
             for m in room.messages.iter_mut() {
-                println!("{:?}, {:?},       {:?}", m.timestamp, travel_to_the_past, m.timestamp - travel_to_the_past);
+                println!(
+                    "{:?}, {:?},       {:?}",
+                    m.timestamp,
+                    travel_to_the_past,
+                    m.timestamp - travel_to_the_past
+                );
                 m.timestamp = travel_to_the_past;
             }
         }
@@ -2080,13 +2372,18 @@ mod netwayste_server_tests {
         let player_name = "some name".to_owned();
         let pkt = server.handle_new_connection(player_name, fake_socket_addr());
         match pkt {
-            Packet::Response{sequence: _, request_ack: _, code} => {
-                match code {
-                    ResponseCode::LoggedIn{cookie: _, server_version: _} => {}
-                    _ => panic!("Unexpected ResponseCode: {:?}", code)
-                }
-            }
-            _ => panic!("Unexpected Packet Type: {:?}", pkt)
+            Packet::Response {
+                sequence: _,
+                request_ack: _,
+                code,
+            } => match code {
+                ResponseCode::LoggedIn {
+                    cookie: _,
+                    server_version: _,
+                } => {}
+                _ => panic!("Unexpected ResponseCode: {:?}", code),
+            },
+            _ => panic!("Unexpected Packet Type: {:?}", pkt),
         }
     }
 
@@ -2097,28 +2394,33 @@ mod netwayste_server_tests {
 
         let pkt = server.handle_new_connection(player_name.clone(), fake_socket_addr());
         match pkt {
-            Packet::Response{sequence: _, request_ack: _, code} => {
-                match code {
-                    ResponseCode::LoggedIn{cookie: _, server_version} => {
-                        assert_eq!(server_version, VERSION.to_owned() )
-                    }
-                    _ => panic!("Unexpected ResponseCode: {:?}", code)
-                }
-            }
-            _ => panic!("Unexpected Packet Type: {:?}", pkt)
+            Packet::Response {
+                sequence: _,
+                request_ack: _,
+                code,
+            } => match code {
+                ResponseCode::LoggedIn {
+                    cookie: _,
+                    server_version,
+                } => assert_eq!(server_version, VERSION.to_owned()),
+                _ => panic!("Unexpected ResponseCode: {:?}", code),
+            },
+            _ => panic!("Unexpected Packet Type: {:?}", pkt),
         }
 
         let pkt = server.handle_new_connection(player_name, fake_socket_addr());
         match pkt {
-            Packet::Response{sequence: _, request_ack: _, code} => {
-                match code {
-                    ResponseCode::Unauthorized{error_msg} => {
-                        assert_eq!(error_msg, "not a unique name".to_owned());
-                    }
-                    _ => panic!("Unexpected ResponseCode: {:?}", code)
+            Packet::Response {
+                sequence: _,
+                request_ack: _,
+                code,
+            } => match code {
+                ResponseCode::Unauthorized { error_msg } => {
+                    assert_eq!(error_msg, "not a unique name".to_owned());
                 }
-            }
-            _ => panic!("Unexpected Packet Type: {:?}", pkt)
+                _ => panic!("Unexpected ResponseCode: {:?}", code),
+            },
+            _ => panic!("Unexpected Packet Type: {:?}", pkt),
         }
     }
 
@@ -2130,16 +2432,23 @@ mod netwayste_server_tests {
             Just(RequestAction::ListPlayers),
             Just(RequestAction::ListRooms),
             Just(RequestAction::None),
-        ].boxed()
+        ]
+        .boxed()
     }
 
     fn a_request_action_complex_strat() -> BoxedStrategy<RequestAction> {
         prop_oneof![
-            ("([A-Z]{1,4} [0-9]{1,2}){3}").prop_map(|a| RequestAction::ChatMessage{message: a}),
-            ("([A-Z]{1,4} [0-9]{1,2}){3}").prop_map(|a| RequestAction::NewRoom{room_name: a}),
-            ("([A-Z]{1,4} [0-9]{1,2}){3}").prop_map(|a| RequestAction::JoinRoom{room_name: a}),
-            ("([A-Z]{1,4} [0-9]{1,2}){3}", "[0-9].[0-9].[0-9]").prop_map(|(a, b)| RequestAction::Connect{name: a, client_version: b})
-        ].boxed()
+            ("([A-Z]{1,4} [0-9]{1,2}){3}").prop_map(|a| RequestAction::ChatMessage { message: a }),
+            ("([A-Z]{1,4} [0-9]{1,2}){3}").prop_map(|a| RequestAction::NewRoom { room_name: a }),
+            ("([A-Z]{1,4} [0-9]{1,2}){3}").prop_map(|a| RequestAction::JoinRoom { room_name: a }),
+            ("([A-Z]{1,4} [0-9]{1,2}){3}", "[0-9].[0-9].[0-9]").prop_map(|(a, b)| {
+                RequestAction::Connect {
+                    name: a,
+                    client_version: b,
+                }
+            })
+        ]
+        .boxed()
     }
 
     // These tests are checking that we do not panic on each RequestAction
@@ -2173,11 +2482,23 @@ mod netwayste_server_tests {
         let player_name = "some player".to_owned();
         server.create_new_room(None, "some room".to_owned().clone());
         let player_id: PlayerID = {
-            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            let player: &mut Player =
+                server.add_new_player(player_name.clone(), fake_socket_addr());
             player.player_id
         };
-        let result = server.process_request_action(player_id, RequestAction::Connect{name: player_name, client_version: "0.1.0".to_owned()});
-        assert_eq!(result, ResponseCode::BadRequest{error_msg: "Already connected".to_owned()});
+        let result = server.process_request_action(
+            player_id,
+            RequestAction::Connect {
+                name: player_name,
+                client_version: "0.1.0".to_owned(),
+            },
+        );
+        assert_eq!(
+            result,
+            ResponseCode::BadRequest {
+                error_msg: "Already connected".to_owned()
+            }
+        );
     }
 
     #[test]
@@ -2185,25 +2506,38 @@ mod netwayste_server_tests {
         let mut server = ServerState::new();
         server.create_new_room(None, "some room".to_owned().clone());
         let player_id: PlayerID = {
-            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            let player: &mut Player =
+                server.add_new_player("some player".to_owned(), fake_socket_addr());
             player.player_id
         };
         let result = server.process_request_action(player_id, RequestAction::None);
-        assert_eq!(result, ResponseCode::BadRequest{error_msg: "Invalid request".to_owned()});
+        assert_eq!(
+            result,
+            ResponseCode::BadRequest {
+                error_msg: "Invalid request".to_owned()
+            }
+        );
     }
 
     #[test]
     fn prepare_response_spot_check_response_packet() {
         let mut server = ServerState::new();
         let player_id: PlayerID = {
-            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            let player: &mut Player =
+                server.add_new_player("some player".to_owned(), fake_socket_addr());
             player.request_ack = Some(1);
             player.player_id
         };
-        let pkt: Packet = server.prepare_response(player_id, RequestAction::ListRooms).unwrap();
+        let pkt: Packet = server
+            .prepare_response(player_id, RequestAction::ListRooms)
+            .unwrap();
         match pkt {
-            Packet::Response{code, sequence, request_ack} => {
-                if let ResponseCode::RoomList{rooms} = code {
+            Packet::Response {
+                code,
+                sequence,
+                request_ack,
+            } => {
+                if let ResponseCode::RoomList { rooms } = code {
                     assert_eq!(rooms.len(), 1); // 1 room - general
                 } else {
                     panic!("`code` is not a RoomList! code is {:?}", code);
@@ -2211,7 +2545,7 @@ mod netwayste_server_tests {
                 assert_eq!(sequence, 1);
                 assert_eq!(request_ack, Some(2));
             }
-            _ => panic!("Unexpected Packet type on Response path: {:?}", pkt)
+            _ => panic!("Unexpected Packet type on Response path: {:?}", pkt),
         }
         let player: &Player = server.get_player(player_id);
         assert_eq!(player.next_resp_seq, 2);
@@ -2219,32 +2553,47 @@ mod netwayste_server_tests {
 
     #[test]
     fn validate_client_version_client_is_up_to_date() {
-        assert_eq!(validate_client_version( env!("CARGO_PKG_VERSION").to_owned()), true);
+        assert_eq!(
+            validate_client_version(env!("CARGO_PKG_VERSION").to_owned()),
+            true
+        );
     }
 
     #[test]
     fn validate_client_version_client_is_very_old() {
-      assert_eq!(validate_client_version("0.0.1".to_owned()), true);
+        assert_eq!(validate_client_version("0.0.1".to_owned()), true);
     }
 
     #[test]
     fn validate_client_version_client_is_from_the_future() {
-        assert_eq!(validate_client_version(format!("{}.{}.{}", <i32>::max_value(), <i32>::max_value(), <i32>::max_value()).to_owned()), false);
+        assert_eq!(
+            validate_client_version(
+                format!(
+                    "{}.{}.{}",
+                    <i32>::max_value(),
+                    <i32>::max_value(),
+                    <i32>::max_value()
+                )
+                .to_owned()
+            ),
+            false
+        );
     }
 
     #[test]
     fn decode_packet_update_reply_good_case() {
         let mut server = ServerState::new();
         let cookie: String = {
-            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            let player: &mut Player =
+                server.add_new_player("some player".to_owned(), fake_socket_addr());
             player.cookie.clone()
         };
 
         let update_reply_packet = Packet::UpdateReply {
-                cookie: cookie,
-                last_chat_seq: Some(0),
-                last_game_update_seq: None,
-                last_gen: None,
+            cookie: cookie,
+            last_chat_seq: Some(0),
+            last_game_update_seq: None,
+            last_gen: None,
         };
 
         let result = server.decode_packet(fake_socket_addr(), update_reply_packet);
@@ -2256,17 +2605,18 @@ mod netwayste_server_tests {
     fn decode_packet_update_reply_invalid_cookie() {
         let mut server = ServerState::new();
         {
-            let player: &mut Player = server.add_new_player("some player".to_owned(), fake_socket_addr());
+            let player: &mut Player =
+                server.add_new_player("some player".to_owned(), fake_socket_addr());
             player.cookie.clone()
         };
 
         let cookie = "CookieMonster".to_owned();
 
         let update_reply_packet = Packet::UpdateReply {
-                cookie: cookie,
-                last_chat_seq: Some(0),
-                last_game_update_seq: None,
-                last_gen: None,
+            cookie: cookie,
+            last_chat_seq: Some(0),
+            last_game_update_seq: None,
+            last_gen: None,
         };
 
         let result = server.decode_packet(fake_socket_addr(), update_reply_packet);
@@ -2298,7 +2648,8 @@ mod netwayste_server_tests {
         server.create_new_room(None, room_name.to_owned());
 
         let player_id: PlayerID = {
-            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            let player: &mut Player =
+                server.add_new_player(player_name.clone(), fake_socket_addr());
             player.player_id
         };
         server.join_room(player_id, room_name);
@@ -2318,22 +2669,26 @@ mod netwayste_server_tests {
         assert_eq!(addr, fake_socket_addr());
 
         match pkt {
-            Packet::Update{chats, game_updates, universe_update} => {
+            Packet::Update {
+                chats,
+                game_updates,
+                universe_update,
+            } => {
                 assert!(game_updates.is_empty());
                 assert_eq!(universe_update, UniUpdateType::NoChange);
                 assert!(!chats.is_empty());
 
                 // All client chat sequence numbers start counting at 1
-                let mut i=1;
+                let mut i = 1;
 
                 for msg in chats {
                     assert_eq!(msg.player_name, player_name);
                     assert_eq!(msg.chat_seq, Some(i));
                     assert_eq!(msg.message, message_text);
-                    i+=1;
+                    i += 1;
                 }
             }
-            _ => panic!("Unexpected packet in client update construction!")
+            _ => panic!("Unexpected packet in client update construction!"),
         }
     }
 
@@ -2347,7 +2702,8 @@ mod netwayste_server_tests {
         server.create_new_room(None, room_name.to_owned());
 
         let player_id: PlayerID = {
-            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            let player: &mut Player =
+                server.add_new_player(player_name.clone(), fake_socket_addr());
             player.player_id
         };
         server.join_room(player_id, room_name);
@@ -2374,7 +2730,11 @@ mod netwayste_server_tests {
         assert_eq!(addr, fake_socket_addr());
 
         match pkt {
-            Packet::Update{mut chats, game_updates, universe_update} => {
+            Packet::Update {
+                mut chats,
+                game_updates,
+                universe_update,
+            } => {
                 assert!(game_updates.is_empty());
                 assert_eq!(universe_update, UniUpdateType::NoChange);
                 assert!(!chats.is_empty());
@@ -2386,7 +2746,7 @@ mod netwayste_server_tests {
                 assert_eq!(msg.chat_seq, Some(3));
                 assert_eq!(msg.message, message_text);
             }
-            _ => panic!("Unexpected packet in client update construction!")
+            _ => panic!("Unexpected packet in client update construction!"),
         }
     }
 
@@ -2399,11 +2759,13 @@ mod netwayste_server_tests {
         server.create_new_room(None, room_name.to_owned());
 
         let player_id: PlayerID = {
-            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            let player: &mut Player =
+                server.add_new_player(player_name.clone(), fake_socket_addr());
             player.player_id
         };
         let player_id2: PlayerID = {
-            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            let player: &mut Player =
+                server.add_new_player(player_name.clone(), fake_socket_addr());
             player.player_id
         };
 
@@ -2416,14 +2778,24 @@ mod netwayste_server_tests {
         let room: &Room = server.get_room(player_id).unwrap();
 
         let player = (*server.get_player(player_id)).clone();
-        let msgs = server.collect_unacknowledged_messages(room, &player).unwrap();
+        let msgs = server
+            .collect_unacknowledged_messages(room, &player)
+            .unwrap();
         assert_eq!(msgs.len(), 1);
-        assert_eq!(msgs[0].message, "Silver birch against a Swedish sky".to_owned());
+        assert_eq!(
+            msgs[0].message,
+            "Silver birch against a Swedish sky".to_owned()
+        );
 
         let player = (*server.get_player(player_id2)).clone();
-        let msgs = server.collect_unacknowledged_messages(room, &player).unwrap();
+        let msgs = server
+            .collect_unacknowledged_messages(room, &player)
+            .unwrap();
         assert_eq!(msgs.len(), 1);
-        assert_eq!(msgs[0].message, "Silver birch against a Swedish sky".to_owned());
+        assert_eq!(
+            msgs[0].message,
+            "Silver birch against a Swedish sky".to_owned()
+        );
     }
 
     #[test]
@@ -2454,7 +2826,8 @@ mod netwayste_server_tests {
         let player_name = "some player".to_owned();
 
         let player_id: PlayerID = {
-            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            let player: &mut Player =
+                server.add_new_player(player_name.clone(), fake_socket_addr());
             player.player_id
         };
 
@@ -2468,7 +2841,8 @@ mod netwayste_server_tests {
         let player_name = "some player".to_owned();
 
         let (player_id, cookie) = {
-            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            let player: &mut Player =
+                server.add_new_player(player_name.clone(), fake_socket_addr());
             (player.player_id, player.cookie.clone())
         };
 
@@ -2483,7 +2857,8 @@ mod netwayste_server_tests {
         let player_name = "some player".to_owned();
 
         let player_id: PlayerID = {
-            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            let player: &mut Player =
+                server.add_new_player(player_name.clone(), fake_socket_addr());
             player.player_id
         };
 
@@ -2506,13 +2881,15 @@ mod netwayste_server_tests {
         let player_name = "some player".to_owned();
 
         let player_id: PlayerID = {
-            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            let player: &mut Player =
+                server.add_new_player(player_name.clone(), fake_socket_addr());
             player.request_ack = Some(4);
             player.player_id
         };
 
         let player_id2: PlayerID = {
-            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            let player: &mut Player =
+                server.add_new_player(player_name.clone(), fake_socket_addr());
             player.request_ack = None;
             player.player_id
         };
@@ -2530,7 +2907,8 @@ mod netwayste_server_tests {
         let player_name = "some player".to_owned();
 
         let player_id: PlayerID = {
-            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            let player: &mut Player =
+                server.add_new_player(player_name.clone(), fake_socket_addr());
             player.request_ack = Some(4);
             player.player_id
         };
@@ -2539,7 +2917,7 @@ mod netwayste_server_tests {
             let pkt = Packet::Response {
                 sequence: i,
                 request_ack: None,
-                code: ResponseCode::OK
+                code: ResponseCode::OK,
             };
 
             let nm: &mut NetworkManager = server.network_map.get_mut(&player_id).unwrap();
@@ -2547,13 +2925,25 @@ mod netwayste_server_tests {
         }
 
         server.clear_transmission_queue_on_ack(player_id, None);
-        assert_eq!(server.network_map.get(&player_id).unwrap().tx_packets.len(), 5);
+        assert_eq!(
+            server.network_map.get(&player_id).unwrap().tx_packets.len(),
+            5
+        );
         server.clear_transmission_queue_on_ack(player_id, Some(0));
-        assert_eq!(server.network_map.get(&player_id).unwrap().tx_packets.len(), 5);
+        assert_eq!(
+            server.network_map.get(&player_id).unwrap().tx_packets.len(),
+            5
+        );
         server.clear_transmission_queue_on_ack(player_id, Some(1));
-        assert_eq!(server.network_map.get(&player_id).unwrap().tx_packets.len(), 4);
+        assert_eq!(
+            server.network_map.get(&player_id).unwrap().tx_packets.len(),
+            4
+        );
         server.clear_transmission_queue_on_ack(player_id, Some(5));
-        assert_eq!(server.network_map.get(&player_id).unwrap().tx_packets.len(), 0);
+        assert_eq!(
+            server.network_map.get(&player_id).unwrap().tx_packets.len(),
+            0
+        );
     }
 
     #[test]
@@ -2571,17 +2961,17 @@ mod netwayste_server_tests {
         let player_name = "some player".to_owned();
 
         let player_id: PlayerID = {
-            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
+            let player: &mut Player =
+                server.add_new_player(player_name.clone(), fake_socket_addr());
             player.request_ack = Some(5);
             player.player_id
         };
-
 
         for i in 0..5 {
             let pkt = Packet::Response {
                 sequence: i,
                 request_ack: None,
-                code: ResponseCode::OK
+                code: ResponseCode::OK,
             };
 
             let nm: &mut NetworkManager = server.network_map.get_mut(&player_id).unwrap();
@@ -2589,7 +2979,7 @@ mod netwayste_server_tests {
 
             if i < 3 {
                 let attempt: &mut NetAttempt = nm.tx_packets.attempts.back_mut().unwrap();
-                attempt.time = Instant::now() - Duration::from_secs(i+1);
+                attempt.time = Instant::now() - Duration::from_secs(i + 1);
             }
         }
 
@@ -2614,8 +3004,9 @@ mod netwayste_server_tests {
         let player_name = "some player".to_owned();
 
         let (player_id, player_cookie): (PlayerID, String) = {
-            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
-            player.request_ack = Some(1);   // Player connected and we've confirmed the first transaction
+            let player: &mut Player =
+                server.add_new_player(player_name.clone(), fake_socket_addr());
+            player.request_ack = Some(1); // Player connected and we've confirmed the first transaction
             (player.player_id, player.cookie.clone())
         };
 
@@ -2624,7 +3015,7 @@ mod netwayste_server_tests {
                 cookie: Some(player_cookie),
                 sequence: 2,
                 response_ack: None,
-                action: RequestAction::ListPlayers
+                action: RequestAction::ListPlayers,
             };
 
             let nm: &mut NetworkManager = server.network_map.get_mut(&player_id).unwrap();
@@ -2635,12 +3026,10 @@ mod netwayste_server_tests {
 
         server.process_queued_rx_packets(player_id);
 
-
         {
             let nm: &mut NetworkManager = server.network_map.get_mut(&player_id).unwrap();
             assert_eq!(nm.tx_packets.len(), 1);
         }
-
     }
 
     #[test]
@@ -2649,8 +3038,9 @@ mod netwayste_server_tests {
         let player_name = "some player".to_owned();
 
         let (player_id, player_cookie): (PlayerID, String) = {
-            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
-            player.request_ack = Some(1);   // Player connected and we've confirmed the first transaction
+            let player: &mut Player =
+                server.add_new_player(player_name.clone(), fake_socket_addr());
+            player.request_ack = Some(1); // Player connected and we've confirmed the first transaction
             (player.player_id, player.cookie.clone())
         };
 
@@ -2659,7 +3049,7 @@ mod netwayste_server_tests {
                 cookie: Some(player_cookie.clone()),
                 sequence: i,
                 response_ack: None,
-                action: RequestAction::ListPlayers
+                action: RequestAction::ListPlayers,
             };
 
             let nm: &mut NetworkManager = server.network_map.get_mut(&player_id).unwrap();
@@ -2674,7 +3064,6 @@ mod netwayste_server_tests {
             let nm: &mut NetworkManager = server.network_map.get_mut(&player_id).unwrap();
             assert_eq!(nm.tx_packets.len(), 8);
         }
-
     }
 
     #[test]
@@ -2683,8 +3072,9 @@ mod netwayste_server_tests {
         let player_name = "some player".to_owned();
 
         let (player_id, player_cookie): (PlayerID, String) = {
-            let player: &mut Player = server.add_new_player(player_name.clone(), fake_socket_addr());
-            player.request_ack = Some(1);   // Player connected and we've confirmed the first transaction
+            let player: &mut Player =
+                server.add_new_player(player_name.clone(), fake_socket_addr());
+            player.request_ack = Some(1); // Player connected and we've confirmed the first transaction
             (player.player_id, player.cookie.clone())
         };
 
@@ -2693,7 +3083,7 @@ mod netwayste_server_tests {
                 cookie: Some(player_cookie.clone()),
                 sequence: *i,
                 response_ack: None,
-                action: RequestAction::ListPlayers
+                action: RequestAction::ListPlayers,
             };
 
             let nm: &mut NetworkManager = server.network_map.get_mut(&player_id).unwrap();

--- a/netwayste/src/tests.rs
+++ b/netwayste/src/tests.rs
@@ -15,10 +15,13 @@
  *  You should have received a copy of the GNU General Public License
  *  along with netwayste.  If not, see <http://www.gnu.org/licenses/>. */
 
-use std::{thread, time::{Instant, Duration}};
-use std::net::SocketAddr;
-use crate::net::*;
 use crate::futures::sync::mpsc;
+use crate::net::*;
+use std::net::SocketAddr;
+use std::{
+    thread,
+    time::{Duration, Instant},
+};
 
 mod netwayste_net_tests {
     use super::*;
@@ -27,7 +30,6 @@ mod netwayste_net_tests {
         use std::net::{IpAddr, Ipv4Addr};
         SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 5678)
     }
-
 
     // `discord_older_packets()` tests are disabled  until after the necessity of the function is re-evaluated
     #[test]
@@ -49,7 +51,7 @@ mod netwayste_net_tests {
             sequence: 0,
             response_ack: None,
             cookie: None,
-            action: RequestAction::None
+            action: RequestAction::None,
         };
 
         nm.tx_packets.push_back(pkt.clone());
@@ -75,7 +77,7 @@ mod netwayste_net_tests {
             sequence: 0,
             response_ack: None,
             cookie: None,
-            action: RequestAction::None
+            action: RequestAction::None,
         };
 
         for _ in 0..NETWORK_QUEUE_LENGTH {
@@ -83,7 +85,7 @@ mod netwayste_net_tests {
         }
         assert_eq!(nm.tx_packets.len(), NETWORK_QUEUE_LENGTH);
         nm.tx_packets.discard_older_items();
-        assert_eq!(nm.tx_packets.len(), NETWORK_QUEUE_LENGTH-1);
+        assert_eq!(nm.tx_packets.len(), NETWORK_QUEUE_LENGTH - 1);
 
         for _ in 0..NETWORK_QUEUE_LENGTH {
             nm.rx_packets.push_back(pkt.clone());
@@ -101,20 +103,20 @@ mod netwayste_net_tests {
             sequence: 0,
             response_ack: None,
             cookie: None,
-            action: RequestAction::None
+            action: RequestAction::None,
         };
 
-        for _ in 0..NETWORK_QUEUE_LENGTH+10 {
+        for _ in 0..NETWORK_QUEUE_LENGTH + 10 {
             nm.tx_packets.push_back(pkt.clone());
         }
-        assert_eq!(nm.tx_packets.len(), NETWORK_QUEUE_LENGTH+10);
+        assert_eq!(nm.tx_packets.len(), NETWORK_QUEUE_LENGTH + 10);
         nm.tx_packets.discard_older_items();
-        assert_eq!(nm.tx_packets.len(), NETWORK_QUEUE_LENGTH-1);
+        assert_eq!(nm.tx_packets.len(), NETWORK_QUEUE_LENGTH - 1);
 
-        for _ in 0..NETWORK_QUEUE_LENGTH+5 {
+        for _ in 0..NETWORK_QUEUE_LENGTH + 5 {
             nm.rx_packets.push_back(pkt.clone());
         }
-        assert_eq!(nm.rx_packets.len(), NETWORK_QUEUE_LENGTH+5);
+        assert_eq!(nm.rx_packets.len(), NETWORK_QUEUE_LENGTH + 5);
         nm.rx_packets.discard_older_items();
         assert_eq!(nm.rx_packets.len(), NETWORK_QUEUE_LENGTH);
     }
@@ -126,7 +128,7 @@ mod netwayste_net_tests {
             sequence: 0,
             response_ack: None,
             cookie: None,
-            action: RequestAction::None
+            action: RequestAction::None,
         };
 
         nm.tx_packets.buffer_item(pkt);
@@ -140,7 +142,7 @@ mod netwayste_net_tests {
             sequence: 0,
             response_ack: None,
             cookie: None,
-            action: RequestAction::None
+            action: RequestAction::None,
         };
 
         nm.tx_packets.buffer_item(pkt);
@@ -148,12 +150,18 @@ mod netwayste_net_tests {
             sequence: 0,
             response_ack: None,
             cookie: None,
-            action: RequestAction::LeaveRoom
+            action: RequestAction::LeaveRoom,
         };
 
         nm.tx_packets.buffer_item(pkt);
         let pkt = nm.tx_packets.queue.back().unwrap();
-        if let Packet::Request { sequence: _, response_ack: _, cookie: _, action } = pkt {
+        if let Packet::Request {
+            sequence: _,
+            response_ack: _,
+            cookie: _,
+            action,
+        } = pkt
+        {
             assert_eq!(*action, RequestAction::None);
         }
     }
@@ -165,7 +173,7 @@ mod netwayste_net_tests {
             sequence: 0,
             response_ack: None,
             cookie: None,
-            action: RequestAction::None
+            action: RequestAction::None,
         };
 
         nm.tx_packets.buffer_item(pkt);
@@ -173,7 +181,7 @@ mod netwayste_net_tests {
             sequence: 1,
             response_ack: None,
             cookie: None,
-            action: RequestAction::LeaveRoom
+            action: RequestAction::LeaveRoom,
         };
         nm.tx_packets.buffer_item(pkt);
         assert_eq!(nm.tx_packets.len(), 2);
@@ -186,7 +194,7 @@ mod netwayste_net_tests {
             sequence: 1,
             response_ack: None,
             cookie: None,
-            action: RequestAction::None
+            action: RequestAction::None,
         };
 
         nm.tx_packets.buffer_item(pkt);
@@ -194,37 +202,48 @@ mod netwayste_net_tests {
             sequence: 0,
             response_ack: None,
             cookie: None,
-            action: RequestAction::LeaveRoom
+            action: RequestAction::LeaveRoom,
         };
         nm.tx_packets.buffer_item(pkt);
         assert_eq!(nm.tx_packets.len(), 2);
 
         let pkt = nm.tx_packets.queue.back().unwrap();
-        if let Packet::Request { sequence, response_ack: _, cookie: _, action:_ } = pkt {
+        if let Packet::Request {
+            sequence,
+            response_ack: _,
+            cookie: _,
+            action: _,
+        } = pkt
+        {
             assert_eq!(*sequence, 1);
         }
     }
-
 
     // `buffer_item()` test with an enforced hard limit size is disabled until performance is re-examined
     #[test]
     #[ignore]
     fn test_buffer_item_max_queue_limit_maintained() {
         let mut nm = NetworkManager::new();
-        for index in 0..NETWORK_QUEUE_LENGTH+5 {
+        for index in 0..NETWORK_QUEUE_LENGTH + 5 {
             let pkt = Packet::Request {
                 sequence: index as u64,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.tx_packets.buffer_item(pkt);
         }
 
-        let mut iter =  nm.tx_packets.queue.iter();
-        for index in 5..NETWORK_QUEUE_LENGTH+5 {
+        let mut iter = nm.tx_packets.queue.iter();
+        for index in 5..NETWORK_QUEUE_LENGTH + 5 {
             let pkt = iter.next().unwrap();
-            if let Packet::Request { sequence, response_ack: _, cookie: _, action:_ } = pkt {
+            if let Packet::Request {
+                sequence,
+                response_ack: _,
+                cookie: _,
+                action: _,
+            } = pkt
+            {
                 assert_eq!(*sequence, index as u64);
             }
         }
@@ -238,7 +257,7 @@ mod netwayste_net_tests {
                 sequence: index as u64,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.rx_packets.buffer_item(pkt);
         }
@@ -258,7 +277,7 @@ mod netwayste_net_tests {
                 sequence: index as u64,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.rx_packets.buffer_item(pkt);
         }
@@ -274,18 +293,18 @@ mod netwayste_net_tests {
     fn test_buffer_item_basic_sequential_gap_ascending() {
         let mut nm = NetworkManager::new();
         // TODO Replace with (x,y).step_by(z) once stable
-        for index in [0,2,4,6,8,10].iter() {
+        for index in [0, 2, 4, 6, 8, 10].iter() {
             let pkt = Packet::Request {
                 sequence: *index as u64,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.rx_packets.buffer_item(pkt);
         }
 
         let mut iter = nm.rx_packets.queue.iter();
-        for &index in [0,2,4,6,8,10].iter() {
+        for &index in [0, 2, 4, 6, 8, 10].iter() {
             let pkt = iter.next().unwrap();
             assert_eq!(index, pkt.sequence_number() as usize);
         }
@@ -294,18 +313,18 @@ mod netwayste_net_tests {
     #[test]
     fn test_buffer_item_basic_sequential_gap_descending() {
         let mut nm = NetworkManager::new();
-        for index in [0,2,4,6,8,10].iter().rev() {
+        for index in [0, 2, 4, 6, 8, 10].iter().rev() {
             let pkt = Packet::Request {
                 sequence: *index as u64,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.rx_packets.buffer_item(pkt);
         }
 
         let mut iter = nm.rx_packets.queue.iter();
-        for index in [0,2,4,6,8,10].iter() {
+        for index in [0, 2, 4, 6, 8, 10].iter() {
             let pkt = iter.next().unwrap();
             assert_eq!(*index, pkt.sequence_number());
         }
@@ -319,7 +338,7 @@ mod netwayste_net_tests {
                 sequence: *index as u64,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.rx_packets.buffer_item(pkt);
         }
@@ -340,7 +359,7 @@ mod netwayste_net_tests {
                 sequence: *index as u64,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.rx_packets.buffer_item(pkt);
         }
@@ -360,7 +379,7 @@ mod netwayste_net_tests {
                 sequence: *index as u64,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.rx_packets.buffer_item(pkt);
         }
@@ -381,7 +400,7 @@ mod netwayste_net_tests {
                 sequence: index as u64,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.rx_packets.buffer_item(pkt);
         }
@@ -391,7 +410,7 @@ mod netwayste_net_tests {
                 sequence: *index as u64,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.rx_packets.buffer_item(pkt);
         }
@@ -401,7 +420,7 @@ mod netwayste_net_tests {
                 sequence: index as u64,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.rx_packets.buffer_item(pkt);
         }
@@ -425,7 +444,7 @@ mod netwayste_net_tests {
                 sequence: index as u64,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.rx_packets.buffer_item(pkt);
         }
@@ -435,7 +454,7 @@ mod netwayste_net_tests {
                 sequence: *index as u64,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.rx_packets.buffer_item(pkt);
         }
@@ -445,7 +464,7 @@ mod netwayste_net_tests {
                 sequence: index as u64,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.rx_packets.buffer_item(pkt);
         }
@@ -466,12 +485,12 @@ mod netwayste_net_tests {
         let u64_max = <u64>::max_value();
         let start = u64_max - 5;
 
-        for index in start..(start+5) {
+        for index in start..(start + 5) {
             let pkt = Packet::Request {
                 sequence: index as u64,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.rx_packets.buffer_item(pkt);
         }
@@ -481,7 +500,7 @@ mod netwayste_net_tests {
                 sequence: u64_max,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.rx_packets.buffer_item(pkt);
         }
@@ -491,7 +510,7 @@ mod netwayste_net_tests {
                 sequence: index as u64,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.rx_packets.buffer_item(pkt);
         }
@@ -511,12 +530,12 @@ mod netwayste_net_tests {
         let u64_max = <u64>::max_value();
         let start = u64_max - 5;
 
-        for index in start..(start+5) {
+        for index in start..(start + 5) {
             let pkt = Packet::Request {
                 sequence: index as u64,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.rx_packets.buffer_item(pkt);
         }
@@ -526,7 +545,7 @@ mod netwayste_net_tests {
                 sequence: u64_max,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.rx_packets.buffer_item(pkt);
         }
@@ -536,7 +555,7 @@ mod netwayste_net_tests {
                 sequence: *index as u64,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.rx_packets.buffer_item(pkt);
         }
@@ -564,32 +583,47 @@ mod netwayste_net_tests {
         let two = 2;
         let three = 3;
 
-        let input_order = [ max_minus_4,
-                            two,
-                            max_minus_1,
-                            max_minus_5,
-                            u64_max,
-                            three,
-                            max_minus_2,
-                            zero,
-                            max_minus_3,
-                            one ];
+        let input_order = [
+            max_minus_4,
+            two,
+            max_minus_1,
+            max_minus_5,
+            u64_max,
+            three,
+            max_minus_2,
+            zero,
+            max_minus_3,
+            one,
+        ];
 
         for index in input_order.iter() {
             let pkt = Packet::Request {
                 sequence: *index as u64,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.rx_packets.buffer_item(pkt);
         }
 
         let mut iter = nm.rx_packets.queue.iter();
         let mut range = vec![];
-        range.extend([max_minus_5, max_minus_4, max_minus_3, max_minus_2, max_minus_1, u64_max, zero, one, two, three]
-                .iter()
-                .cloned()); // Add in u64 max value plus others
+        range.extend(
+            [
+                max_minus_5,
+                max_minus_4,
+                max_minus_3,
+                max_minus_2,
+                max_minus_1,
+                u64_max,
+                zero,
+                one,
+                two,
+                three,
+            ]
+            .iter()
+            .cloned(),
+        ); // Add in u64 max value plus others
 
         for index in range.iter() {
             let pkt = iter.next().unwrap();
@@ -613,14 +647,18 @@ mod netwayste_net_tests {
                 sequence: *index as u64,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.rx_packets.buffer_item(pkt);
         }
 
         let mut iter = nm.rx_packets.queue.iter();
         let mut range = vec![];
-        range.extend([max_minus_2, max_minus_1, u64_max, two, three].iter().cloned()); // Add in u64 max value plus others
+        range.extend(
+            [max_minus_2, max_minus_1, u64_max, two, three]
+                .iter()
+                .cloned(),
+        ); // Add in u64 max value plus others
         for index in range.iter() {
             let pkt = iter.next().unwrap();
             assert_eq!(*index, pkt.sequence_number());
@@ -639,21 +677,43 @@ mod netwayste_net_tests {
         let two = 2;
         let three = 3;
 
-        let input_order = [max_minus_1, max_minus_2, three, u64_max, two, one, zero, max_minus_3];
+        let input_order = [
+            max_minus_1,
+            max_minus_2,
+            three,
+            u64_max,
+            two,
+            one,
+            zero,
+            max_minus_3,
+        ];
 
         for index in input_order.iter() {
             let pkt = Packet::Request {
                 sequence: *index as u64,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.rx_packets.buffer_item(pkt);
         }
 
         let mut iter = nm.rx_packets.queue.iter();
         let mut range = vec![];
-        range.extend([max_minus_3, max_minus_2, max_minus_1, u64_max, zero, one, two, three].iter().cloned());
+        range.extend(
+            [
+                max_minus_3,
+                max_minus_2,
+                max_minus_1,
+                u64_max,
+                zero,
+                one,
+                two,
+                three,
+            ]
+            .iter()
+            .cloned(),
+        );
 
         for index in range.iter() {
             let pkt = iter.next().unwrap();
@@ -674,21 +734,43 @@ mod netwayste_net_tests {
         let three = 3;
 
         // Forward wrap occurs non-contiguously (aka [254, 0, ...] for bytes)
-        let input_order = [max_minus_1, zero, three, u64_max, max_minus_2, one, two, max_minus_3];
+        let input_order = [
+            max_minus_1,
+            zero,
+            three,
+            u64_max,
+            max_minus_2,
+            one,
+            two,
+            max_minus_3,
+        ];
 
         for index in input_order.iter() {
             let pkt = Packet::Request {
                 sequence: *index as u64,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.rx_packets.buffer_item(pkt);
         }
 
         let mut iter = nm.rx_packets.queue.iter();
         let mut range = vec![];
-        range.extend([max_minus_3, max_minus_2, max_minus_1, u64_max, zero, one, two, three].iter().cloned());
+        range.extend(
+            [
+                max_minus_3,
+                max_minus_2,
+                max_minus_1,
+                u64_max,
+                zero,
+                one,
+                two,
+                three,
+            ]
+            .iter()
+            .cloned(),
+        );
 
         for index in range.iter() {
             let pkt = iter.next().unwrap();
@@ -709,21 +791,43 @@ mod netwayste_net_tests {
         let three = 3;
 
         // Wrap takes place in reverse order ( aka [0, 254, ...] for bytes)
-        let input_order = [zero, max_minus_1, three, u64_max, max_minus_2, one, two, max_minus_3];
+        let input_order = [
+            zero,
+            max_minus_1,
+            three,
+            u64_max,
+            max_minus_2,
+            one,
+            two,
+            max_minus_3,
+        ];
 
         for index in input_order.iter() {
             let pkt = Packet::Request {
                 sequence: *index as u64,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.rx_packets.buffer_item(pkt);
         }
 
         let mut iter = nm.rx_packets.queue.iter();
         let mut range = vec![];
-        range.extend([max_minus_3, max_minus_2, max_minus_1, u64_max, zero, one, two, three].iter().cloned());
+        range.extend(
+            [
+                max_minus_3,
+                max_minus_2,
+                max_minus_1,
+                u64_max,
+                zero,
+                one,
+                two,
+                three,
+            ]
+            .iter()
+            .cloned(),
+        );
 
         for index in range.iter() {
             let pkt = iter.next().unwrap();
@@ -745,21 +849,47 @@ mod netwayste_net_tests {
         let two = 2;
         let three = 3;
 
-        let input_order = [u64_max, max_minus_4, two, max_minus_1, max_minus_5, three, max_minus_2, zero, max_minus_3, one];
+        let input_order = [
+            u64_max,
+            max_minus_4,
+            two,
+            max_minus_1,
+            max_minus_5,
+            three,
+            max_minus_2,
+            zero,
+            max_minus_3,
+            one,
+        ];
 
         for index in input_order.iter() {
             let pkt = Packet::Request {
                 sequence: *index as u64,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.rx_packets.buffer_item(pkt);
         }
 
         let mut iter = nm.rx_packets.queue.iter();
         let mut range = vec![];
-        range.extend([max_minus_5, max_minus_4, max_minus_3, max_minus_2, max_minus_1, u64_max, zero, one, two, three].iter().cloned());
+        range.extend(
+            [
+                max_minus_5,
+                max_minus_4,
+                max_minus_3,
+                max_minus_2,
+                max_minus_1,
+                u64_max,
+                zero,
+                one,
+                two,
+                three,
+            ]
+            .iter()
+            .cloned(),
+        );
 
         for index in range.iter() {
             let pkt = iter.next().unwrap();
@@ -781,23 +911,47 @@ mod netwayste_net_tests {
         let two = 2;
         let three = 3;
 
-        let input_order = [three, two, one, zero, u64_max, max_minus_1, max_minus_2, max_minus_3, max_minus_4, max_minus_5];
+        let input_order = [
+            three,
+            two,
+            one,
+            zero,
+            u64_max,
+            max_minus_1,
+            max_minus_2,
+            max_minus_3,
+            max_minus_4,
+            max_minus_5,
+        ];
 
         for index in input_order.iter() {
             let pkt = Packet::Request {
                 sequence: *index as u64,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.rx_packets.buffer_item(pkt);
         }
 
         let mut iter = nm.rx_packets.queue.iter();
         let mut range = vec![];
-        range.extend([max_minus_5, max_minus_4, max_minus_3, max_minus_2, max_minus_1, u64_max, zero, one, two, three]
-                .iter()
-                .cloned());
+        range.extend(
+            [
+                max_minus_5,
+                max_minus_4,
+                max_minus_3,
+                max_minus_2,
+                max_minus_1,
+                u64_max,
+                zero,
+                one,
+                two,
+                three,
+            ]
+            .iter()
+            .cloned(),
+        );
 
         for index in range.iter() {
             let pkt = iter.next().unwrap();
@@ -819,23 +973,47 @@ mod netwayste_net_tests {
         let two = 2;
         let three = 3;
 
-        let input_order = [max_minus_5, three, max_minus_4, two, max_minus_3, one, max_minus_2, zero, max_minus_1, u64_max];
+        let input_order = [
+            max_minus_5,
+            three,
+            max_minus_4,
+            two,
+            max_minus_3,
+            one,
+            max_minus_2,
+            zero,
+            max_minus_1,
+            u64_max,
+        ];
 
         for index in input_order.iter() {
             let pkt = Packet::Request {
                 sequence: *index as u64,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.rx_packets.buffer_item(pkt);
         }
 
         let mut iter = nm.rx_packets.queue.iter();
         let mut range = vec![];
-        range.extend([max_minus_5, max_minus_4, max_minus_3, max_minus_2, max_minus_1, u64_max, zero, one, two, three]
-                .iter()
-                .cloned()); // Add in u64 max value plus others
+        range.extend(
+            [
+                max_minus_5,
+                max_minus_4,
+                max_minus_3,
+                max_minus_2,
+                max_minus_1,
+                u64_max,
+                zero,
+                one,
+                two,
+                three,
+            ]
+            .iter()
+            .cloned(),
+        ); // Add in u64 max value plus others
 
         for index in range.iter() {
             let pkt = iter.next().unwrap();
@@ -850,7 +1028,7 @@ mod netwayste_net_tests {
             sequence: 0,
             response_ack: None,
             cookie: None,
-            action: RequestAction::None
+            action: RequestAction::None,
         };
 
         for _ in 0..NETWORK_QUEUE_LENGTH {
@@ -869,7 +1047,7 @@ mod netwayste_net_tests {
                 sequence: index as u64,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.rx_packets.buffer_item(pkt);
         }
@@ -878,7 +1056,7 @@ mod netwayste_net_tests {
                 sequence: index as u64,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
             nm.rx_packets.buffer_item(pkt);
         }
@@ -890,7 +1068,14 @@ mod netwayste_net_tests {
             let pkt = iter.next().unwrap();
             assert_eq!(index, pkt.sequence_number() as usize);
             // Verify that the packet is not dequeued
-            assert_eq!(index, nm.rx_packets.as_queue_type().get(index).unwrap().sequence_number() as usize);
+            assert_eq!(
+                index,
+                nm.rx_packets
+                    .as_queue_type()
+                    .get(index)
+                    .unwrap()
+                    .sequence_number() as usize
+            );
         }
     }
 
@@ -902,14 +1087,14 @@ mod netwayste_net_tests {
                 sequence: i,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
 
             nm.tx_packets.buffer_item(pkt.clone());
 
             if i < 3 {
                 let attempt: &mut NetAttempt = nm.tx_packets.attempts.back_mut().unwrap();
-                attempt.time = Instant::now() - Duration::from_secs(i+1);
+                attempt.time = Instant::now() - Duration::from_secs(i + 1);
             }
         }
         assert_eq!(nm.tx_packets.get_retransmit_indices().len(), 3);
@@ -926,7 +1111,7 @@ mod netwayste_net_tests {
                 sequence: i,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
 
             nm.tx_packets.buffer_item(pkt.clone());
@@ -952,14 +1137,14 @@ mod netwayste_net_tests {
                 sequence: i,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
 
             nm.tx_packets.buffer_item(pkt.clone());
 
-           if i < 3 {
+            if i < 3 {
                 let attempt: &mut NetAttempt = nm.tx_packets.attempts.back_mut().unwrap();
-                attempt.time = Instant::now() - Duration::from_secs(i+1);
+                attempt.time = Instant::now() - Duration::from_secs(i + 1);
             }
         }
 
@@ -986,14 +1171,14 @@ mod netwayste_net_tests {
                 sequence: i,
                 response_ack: None,
                 cookie: None,
-                action: RequestAction::None
+                action: RequestAction::None,
             };
 
             nm.tx_packets.buffer_item(pkt.clone());
 
-           if i < 3 {
+            if i < 3 {
                 let attempt: &mut NetAttempt = nm.tx_packets.attempts.back_mut().unwrap();
-                attempt.time = Instant::now() - Duration::from_secs(i+1);
+                attempt.time = Instant::now() - Duration::from_secs(i + 1);
             }
         }
 
@@ -1009,7 +1194,7 @@ mod netwayste_net_tests {
 
             for j in 0..indices.len() {
                 let attempt: &mut NetAttempt = nm.tx_packets.attempts.get_mut(j).unwrap();
-                attempt.time = Instant::now() - Duration::from_secs( 1u64);
+                attempt.time = Instant::now() - Duration::from_secs(1u64);
             }
         }
 
@@ -1020,9 +1205,7 @@ mod netwayste_net_tests {
         for i in 3..5 {
             assert_eq!(nm.tx_packets.attempts.get(i).unwrap().retries, 0);
         }
-
     }
-
 }
 
 mod netwayste_client_tests {
@@ -1074,7 +1257,11 @@ mod netwayste_client_tests {
 
         let mut incoming_messages = vec![];
         for x in 0..10 {
-            let new_msg =  BroadcastChatMessage::new(x as u64, "a player".to_owned(), format!("message {}", x));
+            let new_msg = BroadcastChatMessage::new(
+                x as u64,
+                "a player".to_owned(),
+                format!("message {}", x),
+            );
             incoming_messages.push(new_msg);
         }
 
@@ -1087,7 +1274,11 @@ mod netwayste_client_tests {
         let mut client_state = create_client_net_state();
         client_state.chat_msg_seq_num = 10;
 
-        let incoming_messages = vec![ BroadcastChatMessage::new(10u64, "a player".to_owned(), format!("message {}", 10))];
+        let incoming_messages = vec![BroadcastChatMessage::new(
+            10u64,
+            "a player".to_owned(),
+            format!("message {}", 10),
+        )];
 
         client_state.handle_incoming_chats(incoming_messages);
         assert_eq!(client_state.chat_msg_seq_num, 10);
@@ -1099,7 +1290,11 @@ mod netwayste_client_tests {
         let mut client_state = create_client_net_state();
         client_state.chat_msg_seq_num = 10;
 
-        let incoming_messages = vec![ BroadcastChatMessage::new(11u64, "a player".to_owned(), format!("message {}", 11))];
+        let incoming_messages = vec![BroadcastChatMessage::new(
+            11u64,
+            "a player".to_owned(),
+            format!("message {}", 11),
+        )];
 
         client_state.handle_incoming_chats(incoming_messages);
     }
@@ -1113,18 +1308,27 @@ mod netwayste_client_tests {
 
         let mut incoming_messages = vec![];
         for x in 0..20 {
-            let new_msg =  BroadcastChatMessage::new(x as u64, "a player".to_owned(), format!("message {}", x));
+            let new_msg = BroadcastChatMessage::new(
+                x as u64,
+                "a player".to_owned(),
+                format!("message {}", x),
+            );
             incoming_messages.push(new_msg);
         }
 
         client_state.handle_incoming_chats(incoming_messages);
         assert_eq!(client_state.chat_msg_seq_num, 19);
 
-        let mut seq_num = starting_chat_seq_num+1;
-        let chat_queue = &client_state.network.rx_chat_messages.as_ref().unwrap().queue;
+        let mut seq_num = starting_chat_seq_num + 1;
+        let chat_queue = &client_state
+            .network
+            .rx_chat_messages
+            .as_ref()
+            .unwrap()
+            .queue;
         for msg in chat_queue {
             assert_eq!(msg.chat_seq.unwrap(), seq_num);
-            seq_num+=1;
+            seq_num += 1;
         }
     }
 }

--- a/netwayste/src/utils.rs
+++ b/netwayste/src/utils.rs
@@ -18,3 +18,4 @@
 mod ping;
 
 pub use ping::LatencyFilter;
+pub use ping::PingPong;

--- a/netwayste/src/utils/mod.rs
+++ b/netwayste/src/utils/mod.rs
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 The Conwayste Developers
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 mod ping;
 
 pub use ping::PingFilter;

--- a/netwayste/src/utils/mod.rs
+++ b/netwayste/src/utils/mod.rs
@@ -1,0 +1,3 @@
+mod ping;
+
+pub use ping::PingFilter;

--- a/netwayste/src/utils/mod.rs
+++ b/netwayste/src/utils/mod.rs
@@ -17,4 +17,4 @@
 
 mod ping;
 
-pub use ping::PingFilter;
+pub use ping::LatencyFilter;

--- a/netwayste/src/utils/ping.rs
+++ b/netwayste/src/utils/ping.rs
@@ -67,6 +67,13 @@ impl PingFilter {
     pub fn update(&mut self) {
         if !self.in_progress {
             error!("The PingFilter's start() was not called so a duration cannot be computed.");
+            let elapsed = self.start_timestamp.elapsed();
+            error!(
+                "PingFilter.start_timestamp snapshot was {}.{}.{} seconds ago.",
+                elapsed.as_secs(),
+                elapsed.as_millis(),
+                elapsed.as_micros()
+            );
         }
 
         let latency = Instant::now().duration_since(self.start_timestamp);
@@ -151,5 +158,4 @@ mod tests {
 
         assert_eq!(pf.average_latency_ms, Some(650));
     }
-
 }

--- a/netwayste/src/utils/ping.rs
+++ b/netwayste/src/utils/ping.rs
@@ -116,8 +116,6 @@ impl LatencyFilter {
             let average_rtt_ms = (self.running_sum as f64 / LATENCY_FILTER_DEPTH as f64) as u64;
             let average_latency_ms = average_rtt_ms / 2;
 
-            // TODO: Remove me once the server list is implemented in the UI
-            println!("Client-side Ping: {}", average_latency_ms);
             self.average_latency_ms = Some(average_latency_ms);
         }
 

--- a/netwayste/src/utils/ping.rs
+++ b/netwayste/src/utils/ping.rs
@@ -39,6 +39,7 @@ impl PingFilter {
         }
     }
 
+    #[deny(unused_variables)]
     pub fn reset(&mut self) {
         let Self {
             ref mut average_latency_ms,

--- a/netwayste/src/utils/ping.rs
+++ b/netwayste/src/utils/ping.rs
@@ -22,6 +22,7 @@ use std::time::Instant;
 /// meaningful average.
 const PING_FILTER_DEPTH: usize = 12;
 
+/// A moving-average filter used to level out the latencies calculated from network request/response times.
 pub struct PingFilter {
     pub average_latency_ms: Option<u64>,
     running_sum: u64,
@@ -65,7 +66,7 @@ impl PingFilter {
 
     pub fn update(&mut self) {
         if !self.in_progress {
-            panic!("start() was not called so a duration cannot be computed");
+            error!("The PingFilter's start() was not called so a duration cannot be computed.");
         }
 
         let latency = Instant::now().duration_since(self.start_timestamp);
@@ -151,10 +152,4 @@ mod tests {
         assert_eq!(pf.average_latency_ms, Some(650));
     }
 
-    #[test]
-    #[should_panic(expected = "start() was not called so a duration cannot be computed")]
-    fn test_ping_filter_update_called_before_start() {
-        let mut pf = PingFilter::new();
-        pf.update();
-    }
 }

--- a/netwayste/src/utils/ping.rs
+++ b/netwayste/src/utils/ping.rs
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2020 The Conwayste Developers
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 use std::collections::VecDeque;
 use std::time::Instant;
 

--- a/netwayste/src/utils/ping.rs
+++ b/netwayste/src/utils/ping.rs
@@ -88,7 +88,9 @@ impl LatencyFilter {
             let oldest = self.history.pop_front().unwrap();
             self.running_sum -= oldest;
 
-            let average_latency_ms = (self.running_sum as f64 / LATENCY_FILTER_DEPTH as f64) as u64;
+            // average round-trip time
+            let average_rtt_ms = (self.running_sum as f64 / LATENCY_FILTER_DEPTH as f64) as u64;
+            let average_latency_ms = average_rtt_ms / 2;
             println!("Client-side Ping: {}", average_latency_ms); // PR_GATE
             self.average_latency_ms = Some(average_latency_ms);
         }

--- a/netwayste/src/utils/ping.rs
+++ b/netwayste/src/utils/ping.rs
@@ -14,13 +14,36 @@
  * You should have received a copy of the GNU General Public License along with
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#![allow(dead_code)]    // Because this file is pub for server.rs. TODO: Refactor server into crate
 
 use std::collections::VecDeque;
 use std::time::Instant;
 
+use serde::{Deserialize, Serialize};
+use rand::random;
+
 /// This indicates the number of samples needed by the latency filter to calculate a statistically
 /// meaningful average.
 const LATENCY_FILTER_DEPTH: usize = 12;
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+pub struct PingPong {
+    pub nonce: u64
+}
+
+impl PingPong {
+    pub fn ping() -> PingPong {
+        PingPong {
+            nonce: random::<u64>()
+        }
+    }
+
+    pub fn pong(nonce: u64) -> PingPong {
+        PingPong {
+            nonce
+        }
+    }
+}
 
 /// A moving-average filter used to level out the latencies calculated from network request/response times.
 pub struct LatencyFilter {

--- a/netwayste/src/utils/ping.rs
+++ b/netwayste/src/utils/ping.rs
@@ -1,0 +1,133 @@
+use std::collections::VecDeque;
+use std::time::Instant;
+
+const PING_FILTER_DEPTH: usize = 12;
+
+pub struct PingFilter {
+    pub average_latency_ms: u128,
+    running_sum: u128,
+    history: VecDeque<u128>,
+    start_timestamp: Instant,
+    in_progress: bool,
+}
+
+impl PingFilter {
+    pub fn new() -> PingFilter {
+        PingFilter {
+            average_latency_ms: 0,
+            running_sum: 0,
+            history: VecDeque::with_capacity(PING_FILTER_DEPTH),
+            start_timestamp: Instant::now(),
+            in_progress: false,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        let Self {
+            ref mut average_latency_ms,
+            ref mut running_sum,
+            ref mut history,
+            ref mut start_timestamp,
+            ref mut in_progress,
+        } = *self;
+
+        *average_latency_ms = 0;
+        *running_sum = 0;
+        history.clear();
+        *start_timestamp = Instant::now();
+        *in_progress = false;
+    }
+
+    pub fn start(&mut self) {
+        self.start_timestamp = Instant::now();
+        self.in_progress = true;
+    }
+
+    pub fn update(&mut self) {
+        if !self.in_progress {
+            panic!("start() was not called so a duration cannot be computed");
+        }
+
+        let latency = Instant::now().duration_since(self.start_timestamp);
+        let latency_ms = latency.as_millis();
+
+        self.running_sum += latency_ms;
+        self.history.push_back(latency_ms);
+
+        // Wait for the filter to be populated
+        if self.history.len() > PING_FILTER_DEPTH {
+            // unwraps safe b/c of length check
+            let oldest = self.history.pop_front().unwrap();
+            self.running_sum -= oldest;
+            self.average_latency_ms = (self.running_sum as f64 / PING_FILTER_DEPTH as f64) as u128;
+            println!("Client-side Ping: {}", self.average_latency_ms); // PR_GATE
+        }
+
+        self.in_progress = false;
+    }
+
+    #[cfg(test)]
+    fn set_start_time(&mut self, ms_in_past: u64) {
+        self.in_progress = true;
+        let opt_past_timestamp = Instant::now().checked_sub(Duration::from_millis(ms_in_past));
+        if let Some(past_timestamp) = opt_past_timestamp {
+            self.start_timestamp = past_timestamp;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ping_filter_under_filled_does_not_set_latency() {
+        let mut pf = PingFilter::new();
+
+        (0..PING_FILTER_DEPTH).into_iter().for_each(|_| {
+            pf.set_start_time(500);
+            pf.update();
+        });
+
+        assert_eq!(pf.average_latency_ms, 0);
+    }
+
+    #[test]
+    fn test_ping_filter_filled_sets_latency() {
+        let mut pf = PingFilter::new();
+
+        (0..=PING_FILTER_DEPTH).into_iter().for_each(|_| {
+            pf.set_start_time(500);
+            pf.update();
+        });
+
+        assert_eq!(pf.average_latency_ms, 500);
+
+        // Perform an additional 12 for shiggles
+        (0..=PING_FILTER_DEPTH).into_iter().for_each(|_| {
+            pf.set_start_time(500);
+            pf.update();
+        });
+
+        assert_eq!(pf.average_latency_ms, 500);
+    }
+
+    #[test]
+    fn test_ping_filter_filled_sets_latency_with_varying_pings() {
+        let mut pf = PingFilter::new();
+
+        (0..=PING_FILTER_DEPTH*100).step_by(100).into_iter().for_each(|i| {
+            pf.set_start_time(i as u64);
+            pf.update();
+        });
+
+        assert_eq!(pf.average_latency_ms, 650);
+    }
+
+    #[test]
+    #[should_panic(expected = "start() was not called so a duration cannot be computed")]
+    fn test_ping_filter_update_called_before_start() {
+        let mut pf = PingFilter::new();
+        pf.update();
+    }
+}

--- a/netwayste/src/utils/ping.rs
+++ b/netwayste/src/utils/ping.rs
@@ -133,10 +133,13 @@ mod tests {
     fn test_ping_filter_filled_sets_latency_with_varying_pings() {
         let mut pf = PingFilter::new();
 
-        (0..=PING_FILTER_DEPTH*100).step_by(100).into_iter().for_each(|i| {
-            pf.set_start_time(i as u64);
-            pf.update();
-        });
+        (0..=PING_FILTER_DEPTH * 100)
+            .step_by(100)
+            .into_iter()
+            .for_each(|i| {
+                pf.set_start_time(i as u64);
+                pf.update();
+            });
 
         assert_eq!(pf.average_latency_ms, 650);
     }

--- a/netwayste/src/utils/ping.rs
+++ b/netwayste/src/utils/ping.rs
@@ -114,7 +114,9 @@ impl LatencyFilter {
             // average round-trip time
             let average_rtt_ms = (self.running_sum as f64 / LATENCY_FILTER_DEPTH as f64) as u64;
             let average_latency_ms = average_rtt_ms / 2;
-            println!("Client-side Ping: {}", average_latency_ms); // PR_GATE
+
+            // TODO: Remove me once the server list is implemented in the UI
+            println!("Client-side Ping: {}", average_latency_ms);
             self.average_latency_ms = Some(average_latency_ms);
         }
 
@@ -138,7 +140,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_ping_filter_under_filled_does_not_set_latency() {
+    fn test_latency_filter_under_filled_does_not_set_latency() {
         let mut pf = LatencyFilter::new();
 
         (0..LATENCY_FILTER_DEPTH).into_iter().for_each(|_| {
@@ -150,7 +152,7 @@ mod tests {
     }
 
     #[test]
-    fn test_ping_filter_filled_sets_latency() {
+    fn test_latency_filter_filled_sets_latency() {
         let mut pf = LatencyFilter::new();
 
         (0..=LATENCY_FILTER_DEPTH).into_iter().for_each(|_| {
@@ -158,7 +160,7 @@ mod tests {
             pf.update();
         });
 
-        assert_eq!(pf.average_latency_ms, Some(500));
+        assert_eq!(pf.average_latency_ms, Some(250));
 
         // Perform an additional 12 for shiggles
         (0..=LATENCY_FILTER_DEPTH).into_iter().for_each(|_| {
@@ -166,11 +168,11 @@ mod tests {
             pf.update();
         });
 
-        assert_eq!(pf.average_latency_ms, Some(500));
+        assert_eq!(pf.average_latency_ms, Some(250));
     }
 
     #[test]
-    fn test_ping_filter_filled_sets_latency_with_varying_pings() {
+    fn test_latency_filter_filled_sets_latency_with_varying_pings() {
         let mut pf = LatencyFilter::new();
 
         (0..=LATENCY_FILTER_DEPTH * 100)
@@ -181,6 +183,6 @@ mod tests {
                 pf.update();
             });
 
-        assert_eq!(pf.average_latency_ms, Some(650));
+        assert_eq!(pf.average_latency_ms, Some(325));
     }
 }

--- a/netwayste/src/utils/ping.rs
+++ b/netwayste/src/utils/ping.rs
@@ -46,6 +46,7 @@ impl PingPong {
 }
 
 /// A moving-average filter used to level out the latencies calculated from network request/response times.
+#[derive(PartialEq,Eq,Debug, Clone)]
 pub struct LatencyFilter {
     pub average_latency_ms: Option<u64>,
     running_sum: u64,


### PR DESCRIPTION
- [x] Add server status packet types (GetStatus/Status) to `net.rs`
- [x] Update netwayste client and server code to support server status query
- [x] Add client-side latency measurement in GetStatus/Status
- [x] Add server-side latency measurement in Update/UpdateReply
- [x] Add unit tests where applicable
- [x] No new warnings
- [x] Address `PR_GATE`s
- [x] Fix bug causing dissector to reach `unreachable!()` during an `get_ett_addr()` 
    Fixed in  9816ee9

*(Easier to view diff when using 27f008a as the baseline)*
