### PR TITLE
GUI: fix bug where buttons incorrectly selected on screen change

### DIFF
--- a/conwayste/src/client.rs
+++ b/conwayste/src/client.rs
@@ -1077,6 +1077,8 @@ impl MainState {
     }
 
     // update
+    // TODO: delete all of this, for several reasons, but one reason is that it doesn't switch
+    // screens properly.
     fn receive_net_updates(&mut self) -> GameResult<()> {
         let mut net_worker_guard = self.net_worker.lock().unwrap();
         if net_worker_guard.is_none() {

--- a/conwayste/src/client.rs
+++ b/conwayste/src/client.rs
@@ -1055,10 +1055,19 @@ impl MainState {
                 )?;
             }
 
-            // Emit a Load event on the new screen
+            // Emit a Load event and a ScreenChange event on the new screen
             if let Some(layering) = self.ui_layout.get_screen_layering_mut(new_screen) {
                 layering.emit(
                     &Event::new_load(),
+                    ggez_ctx,
+                    &mut self.config,
+                    &mut self.screen_stack,
+                    game_area_state,
+                    &mut self.static_node_ids,
+                    &mut self.viewport,
+                )?;
+                layering.emit(
+                    &Event::new_screen_change(),
                     ggez_ctx,
                     &mut self.config,
                     &mut self.screen_stack,

--- a/conwayste/src/client.rs
+++ b/conwayste/src/client.rs
@@ -462,10 +462,6 @@ impl EventHandler<GameError> for MainState {
                                 error!("Error from layer.emit on left click: {:?}", e);
                             });
                     }
-                    MouseAction::DoubleClick => {
-                        // TODO add support
-                        error!("Please add double click support in the client update event dispatcher.");
-                    }
                 }
             }
 
@@ -1156,7 +1152,7 @@ impl MainState {
                     self.inputs.mouse_info.mousebutton = MouseButton::Other(0);
                     self.inputs.mouse_info.down_position = Point2 { x: 0.0, y: 0.0 };
                 }
-                MouseAction::Drag | MouseAction::Held | MouseAction::DoubleClick => {}
+                MouseAction::Drag | MouseAction::Held => {}
             }
         }
 

--- a/conwayste/src/input.rs
+++ b/conwayste/src/input.rs
@@ -32,7 +32,6 @@ pub enum MouseAction {
     Held,
     Drag,
     Click,
-    DoubleClick, // For Aaron TODO :)
 }
 
 pub struct MouseInfo {

--- a/conwayste/src/ui/button.rs
+++ b/conwayste/src/ui/button.rs
@@ -136,6 +136,9 @@ impl Button {
         b.on(EventType::MouseMove, Box::new(Button::mouse_move_handler))
             .unwrap(); // unwrap OK b/c not being called within handler
 
+        b.on(EventType::ScreenChange, Box::new(Button::screen_change_handler))
+            .unwrap(); // unwrap OK b/c not being called within handler
+
         b
     }
 
@@ -150,6 +153,17 @@ impl Button {
             self.dimensions.x + (button_center.x - label_center_point.x),
             self.dimensions.y + (button_center.y - label_center_point.y),
         );
+    }
+
+    /// If we switched to this screen from another one, clear the hover state.
+    fn screen_change_handler(
+        obj: &mut dyn EmitEvent,
+        _uictx: &mut UIContext,
+        _event: &Event,
+    ) -> Result<Handled, Box<dyn Error>> {
+        let button = obj.downcast_mut::<Button>().unwrap(); // unwrap OK because this will always be Button
+        button.hover = false;
+        Ok(Handled::Handled)
     }
 
     fn mouse_move_handler(

--- a/conwayste/src/ui/context.rs
+++ b/conwayste/src/ui/context.rs
@@ -136,7 +136,6 @@ impl<'a> UIContext<'a> {
     /// # Panics
     ///
     /// This will panic if the screen stack is empty, but that shouldn't ever happen.
-    #[allow(unused)]
     pub fn current_screen(&self) -> Screen {
         *self.screen_stack.last().unwrap()
     }

--- a/conwayste/src/ui/context.rs
+++ b/conwayste/src/ui/context.rs
@@ -205,6 +205,7 @@ pub enum EventType {
     // child_event(). Note that a LoseFocus event will not be received after this is sent.
     ChildReleasedFocus,
     ChildRequestsFocus,
+    ScreenChange, // Emitted once after screen changed from something else
     TextEntered,
     Update,
     RequestFocus,
@@ -269,6 +270,7 @@ const BROADCASTED_EVENTS: &[EventType] = &[
     EventType::MouseMove,
     EventType::Load,
     EventType::Save,
+    EventType::ScreenChange,
 ];
 
 impl EventType {
@@ -388,6 +390,13 @@ impl Event {
     pub fn new_child_released_focus() -> Self {
         Event {
             what: EventType::ChildReleasedFocus,
+            ..Default::default()
+        }
+    }
+
+    pub fn new_screen_change() -> Self {
+        Event {
+            what: EventType::ScreenChange,
             ..Default::default()
         }
     }

--- a/conwayste/src/ui/focus.rs
+++ b/conwayste/src/ui/focus.rs
@@ -62,7 +62,6 @@ impl FocusCycle {
     }
 
     /// Clears the focus.
-    #[allow(unused)]
     pub fn clear_focus(&mut self) {
         self.index = None;
     }

--- a/conwayste/src/ui/gamearea.rs
+++ b/conwayste/src/ui/gamearea.rs
@@ -60,25 +60,23 @@ impl fmt::Debug for GameArea {
 /// widget.
 impl GameArea {
     pub fn new() -> Self {
-        let bigbang = {
-            // we're going to have to tear this all out when this becomes a real game
-            let player0_writable = Region::new(100, 70, 34, 16);
-            let player1_writable = Region::new(0, 0, 80, 80);
+        // we're going to have to tear this all out when this becomes a real game
+        let player0_writable = Region::new(100, 70, 34, 16);
+        let player1_writable = Region::new(0, 0, 80, 80);
 
-            let player0 = PlayerBuilder::new(player0_writable);
-            let player1 = PlayerBuilder::new(player1_writable);
-            let players = vec![player0, player1];
+        let player0 = PlayerBuilder::new(player0_writable);
+        let player1 = PlayerBuilder::new(player1_writable);
+        let players = vec![player0, player1];
 
-            BigBang::new()
-                .width(UNIVERSE_WIDTH_IN_CELLS)
-                .height(UNIVERSE_HEIGHT_IN_CELLS)
-                .server_mode(true) // TODO will change to false once we get server support up
-                // Currently 'client' is technically both client and server
-                .history(HISTORY_SIZE)
-                .fog_radius(FOG_RADIUS)
-                .add_players(players)
-                .birth()
-        };
+        let bigbang = BigBang::new()
+            .width(UNIVERSE_WIDTH_IN_CELLS)
+            .height(UNIVERSE_HEIGHT_IN_CELLS)
+            .server_mode(true) // TODO will change to false once we get server support up
+            // Currently 'client' is technically both client and server
+            .history(HISTORY_SIZE)
+            .fog_radius(FOG_RADIUS)
+            .add_players(players)
+            .birth();
         let mut uni = bigbang.unwrap();
 
         init_patterns(&mut uni).unwrap();

--- a/conwayste/src/ui/layer.rs
+++ b/conwayste/src/ui/layer.rs
@@ -526,7 +526,7 @@ impl Layering {
             viewport,
         );
         if event.is_broadcast_event() {
-            Layering::broadcast_event(event, &mut uictx)
+            Layering::broadcast_event(event, &mut uictx, &mut self.focus_cycles)
         } else if event.is_mouse_event() {
             Layering::emit_mouse_event(event, &mut uictx, &mut self.focus_cycles[self.highest_z_order])
         } else if event.is_key_event() {
@@ -537,7 +537,16 @@ impl Layering {
         }
     }
 
-    fn broadcast_event(event: &Event, uictx: &mut UIContext) -> Result<(), Box<dyn Error>> {
+    fn broadcast_event(
+        event: &Event,
+        uictx: &mut UIContext,
+        focus_cycles: &mut Vec<FocusCycle>,
+    ) -> Result<(), Box<dyn Error>> {
+        // Special case
+        if event.what == EventType::ScreenChange {
+            clear_focus_cycles(focus_cycles);
+        }
+
         for child_id in uictx.widget_view.children_ids() {
             // Get a mutable reference to a BoxedWidget, as well as a UIContext with a view on the
             // widgets in the tree under this widget.
@@ -784,6 +793,12 @@ impl Layering {
         }
         Ok(())
     }
+}
+
+fn clear_focus_cycles(focus_cycles: &mut Vec<FocusCycle>) {
+    focus_cycles
+        .iter_mut()
+        .for_each(|focus_cycle| focus_cycle.clear_focus());
 }
 
 #[cfg(test)]

--- a/conwayste/src/ui/pane.rs
+++ b/conwayste/src/ui/pane.rs
@@ -93,6 +93,10 @@ impl Pane {
             }
 
             if event_type.is_broadcast_event() {
+                if event_type == EventType::ScreenChange {
+                    // unwrap OK because not called within handler
+                    pane.on(event_type, Box::new(Pane::lose_focus_handler)).unwrap();
+                }
                 // unwrap OK because not called within handler
                 pane.on(event_type, Box::new(Pane::broadcast_handler)).unwrap();
             }


### PR DESCRIPTION
You can see this in the master branch by starting at the main menu and activating either the Start Single Player Game or Options buttons by either keyboard or mouse, and then pressing the Esc key to go back. The keyboard and mouse activation issues are actually two separate bugs, both of which I fixed in this PR. :grinning: 